### PR TITLE
fix: downgrade the missing relative path

### DIFF
--- a/src/lib/parser/exporters/embedFile.ts
+++ b/src/lib/parser/exporters/embedFile.ts
@@ -1,4 +1,3 @@
-import Bugsnag from '@bugsnag/js';
 import { File } from '../../anki/zip';
 import { SuffixFrom } from '../../misc/file';
 import getUniqueFileName from '../../misc/getUniqueFileName';
@@ -57,10 +56,6 @@ export const embedFile = (
         filePath: filePath,
         fileNames: files.map((f) => f.name),
       })
-    );
-
-    Bugsnag.notify(
-      `Missing relative path to ${filePath} used ${exporter.firstDeckName}`
     );
   }
 


### PR DESCRIPTION
After reviewing several bug reports in Bugsnag and reproducing.
It's possible to export a page in Notion without the images
