### PR TITLE
chore: Update GitHub Actions checkout version

### DIFF
--- a/.github/workflows/build-server.yml
+++ b/.github/workflows/build-server.yml
@@ -11,7 +11,7 @@ jobs:
         node-version: [16.15.1]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
Fixing build warning
> [build (16.15.1)](https://github.com/2anki/2anki.net/actions/runs/5551982487/jobs/10138753908)
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/setup-node@v1.