### PR TITLE
feat: reduce bucket round-trip for uploads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "metascraper-url": "^5.34.7",
         "morgan": "^1.10.0",
         "multer": "^1.4.4-lts.1",
-        "multer-s3": "^2.9.0",
         "nanoid": "^3.1.31",
         "pg": "^8.11.0",
         "react": "^18.2.0",
@@ -5044,11 +5043,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/file-type": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-      "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
-    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -5572,11 +5566,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/html-comment-regex": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.2.tgz",
-      "integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ=="
     },
     "node_modules/html-encoding-sniffer": {
       "version": "3.0.0",
@@ -8475,16 +8464,6 @@
         "node": ">= 6.0.0"
       }
     },
-    "node_modules/multer-s3": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/multer-s3/-/multer-s3-2.10.0.tgz",
-      "integrity": "sha512-RZsiqG19C9gE82lB7v8duJ+TMIf70fWYHlIwuNcsanOH1ePBoPXZvboEQxEow9jUkk7WQsuyVA2TgriOuDrVrw==",
-      "dependencies": {
-        "file-type": "^3.3.0",
-        "html-comment-regex": "^1.1.2",
-        "run-parallel": "^1.1.6"
-      }
-    },
     "node_modules/multimatch": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-4.0.0.tgz",
@@ -9444,7 +9423,8 @@
     "node_modules/queue-microtask": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.2.tgz",
-      "integrity": "sha512-dB15eXv3p2jDlbOiNLyMabYg1/sXvppd8DP2J3EOCQ0AkuSXCW2tP7mnVouVLJKgUMY6yP0kcQDVpLCN13h4Xg=="
+      "integrity": "sha512-dB15eXv3p2jDlbOiNLyMabYg1/sXvppd8DP2J3EOCQ0AkuSXCW2tP7mnVouVLJKgUMY6yP0kcQDVpLCN13h4Xg==",
+      "dev": true
     },
     "node_modules/quick-lru": {
       "version": "5.1.1",
@@ -9717,6 +9697,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "metascraper-url": "^5.34.7",
     "morgan": "^1.10.0",
     "multer": "^1.4.4-lts.1",
-    "multer-s3": "^2.9.0",
     "nanoid": "^3.1.31",
     "pg": "^8.11.0",
     "react": "^18.2.0",

--- a/src/controllers/UploadController.ts
+++ b/src/controllers/UploadController.ts
@@ -74,7 +74,7 @@ class UploadController {
     console.info('uploading file');
     console.time(req.path);
     const storage = new StorageHandler();
-    const handleUploadEndpoint = this.service.getUploadHandler(res, storage);
+    const handleUploadEndpoint = this.service.getUploadHandler(res);
 
     handleUploadEndpoint(req, res, async (error) => {
       if (error) {

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -1,6 +1,5 @@
 import express from 'express';
 import multer from 'multer';
-import multerS3 from 'multer-s3';
 
 import { sendBundle } from '../controllers/UploadController';
 import UploadRepository from '../data_layer/UploadRespository';
@@ -26,25 +25,12 @@ class UploadService {
     await s.delete(key);
   }
 
-  getUploadHandler(res: express.Response, storage: StorageHandler) {
+  getUploadHandler(res: express.Response) {
+    const maxUploadCount = 21;
     return multer({
       limits: getUploadLimits(res.locals.patreon),
-      storage: multerS3({
-        s3: storage.s3,
-        bucket: StorageHandler.DefaultBucketName(),
-        key(_request, file, cb) {
-          let suffix = '.zip';
-          if (
-            file.originalname.includes('.') &&
-            file.originalname.split('.').length > 1
-          ) {
-            const parts = file.originalname.split('.');
-            suffix = parts[parts.length - 1];
-          }
-          cb(null, storage.uniqify(file.originalname, 'upload', 256, suffix));
-        },
-      }),
-    }).array('pakker', 21);
+      dest: process.env.UPLOAD_BASE,
+    }).array('pakker', maxUploadCount);
   }
 
   async handleUpload(

--- a/src/usecases/uploads/GeneratePackagesUseCase.ts
+++ b/src/usecases/uploads/GeneratePackagesUseCase.ts
@@ -1,3 +1,5 @@
+import fs from 'fs';
+
 import { ZipHandler } from '../../lib/anki/zip';
 import { PrepareDeck } from '../../lib/parser/DeckParser';
 import Package from '../../lib/parser/Package';
@@ -60,14 +62,14 @@ class GeneratePackagesUseCase {
     let packages: Package[] = [];
 
     for (const file of files) {
-      const fileContents = await this.storage.getFileContents(file.key);
+      const fileContents = fs.readFileSync(file.path);
       const filename = file.originalname;
       const key = file.key;
 
       if (isFileSupported(filename)) {
         const d = await PrepareDeck(
           filename,
-          [{ name: filename, contents: fileContents.Body }],
+          [{ name: filename, contents: fileContents }],
           settings
         );
         if (d) {
@@ -76,7 +78,7 @@ class GeneratePackagesUseCase {
         }
       } else if (isZIPFile(filename) || isZIPFile(key)) {
         const { packages: extraPackages } = await getPackagesFromZip(
-          fileContents.Body,
+          fileContents,
           isPatreon,
           settings
         );


### PR DESCRIPTION
Previously we were uploading them to the spaces and then retrieving one
file at a time. This can slow down the conversion process a lot.
