### PR TITLE
fix: pass the request and response correctly

### DIFF
--- a/src/routes/VersionRouter.ts
+++ b/src/routes/VersionRouter.ts
@@ -6,7 +6,7 @@ const VersionRouter = () => {
   const controller = new VersionController(new VersionService());
   const router = express.Router();
 
-  router.get('/api/version', controller.getVersionInfo);
+  router.get('/api/version', (req, res) => controller.getVersionInfo(req, res));
 
   return router;
 };


### PR DESCRIPTION
Fixes Sentry crash report:

> Cannot read properties of undefined (reading 'service')
