### PR TITLE
fix: hide chat's empty card table until cards actually exist

### DIFF
--- a/web/src/pages/Chat/CardPreview.test.tsx
+++ b/web/src/pages/Chat/CardPreview.test.tsx
@@ -299,4 +299,30 @@ describe('CardPreview', () => {
       ).not.toBeInTheDocument();
     });
   });
+
+  describe('selector-only state (no cards yet)', () => {
+    it('shows the note type selector without the empty table chrome', () => {
+      render(
+        <CardPreview cards={[]} template="basic" onTemplateChange={vi.fn()} />
+      );
+      expect(
+        screen.getByRole('button', { name: 'Note type: Basic' })
+      ).toBeInTheDocument();
+      expect(screen.queryByText('Front')).not.toBeInTheDocument();
+      expect(screen.queryByText('Back')).not.toBeInTheDocument();
+    });
+
+    it('keeps the column labels when cards exist', () => {
+      render(
+        <CardPreview
+          cards={makeCards(2)}
+          onSave={vi.fn()}
+          template="basic"
+          onTemplateChange={vi.fn()}
+        />
+      );
+      expect(screen.getAllByText('Front').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Back').length).toBeGreaterThan(0);
+    });
+  });
 });

--- a/web/src/pages/Chat/CardPreview.tsx
+++ b/web/src/pages/Chat/CardPreview.tsx
@@ -294,7 +294,7 @@ export default function CardPreview({
         )}
       </div>
 
-      {!allCardsAreMcq && (
+      {displayCards.length > 0 && !allCardsAreMcq && (
         <div
           className={`${styles.cardPreviewColumnLabels} ${hideBackColumn && !hasTags ? styles.cardPreviewColumnLabelsSingle : ''} ${!hideBackColumn && hasTags ? styles.cardPreviewColumnLabelsThree : ''}`}
         >
@@ -313,7 +313,7 @@ export default function CardPreview({
           {switchLabel}
         </p>
       )}
-      <>
+      {displayCards.length > 0 && (
         <div
           className={`${styles.cardPreviewList} ${isRegenerating === true ? styles.cardPreviewListDimmed : ''}`}
           aria-busy={isRegenerating === true}
@@ -362,19 +362,19 @@ export default function CardPreview({
             )
           )}
         </div>
+      )}
 
-        {hasMore && (
-          <button
-            type="button"
-            className={styles.cardPreviewExpandBtn}
-            onClick={() => setExpanded((v) => !v)}
-          >
-            {expanded
-              ? t('cardPreview.showFewer')
-              : t('cardPreview.showAll', { count: displayCards.length })}
-          </button>
-        )}
-      </>
+      {hasMore && (
+        <button
+          type="button"
+          className={styles.cardPreviewExpandBtn}
+          onClick={() => setExpanded((v) => !v)}
+        >
+          {expanded
+            ? t('cardPreview.showFewer')
+            : t('cardPreview.showAll', { count: displayCards.length })}
+        </button>
+      )}
     </div>
   );
 }

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-09-chat-empty-card-table.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-09-chat-empty-card-table.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-09-chat-empty-card-table",
+  "date": "2026-08-09",
+  "type": "fix",
+  "title": "Chat no longer shows an empty card table before any cards exist"
+}


### PR DESCRIPTION
## What

Fixes the empty card table in chat: a prose-only assistant reply (no cards yet) showed the note-type selector plus Front/Back column headers over a blank list — reading as a stuck or pending generation.

## Why it happened

#3032 deliberately renders the selector on the last assistant turn even without cards, so switching note type can trigger generation from the preceding question. That commit hid the card *count* for the cardless state but mounted the rest of the CardPreview shell — column labels and the empty list container — which has rendered as a phantom table ever since.

## How

`CardPreview` now gates the column-label row and the list container on `displayCards.length > 0`. The selector stays reachable on cardless turns (the #3032 feature is unchanged), and the regenerating "Switching to X" hint still renders.

## Tests

- New: selector-only state renders the note-type selector without Front/Back labels (failed before the fix); column labels still present when cards exist.
- CardPreview + ChatPanel: 82/82. Full web vitest: 2828/2828. Typecheck, oxlint, `pnpm format:check` clean.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: backed by a green `pnpm --filter 2anki-web test:golden-path` run (2/2 at 375px, zero console errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
