### PR TITLE
feat: move AI conversions to Claude Sonnet 5

### DIFF
--- a/src/infrastracture/adapters/fileConversion/claudeFileConversion.test.ts
+++ b/src/infrastracture/adapters/fileConversion/claudeFileConversion.test.ts
@@ -181,7 +181,7 @@ describe('convertWithClaude', () => {
     ]);
 
     const callArg = (mock.messages.stream as jest.Mock).mock.calls[0][0];
-    expect(callArg.model).toBe('claude-sonnet-4-6');
+    expect(callArg.model).toBe('claude-sonnet-5');
   });
 
   it('uses CLAUDE_FILE_CONVERSION_MODEL env when set', async () => {

--- a/src/infrastracture/adapters/fileConversion/claudeFileConversion.ts
+++ b/src/infrastracture/adapters/fileConversion/claudeFileConversion.ts
@@ -3,7 +3,7 @@ import type { BetaContentBlockParam } from '@anthropic-ai/sdk/resources/beta/mes
 
 import { logClaudeUsage } from '../../../lib/claude/logClaudeUsage';
 
-const DEFAULT_MODEL = 'claude-sonnet-4-6';
+const DEFAULT_MODEL = 'claude-sonnet-5';
 // A cap, not a charge — output is billed on tokens actually generated, so a
 // generous ceiling costs nothing on documents that were never near it. At the
 // old 8192 a dense multi-page PDF hit the cap routinely, and the truncation

--- a/src/lib/claude/generateDeckInfoFromPdfImages.ts
+++ b/src/lib/claude/generateDeckInfoFromPdfImages.ts
@@ -16,8 +16,8 @@ import {
 
 type CompactDeck = ReturnType<typeof parseDeckResponse>[number];
 
-const PDF_PAGE_VISION_MAX_TOKENS = 8192;
-const PDF_PAGE_VISION_RETRY_MAX_TOKENS = 16384;
+const PDF_PAGE_VISION_MAX_TOKENS = 16384;
+const PDF_PAGE_VISION_RETRY_MAX_TOKENS = 32768;
 const PDF_PAGE_VISION_CONCURRENCY = 4;
 
 const MEDIA_TYPE_BY_EXT: Record<string, VisionMediaType> = {
@@ -125,7 +125,7 @@ async function visionCardsForPage(
 
   const callVision = (maxTokens: number) =>
     client.messages.create({
-      model: 'claude-sonnet-4-5',
+      model: 'claude-sonnet-5',
       max_tokens: maxTokens,
       messages: [
         {

--- a/src/usecases/ai/AINoteTypeUseCase.ts
+++ b/src/usecases/ai/AINoteTypeUseCase.ts
@@ -1,8 +1,8 @@
 import { getAnthropicClient } from '../../lib/claude/ClaudeService';
 import { logClaudeUsage } from '../../lib/claude/logClaudeUsage';
 
-const MODEL = 'claude-sonnet-4-5';
-const MAX_TOKENS = 4096;
+const MODEL = 'claude-sonnet-5';
+const MAX_TOKENS = 8192;
 
 export interface AnkiCardTemplateInput {
   name: string;

--- a/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.test.ts
+++ b/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.test.ts
@@ -213,8 +213,8 @@ describe('PhotoToFlashcardsUseCase', () => {
       const result = await useCase.execute({ ...BASE_INPUT, isPaying: true });
       expect(result.cardCount).toBe(2);
       expect(mockMessageCreate).toHaveBeenCalledTimes(2);
-      expect(mockMessageCreate.mock.calls[0][0].max_tokens).toBe(4096);
-      expect(mockMessageCreate.mock.calls[1][0].max_tokens).toBe(8192);
+      expect(mockMessageCreate.mock.calls[0][0].max_tokens).toBe(8192);
+      expect(mockMessageCreate.mock.calls[1][0].max_tokens).toBe(16384);
     });
 
     it('throws 422 when the retry is also truncated mid-JSON', async () => {

--- a/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.ts
+++ b/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.ts
@@ -168,8 +168,8 @@ function resolvePrompt(
 
 const INPUT_COST_PER_MILLION = 3;
 const OUTPUT_COST_PER_MILLION = 15;
-const VISION_MAX_TOKENS = 4096;
-const VISION_RETRY_MAX_TOKENS = 8192;
+const VISION_MAX_TOKENS = 8192;
+const VISION_RETRY_MAX_TOKENS = 16384;
 
 function findPython(): string {
   const envOverride = process.env.PYTHON ?? process.env.ANKI_PYTHON;
@@ -583,7 +583,7 @@ export class PhotoToFlashcardsUseCase {
 
     const createVisionMessage = (maxTokens: number) =>
       client.messages.create({
-        model: 'claude-sonnet-4-5',
+        model: 'claude-sonnet-5',
         max_tokens: maxTokens,
         messages: [
           {

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-09-sonnet-5-conversions.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-09-sonnet-5-conversions.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-09-sonnet-5-conversions",
+  "date": "2026-08-09",
+  "type": "feature",
+  "title": "AI conversions run on Claude Sonnet 5 — sharper cards from photos, scanned PDFs, and documents"
+}


### PR DESCRIPTION
## Why

Screencast demos showed weaker results on the vision paths (photo-to-deck, scanned PDFs) — those were pinned to Sonnet 4.5 while text conversions ran 4.6. Claude Sonnet 5 is the first Sonnet-tier model with high-resolution vision and specifically better chart/document/diagram understanding, at the same $3/$15 sticker — with intro pricing ($2/$10) making it cheaper than today's models through Aug 31.

## What

- Vision paths → `claude-sonnet-5`: `generateDeckInfoFromPdfImages`, `PhotoToFlashcardsUseCase`, `AINoteTypeUseCase`.
- Text conversions → `claude-sonnet-5`: `claudeFileConversion` DEFAULT_MODEL (was 4-6).
- Vision `max_tokens` budgets doubled (PDF 8192→16384 / retry 32768; photo 4096→8192 / retry 16384; note-type 4096→8192): Sonnet 5 runs adaptive thinking by default and thinking shares the `max_tokens` budget — without headroom, answers truncate.
- Chat (paid tier on 4-6) and tagging (Haiku 4.5) deliberately unchanged.

## Verified

- **Live API smoke** before any edit: `claude-sonnet-5` with our exact request shape (base64 image + `cache_control` system block, no `thinking` param) → `end_turn`, correct answer.
- Call-site audit: no sampling params, no `budget_tokens`, no last-assistant-turn prefills anywhere on the switched paths (the `AINoteTypeUseCase` assistant turn is mid-conversation — legal).
- Full server suite 6333 passed (only the documented `getPageCount` pdfinfo env failure); tsc + format clean.

## Cost note

Sonnet 5's tokenizer counts ~30% more tokens for the same text — after the intro window ends (Aug 31), text-conversion spend rises roughly 30% vs 4-6 at unchanged sticker. Watch the Console usage page against the $1,000/mo line; vision spend is roughly unchanged (page renders keep their current resolution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFM6MBEU4Gg2mVNtGsaxvP