### PR TITLE
chore: add check env for skipping cleanup

### DIFF
--- a/src/lib/storage/jobs/helpers/runCleanup.ts
+++ b/src/lib/storage/jobs/helpers/runCleanup.ts
@@ -5,6 +5,11 @@ import deleteOldUploads from './deleteOldUploads';
 import { getDatabase } from '../../../../data_layer';
 
 export const runCleanup = async (database: Knex) => {
+  if (process.env.SKIP_CLEANUP === 'true') {
+    console.info('Skipping cleanup');
+    return;
+  }
+
   console.time('running cleanup');
   deleteOldFiles();
   await deleteOldUploads(database);


### PR DESCRIPTION
We need this temporarily for a server migration. Replicated servers
should not cleanup since they don't have all the data tables to
determine if files are too old.
