### PR TITLE
fix: remove GitHub link from the no package error

### DIFF
--- a/src/lib/misc/ErrorHandler.tsx
+++ b/src/lib/misc/ErrorHandler.tsx
@@ -2,15 +2,21 @@ import express from 'express';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { sendError } from '../error/sendError';
 
-const NEW_GITHUB_ISSUE = 'https://github.com/2anki/server/issues/new/choose';
 export const NO_PACKAGE_ERROR = new Error(
   renderToStaticMarkup(
-    <div className="info">
-      Deck creation failed with file/rules. Kindly double-check your{' '}
-      <a href="/upload?view=template">settings</a> or submit an issue on{' '}
-      <a href={NEW_GITHUB_ISSUE}>GitHub</a>, including an example for reference.
-      Could not create a deck using your file and rules.
-    </div>
+    <>
+      <div className="info">
+        Could not create a deck using your file(s) and rules. Make sure to at
+        least create on valid toggle or verify your{' '}
+        <a href="/upload?view=template">settings</a>? Example:
+      </div>
+      <div className="card" style={{ width: '50%', padding: '1rem' }}>
+        <details>
+          <summary>This the front</summary>
+          This is the back
+        </details>
+      </div>
+    </>
   )
 );
 


### PR DESCRIPTION
We are getting some very low quality bug reports from people not
spending time to learn how 2anki.net works.
