### PR TITLE
fix: prevent favorites from crashing server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "notion2anki-server",
-  "version": "1.0.0-alpha.50",
+  "version": "1.0.0-alpha.51",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "notion2anki-server",
-      "version": "1.0.0-alpha.50",
+      "version": "1.0.0-alpha.51",
       "license": "MIT",
       "dependencies": {
         "@notionhq/client": "^2.2.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "notion2anki"
   ],
   "author": "Alexander Alemayhu",
-  "version": "1.0.0-alpha.50",
+  "version": "1.0.0-alpha.51",
   "engines": {
     "node": ">=12.0.0"
   },

--- a/src/routes/favorite/getFavorites.ts
+++ b/src/routes/favorite/getFavorites.ts
@@ -2,20 +2,30 @@ import { Request, Response } from 'express';
 import all from '../../lib/favorite/all';
 import Favorites from '../../schemas/public/Favorites';
 import { getNotionAPI } from '../../lib/notion/helpers/getNotionAPI';
+import { APIResponseError } from '@notionhq/client';
+import DB from '../../lib/storage/db';
 
 export default async function getFavorites(req: Request, res: Response) {
   const { owner } = res.locals;
   const api = await getNotionAPI(req, res);
-
-  console.log('getFavorites');
   const favorites = await all(owner);
-  console.log(favorites);
-  const notionBlocks = await Promise.all(
-    favorites.map(async (f: Favorites) =>
-      f.type === 'page'
-        ? api.getPage(f.object_id)
-        : api.getDatabase(f.object_id)
-    )
-  );
-  res.json(notionBlocks);
+
+  try {
+    const notionBlocks = await Promise.all(
+      favorites.map(async (f: Favorites) =>
+        f.type === 'page'
+          ? api.getPage(f.object_id)
+          : api.getDatabase(f.object_id)
+      )
+    );
+    res.json(notionBlocks);
+  } catch (err) {
+    if (err instanceof APIResponseError) {
+      console.info('purging favorites for');
+      await DB('favorites').delete().where({
+        owner,
+      });
+    }
+    res.json([]);
+  }
 }


### PR DESCRIPTION
We can get into a timeout with the Notion API due to lack of access or simply the page being deleted. In that case we purge all of the users favorites.