### PR TITLE
fix: leave Base64 images untouched

### DIFF
--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -20,6 +20,7 @@ import { embedFile } from './exporters/embedFile';
 import getYouTubeEmbedLink from './helpers/getYouTubeEmbedLink';
 import getYouTubeID from './helpers/getYouTubeID';
 import { isFileNameEqual } from '../storage/types';
+import { isFileEmbedable } from '../storage/checks';
 
 export class DeckParser {
   globalTags: cheerio.Cheerio | null;
@@ -419,7 +420,7 @@ export class DeckParser {
           if (images.length > 0) {
             images.each((_i, elem) => {
               const originalName = dom(elem).attr('src');
-              if (originalName && !originalName.startsWith('http')) {
+              if (originalName && isFileEmbedable(originalName)) {
                 const newName = embedFile(
                   exporter,
                   this.files,

--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -20,7 +20,7 @@ import { embedFile } from './exporters/embedFile';
 import getYouTubeEmbedLink from './helpers/getYouTubeEmbedLink';
 import getYouTubeID from './helpers/getYouTubeID';
 import { isFileNameEqual } from '../storage/types';
-import { isFileEmbedable } from '../storage/checks';
+import { isImageFileEmbedable } from '../storage/checks';
 
 export class DeckParser {
   globalTags: cheerio.Cheerio | null;
@@ -420,7 +420,7 @@ export class DeckParser {
           if (images.length > 0) {
             images.each((_i, elem) => {
               const originalName = dom(elem).attr('src');
-              if (originalName && isFileEmbedable(originalName)) {
+              if (originalName && isImageFileEmbedable(originalName)) {
                 const newName = embedFile(
                   exporter,
                   this.files,

--- a/src/lib/parser/exporters/embedFile.ts
+++ b/src/lib/parser/exporters/embedFile.ts
@@ -51,11 +51,13 @@ export const embedFile = (
     }
     return newName;
   } else {
-    // use bugsnag breadcrumb to add all file names
-    Bugsnag.leaveBreadcrumb('Missing relative path', {
-      filePath: filePath,
-      fileNames: files.map((f) => f.name),
-    });
+    console.debug(
+      JSON.stringify({
+        hint: 'Missing relative path',
+        filePath: filePath,
+        fileNames: files.map((f) => f.name),
+      })
+    );
 
     Bugsnag.notify(
       `Missing relative path to ${filePath} used ${exporter.firstDeckName}`

--- a/src/lib/storage/checks.ts
+++ b/src/lib/storage/checks.ts
@@ -16,5 +16,5 @@ export const isTwitterURL = (url: string) => url.match(/twitter\.com/i);
 
 export const isVimeoURL = (url: string) => url.match(/vimeo\.com/i);
 
-export const isFileEmbedable = (url: string) =>
+export const isImageFileEmbedable = (url: string) =>
   !url.startsWith('http') && !url.startsWith('data:image');

--- a/src/lib/storage/checks.ts
+++ b/src/lib/storage/checks.ts
@@ -15,3 +15,6 @@ export const isSoundCloudURL = (url: string) => url.match(/soundcloud\.com/i);
 export const isTwitterURL = (url: string) => url.match(/twitter\.com/i);
 
 export const isVimeoURL = (url: string) => url.match(/vimeo\.com/i);
+
+export const isFileEmbedable = (url: string) =>
+  !url.startsWith('http') && !url.startsWith('data:image');

--- a/src/usecases/uploads/GeneratePackagesUseCase.ts
+++ b/src/usecases/uploads/GeneratePackagesUseCase.ts
@@ -14,7 +14,6 @@ import {
 import { UploadedFile } from '../../lib/storage/types';
 
 import { Body } from 'aws-sdk/clients/s3';
-import Bugsnag from '@bugsnag/js';
 
 export interface PackageResult {
   packages: Package[];

--- a/src/usecases/uploads/GeneratePackagesUseCase.ts
+++ b/src/usecases/uploads/GeneratePackagesUseCase.ts
@@ -64,12 +64,6 @@ class GeneratePackagesUseCase {
 
     for (const file of files) {
       const fileContents = fs.readFileSync(file.path);
-
-      Bugsnag.leaveBreadcrumb('using originalname', {
-        filename: file.filename,
-        originalname: file.originalname,
-      });
-
       const filename = file.originalname;
       const key = file.key;
 


### PR DESCRIPTION
While at it remove Bugsnag breadcrumbs they are [not supported in Node.js.](https://github.com/bugsnag/bugsnag-js/issues/1223)