### PR TITLE
feat: run chat on Claude Sonnet 5 for free and paid tiers

### DIFF
--- a/src/usecases/chat/ChatUseCase.test.ts
+++ b/src/usecases/chat/ChatUseCase.test.ts
@@ -154,7 +154,7 @@ describe('ChatUseCase', () => {
   });
 
   describe('model selection', () => {
-    it('uses haiku model for free users', async () => {
+    it('uses Sonnet 5 for free users', async () => {
       const { anthropic, useCase } = buildUseCase('answer');
 
       await useCase.execute({
@@ -164,11 +164,11 @@ describe('ChatUseCase', () => {
       });
 
       expect(anthropic.messages.stream).toHaveBeenCalledWith(
-        expect.objectContaining({ model: 'claude-haiku-4-5-20251001' })
+        expect.objectContaining({ model: 'claude-sonnet-5' })
       );
     });
 
-    it('uses sonnet model for patreon users', async () => {
+    it('uses Sonnet 5 for patreon users', async () => {
       const { anthropic, useCase } = buildUseCase('answer');
 
       await useCase.execute({
@@ -178,7 +178,7 @@ describe('ChatUseCase', () => {
       });
 
       expect(anthropic.messages.stream).toHaveBeenCalledWith(
-        expect.objectContaining({ model: 'claude-sonnet-4-6' })
+        expect.objectContaining({ model: 'claude-sonnet-5' })
       );
     });
   });
@@ -1054,7 +1054,7 @@ describe('ChatUseCase', () => {
       });
 
       const callArg = anthropic.messages.stream.mock.calls[0][0];
-      expect(callArg.max_tokens).toBe(8192);
+      expect(callArg.max_tokens).toBe(16384);
     });
 
     it('keeps the default max_tokens for non-MCQ templates', async () => {
@@ -1068,7 +1068,7 @@ describe('ChatUseCase', () => {
       });
 
       const callArg = anthropic.messages.stream.mock.calls[0][0];
-      expect(callArg.max_tokens).toBe(4096);
+      expect(callArg.max_tokens).toBe(8192);
     });
 
     it('extracts MCQ cards from the tool_use block for templateSlug=mcq', async () => {

--- a/src/usecases/chat/ChatUseCase.ts
+++ b/src/usecases/chat/ChatUseCase.ts
@@ -80,8 +80,7 @@ const MCQ_TOOL: Anthropic.Tool = {
 };
 
 const FREE_MONTHLY_LIMIT = 20;
-const FREE_MODEL = 'claude-haiku-4-5-20251001';
-const PATREON_MODEL = 'claude-sonnet-4-6';
+const MODEL = 'claude-sonnet-5';
 const MAX_HISTORY_TURNS = 10;
 // A follow-up turn replays the attachment text folded into its original user
 // message, so a large PDF would otherwise be re-sent on every subsequent turn.
@@ -89,12 +88,14 @@ const MAX_HISTORY_TURNS = 10;
 // extractAttachmentText's 200 000-char budget); only the copy carried forward
 // as conversation memory is capped here.
 const MAX_ATTACHMENT_TEXT_IN_HISTORY = 20_000;
-const MAX_TOKENS = 4096;
+// Sonnet 5's adaptive thinking spends from the same max_tokens budget as the
+// visible reply, so both caps are doubled from their pre-Sonnet-5 values.
+const MAX_TOKENS = 8192;
 // MCQ is emitted as forced tool-use JSON (stem + 4 options + rationale per
 // card). At 4096 the structured output truncates on multi-card batches, the
 // tool input never closes, extraction returns nothing, and the turn fails with
 // McqExtractionFailedError. Give the MCQ path more headroom so the JSON fits.
-const MCQ_MAX_TOKENS = 8192;
+const MCQ_MAX_TOKENS = 16384;
 const AUTO_TITLE_MAX_LENGTH = 60;
 
 const STUDY_ASSISTANT_SYSTEM_PROMPT = `You are a study assistant for 2anki, a tool that turns notes into Anki flashcards.
@@ -628,8 +629,6 @@ export class ChatUseCase {
     const { user, conversationId, historyMessages, userContent, onToken } =
       params;
 
-    const model = user.patreon ? PATREON_MODEL : FREE_MODEL;
-
     const resolvedTemplate: ChatCardTemplate = isChatCardTemplate(
       params.templateSlug
     )
@@ -653,7 +652,7 @@ export class ChatUseCase {
     ];
 
     const stream = this.anthropic.messages.stream({
-      model,
+      model: MODEL,
       max_tokens: mcqForced ? MCQ_MAX_TOKENS : MAX_TOKENS,
       system: [
         {

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-09-sonnet-5-chat.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-09-sonnet-5-chat.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-09-sonnet-5-chat",
+  "date": "2026-08-09",
+  "type": "feature",
+  "title": "Chat now runs on Claude Sonnet 5 for everyone — free users included"
+}


### PR DESCRIPTION
## What

Moves chat off the split model pair (free = Haiku 4.5, paid = Sonnet 4.6) — both tiers now run `claude-sonnet-5`.

- Single `MODEL` constant replaces `FREE_MODEL`/`PATREON_MODEL` and the per-user ternary.
- `MAX_TOKENS` 4096 → 8192, `MCQ_MAX_TOKENS` 8192 → 16384: Sonnet 5's adaptive thinking spends from the same `max_tokens` budget as the visible reply, so the old caps would truncate long answers and multi-card MCQ JSON (the exact failure `McqExtractionFailedError` guards).

## Verification

- Live smoke test against the API before editing: streamed chat shape (`end_turn`, text) and the forced `tool_choice` MCQ shape (`tool_use`) both succeed on `claude-sonnet-5` — forced tool use + adaptive thinking was the one compatibility risk.
- `ChatUseCase.test.ts` 72/72; full web vitest 2826/2826 (changelog loader covers the new entry); `tsc -p . --noEmit` clean; `pnpm format:check` clean tree-wide.
- Sonar: local scan not run (trivial constant-level diff); gating merge on the PR analysis reporting zero open findings.

## Cost

Free chat moves from Haiku ($1/$5 per MTok) to Sonnet 5 ($2/$10 intro until Aug 31, then $3/$15). Exposure is bounded by the free tier's 20-message monthly limit and the 8K output cap. Tagging stays on Haiku.

## Browser check

Not applicable — the only web/src change is a changelog JSON entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
