### PR TITLE
spec: combine a multi-file upload into one deck

### DIFF
--- a/Documentation/specs/combine-multi-file-upload.md
+++ b/Documentation/specs/combine-multi-file-upload.md
@@ -1,0 +1,45 @@
+# Combine a multi-file upload into one deck
+
+**Issues:** #3918 (primary), #3917 (within-upload duplicate case subsumed; cross-upload residual stays open)
+**Trio:** pm + designer + engineer, 2026-07-31 (overnight). Decisions below are theirs; override freely.
+
+## Problem
+
+Our heaviest AI user (user 18996, ~46% of weekly AI usage) uploads several overlapping sources on one topic — book chapter, transcript, slides — and gets N parallel decks with near-duplicate cards. Today `worker.ts` runs one `PrepareDeck` per loose file, and the zip AI path converts per-HTML-file into separate subdecks. Sources never inform each other; overlap survives and every duplicate is re-billed.
+
+## v1
+
+When a local/Dropbox/Drive upload contains **2+ loose content files** (not a single zip — its subdeck nesting is loved and untouched), pause the auto-submit with the existing validation-interstitial pattern:
+
+- Title: `One deck from {{count}} files?`
+- Primary: `Make one deck` (emphasized default) · Tertiary link: `Keep them separate`
+- No body copy in v1. Strings ship in all 10 locales (`upload.combine.*`, CLDR plurals for ru/pl).
+
+`Make one deck` sends a per-request `combine=true` form field (never a persisted setting, never an env flag). Server keeps the existing **per-file `generateDeckInfo` calls unchanged and parallel**, then merges all files' cards into ONE deck under one name (first file's base name) and lets the existing `dedupeIdenticalCards` (normalized front+back, #3906) collapse exact cross-file duplicates. **No source concatenation, no sequential do-not-repeat preamble** — per-file-then-merge has zero input-token delta vs today and can only shrink output. With AI off, combine performs the same mechanical merge (one `.apkg` instead of N) — copy promises "one deck", not synthesis, so both engines are honest.
+
+Combine mode switches the per-file fan-out to `allSettled` semantics: one failed file drops with a warning, the rest ship (mirrors the PDF-page and chunk salvage patterns). Success screen shows the normal single-deck state plus a muted `One deck from {{count}} files` caption via an `X-Combined-From-Count` header (same transport as `X-Card-Count`).
+
+## Not building (v1)
+
+- Sequential conversion with accumulated do-not-repeat fronts (costs more tokens than merge, serializes latency; near-dupe suppression deferred until exact-dupe data says it's insufficient).
+- Any dedupe UI, diff/merge preview, or "merge with existing deck" picker.
+- A recent-decks front index or any new table/migration; a sticky combine preference; changes to single-file or single-zip paths.
+- #3917 cross-upload dedupe — revisit only if post-ship data still shows cross-session overlap; the feasible shape then is "extend this attached deck" (extract fronts via `ApkgPreviewService`, feed through a generalized `buildTopUpInstruction`).
+
+## Analytics & lifecycle
+
+- `upload_combine_prompt_shown`; `upload_combine_chosen` `{ choice: 'one_deck' | 'separate', file_count }` — added to BOTH allowlists (parity test). `conversion_succeeded` gains a `combined_from_files` prop on combined runs; no new completion event.
+- Extension of the existing upload surface, not a new surface — no T+30 issue; day-7 prod check on combined-run success rate + cost per multi-file upload, folded into the weekly retro.
+- **Kill condition:** Anthropic cost per multi-file upload must not exceed today's N-separate-decks cost (holds by construction; verify anyway). **Success:** `one_deck` chosen on most prompts; multi-deck batch results drop; top-decile AI-user repeat usage flat-to-up (`/api/ops/metrics`).
+
+## Acceptance criteria
+
+- [ ] 2+ loose content files + `combine=true` → one deck, one `.apkg`, deck name from the first file; exact cross-file front+back duplicates collapse via the #3906 normalization.
+- [ ] Each file still converted by its own parallel `generateDeckInfo` call — no concatenation, input tokens unchanged vs separate conversion (assert call count + per-call payload in tests).
+- [ ] One file failing (e.g. image-only) drops only that file; the combined deck ships with a warning naming the drop count.
+- [ ] `Keep them separate` and single-file/zip uploads are bit-for-bit today's behavior.
+- [ ] Events registered in both allowlists; interstitial + caption strings present in all 10 locales; changelog entry in the same PR.
+
+## Touch list
+
+`worker.ts` (route loose multi-file → single `PrepareDeck` when flagged), `PrepareDeck.ts` (merge + `allSettled` + name), `UploadService.ts` (field + header), `UploadForm.tsx` + `useFileValidation.ts` (interstitial), locales ×10, events ×2, tests (~5 server + 2 web). Risk MEDIUM (hot conversion path, off-path unchanged). No migration, no auth/payments — no worktree trigger.


### PR DESCRIPTION
**Draft: spec awaiting `/implement`.** One-page spec for #3918, produced by an overnight trio; no code in this PR.

Closes #3918 when the implementation lands; #3917 stays open as the cross-upload residual tracker.

## Trio synthesis (pm + designer + engineer, run in parallel)

- **pm:** build one thing — #3918 combine mode; #3917 becomes the deferred cross-upload residual, revisited only if post-ship data shows remaining pain. Default toward combining; hard kill condition on cost per multi-file upload; extension of the upload surface, not a new surface.
- **designer:** the choice lives in the existing post-drop validation interstitial, shown only for 2+ loose content files; combine is the emphasized default but never silent; exact copy locked (`One deck from {{count}} files?` / `Make one deck` / `Keep them separate`); zero dedupe UI; single-file and zip paths untouched.
- **engineer:** per-file-then-merge is the correct mechanism — zero input-token delta, parallel latency, exact cross-file dupes collapse via the existing #3906 normalization. The sequential do-not-repeat shape the issues floated costs MORE tokens, not fewer. `allSettled` the fan-out so one bad file doesn't kill the combined job. No migration; MEDIUM risk; off-path must stay bit-for-bit unchanged.

**Agreements:** one build, no new datastore, no dedupe UI, usage events in the same PR, #3917 deferred.

**Conflicts resolved:**
- Mechanism (pm's sequential do-not-repeat vs engineer's per-file-then-merge): engineer wins on token math grounded in the actual chunking/media code — merge is strictly cheaper and satisfies pm's cost ceiling by construction.
- Control (pm "no toggle" vs designer "always-shown prompt" vs engineer "opt-in CardOption default off"): designer's per-upload interstitial wins — it is pm's combine-forward default, satisfies engineer's off-path-unchanged requirement (the escape link IS today's behavior), and avoids a sticky hidden setting. The flag is per-request, not persisted.
- Engine scope (engineer "AI path only" vs designer "prompt must be engine-agnostic"): combine merges under both engines — mechanically for non-AI — because the copy promises "one deck", not synthesis. The prompt can't be gated on a setting the user doesn't see.

**Expected impact:** power-user retention (top-decile AI users) flat-to-up and Anthropic cost per multi-file upload down — read at `/api/ops/metrics` and the Anthropic dashboard at the day-7 check.

## Decisions made overnight (please review)

- One spec, not two: #3917's within-upload case is subsumed here; its cross-upload residual stays an open issue with the feasible future shape named in the spec. Assumption: you don't want a speculative second spec rotting in `Documentation/specs/`. If wrong, say so and I'll draft the attach-and-extend spec.
- Copy is the designer's verbatim; swap if you'd word it differently.
- Non-AI uploads get the mechanical merge so the prompt is engine-agnostic. If you'd rather scope v1 to AI-only, the interstitial needs an AI-enabled gate — that's the thing to change in the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7TQQrHY4ttkng9To493Nd
