### PR TITLE
fix(data_layer): Throw error if Notion token is not found

### DIFF
--- a/src/data_layer/NotionRespository.ts
+++ b/src/data_layer/NotionRespository.ts
@@ -44,14 +44,26 @@ class NotionRepository {
     });
   }
 
+  /**
+   * Retrieve the users notion token.
+   * If the user does not have a token, throws error.
+   * The caller is expected to handle this error.
+   *
+   * @param owner user id
+   * @returns unhashed token
+   */
   async getNotionToken(owner: string) {
-    if (!owner) {
-      return null;
-    }
     const row = await this.database('notion_tokens')
       .where({ owner })
       .returning('token')
       .first();
+
+    if (!row) {
+      throw new Error(
+        `Could not find your Notion token. Please report this issue with your userid: ${owner}`
+      );
+    }
+
     return unHashToken(row.token);
   }
 


### PR DESCRIPTION
Trying again to resolve the token exception in Sentry:
> TypeError
>
> POST /api/notion/pages
>
> Unhandled
> Cannot read properties of undefined (reading 'token')
