### PR TITLE
chore: move loading of env file before imports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN git clone https://github.com/2anki/web /app/web
 RUN git clone https://github.com/2anki/create_deck /app/create_deck
 RUN npm --prefix /app/web install
 
+RUN pip3 install -r /app/create_deck/requirements.txt
 RUN npm install typescript -g
 RUN npm --prefix /app/server install
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "notion2anki-server",
-  "version": "1.0.0-alpha.51",
+  "version": "1.0.0-alpha.52",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "notion2anki-server",
-      "version": "1.0.0-alpha.51",
+      "version": "1.0.0-alpha.52",
       "license": "MIT",
       "dependencies": {
         "@notionhq/client": "^2.2.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "notion2anki"
   ],
   "author": "Alexander Alemayhu",
-  "version": "1.0.0-alpha.51",
+  "version": "1.0.0-alpha.52",
   "engines": {
     "node": ">=12.0.0"
   },

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,10 +1,15 @@
 import { existsSync } from 'fs';
 import path from 'path';
+import * as dotenv from 'dotenv';
+
+const localEnvFile = path.join(__dirname, '../.env');
+if (existsSync(localEnvFile)) {
+  dotenv.config({ path: localEnvFile });
+}
 
 import morgan from 'morgan';
 import express, { RequestHandler } from 'express';
 import cookieParser from 'cookie-parser';
-import * as dotenv from 'dotenv';
 import { ALLOWED_ORIGINS, BUILD_DIR, INDEX_FILE } from './lib/constants';
 import ErrorHandler from './lib/misc/ErrorHandler';
 
@@ -28,11 +33,6 @@ import { ScheduleCleanup } from './lib/storage/jobs/JobHandler';
 import RequireAuthentication from './middleware/RequireAuthentication';
 import { Knex } from 'knex';
 import { sendError } from './lib/error/sendError';
-
-const localEnvFile = path.join(__dirname, '/../.env');
-if (existsSync(localEnvFile)) {
-  dotenv.config({ path: localEnvFile });
-}
 
 import MigratorConfig = Knex.MigratorConfig;
 


### PR DESCRIPTION
We need it early due to storage layer initializing AWS.