### PR TITLE
build(dependabot): group dev dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,6 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    groups:
+      dev-dependencies:
+        - "*"


### PR DESCRIPTION
No need to merge and deploy them seperately