### PR TITLE
fix: do not add empty lines in the path `d` attribute

### DIFF
--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -139,17 +139,35 @@ export class DeckParser {
     }
   }
 
+  removeNewlinesInSVGPathAttributeD(html: string): string {
+    const dom = cheerio.load(html);
+    const pathElements = dom('path');
+
+    for (const pathElement of pathElements) {
+      if ('attribs' in pathElement && 'd' in pathElement.attribs) {
+        const dAttribute = pathElement.attribs.d;
+        const newDAttribute = dAttribute.replace(/\n/g, '').trim();
+        dom(pathElement).attr('d', newDAttribute);
+      }
+    }
+
+    return dom.html();
+  }
+
   handleHTML(
     fileName: string,
     contents: string,
     deckName: string,
     decks: Deck[]
   ) {
-    const dom = cheerio.load(
-      this.settings.noUnderline
-        ? contents.replace(/border-bottom:0.05em solid/g, '')
-        : contents
+    let dom = cheerio.load(
+      this.removeNewlinesInSVGPathAttributeD(
+        this.settings.noUnderline
+          ? contents.replace(/border-bottom:0.05em solid/g, '')
+          : contents
+      )
     );
+
     let name = deckName || dom('title').text();
     let style = dom('style').html();
     if (style) {


### PR DESCRIPTION
These are coming directly from Notion. No idea why they are doing it
this way. It was not like this before. What basically happens is that
our `preserveNewlinesIfApplicable` function will add `<br />` to the tag
and it will totally break the KaTex.

Fixes: https://github.com/2anki/2anki.net/issues/1382
