### PR TITLE
fix: record why OAuth token exchanges fail, not just that they did

### DIFF
--- a/src/controllers/UsersControllers.test.ts
+++ b/src/controllers/UsersControllers.test.ts
@@ -1307,6 +1307,7 @@ describe('UsersController.loginWithApple', () => {
       loginWithApple:
         overrides?.loginWithApple ??
         jest.fn().mockResolvedValue({
+          ok: true,
           subject: 'apple-sub-001',
           email: 'apple@example.com',
           emailVerified: true,
@@ -1388,6 +1389,7 @@ describe('UsersController.loginWithApple', () => {
   it('stores the Apple refresh token on the linked identity when present', async () => {
     const register = jest.fn().mockResolvedValue([{ id: 20 }]);
     const loginWithApple = jest.fn().mockResolvedValue({
+      ok: true,
       subject: 'apple-sub-001',
       email: 'apple@example.com',
       emailVerified: true,
@@ -1420,6 +1422,7 @@ describe('UsersController.loginWithApple', () => {
       .fn()
       .mockResolvedValue({ id: 20, email: 'apple@example.com' });
     const loginWithApple = jest.fn().mockResolvedValue({
+      ok: true,
       subject: 'apple-sub-001',
       email: 'apple@example.com',
       emailVerified: true,
@@ -1509,7 +1512,11 @@ describe('UsersController.loginWithApple', () => {
   });
 
   it('redirects to /login when the token exchange fails', async () => {
-    const loginWithApple = jest.fn().mockResolvedValue(undefined);
+    const loginWithApple = jest.fn().mockResolvedValue({
+      ok: false,
+      reason: 'token_exchange_failed',
+      message: 'HTTP 400 invalid_grant',
+    });
     const { controller } = buildAppleController({ loginWithApple });
     const res = buildAppleRes();
 
@@ -1520,6 +1527,7 @@ describe('UsersController.loginWithApple', () => {
 
   it('redirects to /login when email is missing and no identity exists', async () => {
     const loginWithApple = jest.fn().mockResolvedValue({
+      ok: true,
       subject: 'apple-sub-noemail',
       email: undefined,
       emailVerified: true,
@@ -1955,6 +1963,7 @@ describe('UsersController.loginWithGoogle — error recording', () => {
       context: {
         reason: 'verify_failed',
         message: 'JsonWebTokenError: invalid signature',
+        userAgent: null,
       },
     });
     expect(res.redirect).toHaveBeenCalledWith(
@@ -2349,6 +2358,7 @@ describe('UsersController cookie options — 30-day persistent session', () => {
     } as unknown as UsersService;
     const authService = {
       loginWithApple: jest.fn().mockResolvedValue({
+        ok: true,
         subject: 'apple-sub',
         email: 'apple@example.com',
         emailVerified: true,

--- a/src/controllers/UsersControllers.ts
+++ b/src/controllers/UsersControllers.ts
@@ -873,6 +873,7 @@ class UsersController {
         context: {
           reason: loginRequest.reason,
           message: loginRequest.message,
+          userAgent: req.headers?.['user-agent'] ?? null,
         },
       });
       return res.redirect('/login?error=google_signin_failed');
@@ -1070,6 +1071,11 @@ class UsersController {
         userId: null,
         surface: 'oauth_apple',
         code: 'oauth_state_mismatch',
+        context: {
+          hadStateCookie: stateCookie != null,
+          hadStateParam: state != null,
+          userAgent: req.headers?.['user-agent'] ?? null,
+        },
       });
       return res.redirect('/login');
     }
@@ -1085,11 +1091,16 @@ class UsersController {
     }
 
     const loginRequest = await this.authService.loginWithApple(code);
-    if (!loginRequest) {
+    if (!loginRequest.ok) {
       await this.recordError?.execute({
         userId: null,
         surface: 'oauth_apple',
         code: 'oauth_token_exchange_failed',
+        context: {
+          reason: loginRequest.reason,
+          message: loginRequest.message,
+          userAgent: req.headers?.['user-agent'] ?? null,
+        },
       });
       return res.redirect('/login');
     }

--- a/src/services/AuthenticationService.test.ts
+++ b/src/services/AuthenticationService.test.ts
@@ -262,6 +262,34 @@ describe('loginWithGoogle', () => {
     );
   });
 
+  it('captures the provider error body when the token exchange fails', async () => {
+    const axiosError = Object.assign(
+      new Error('Request failed with status code 400'),
+      {
+        isAxiosError: true,
+        response: {
+          status: 400,
+          data: {
+            error: 'invalid_grant',
+            error_description: 'Bad authorization code.',
+          },
+        },
+      }
+    );
+    mockedAxios.post = jest.fn().mockRejectedValue(axiosError);
+
+    const service = createService();
+    const result = await service.loginWithGoogle('auth-code');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('token_exchange_failed');
+      expect(result.message).toContain('400');
+      expect(result.message).toContain('invalid_grant');
+      expect(result.message).toContain('Bad authorization code.');
+    }
+  });
+
   it('returns a failure reason when the ID token signature is invalid', async () => {
     const otherKey = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
     const idToken = jwt.sign(
@@ -805,6 +833,7 @@ describe('loginWithApple', () => {
     const result = await service.loginWithApple('auth-code');
 
     expect(result).toEqual({
+      ok: true,
       subject: 'apple-sub-001',
       email: 'user@example.com',
       emailVerified: true,
@@ -828,6 +857,7 @@ describe('loginWithApple', () => {
     const result = await service.loginWithApple('auth-code');
 
     expect(result).toMatchObject({
+      ok: true,
       subject: 'apple-sub-001b',
       refreshToken: undefined,
     });
@@ -849,12 +879,13 @@ describe('loginWithApple', () => {
     const result = await service.loginWithApple('auth-code');
 
     expect(result).toMatchObject({
+      ok: true,
       subject: 'apple-sub-002',
       emailVerified: true,
     });
   });
 
-  it('returns undefined when email_verified is false', async () => {
+  it('fails with email_not_verified when email_verified is false', async () => {
     const idToken = signIdToken({
       iss: 'https://appleid.apple.com',
       aud: SERVICES_ID,
@@ -869,10 +900,10 @@ describe('loginWithApple', () => {
     const service = createService();
     const result = await service.loginWithApple('auth-code');
 
-    expect(result).toBeUndefined();
+    expect(result).toMatchObject({ ok: false, reason: 'email_not_verified' });
   });
 
-  it('returns undefined when the issuer is wrong', async () => {
+  it('fails with verify_failed when the issuer is wrong', async () => {
     const idToken = signIdToken({
       iss: 'https://evil.example.com',
       aud: SERVICES_ID,
@@ -887,10 +918,10 @@ describe('loginWithApple', () => {
     const service = createService();
     const result = await service.loginWithApple('auth-code');
 
-    expect(result).toBeUndefined();
+    expect(result).toMatchObject({ ok: false, reason: 'verify_failed' });
   });
 
-  it('returns undefined when the audience does not match', async () => {
+  it('fails with verify_failed when the audience does not match', async () => {
     const idToken = signIdToken({
       iss: 'https://appleid.apple.com',
       aud: 'com.evil.app',
@@ -905,10 +936,10 @@ describe('loginWithApple', () => {
     const service = createService();
     const result = await service.loginWithApple('auth-code');
 
-    expect(result).toBeUndefined();
+    expect(result).toMatchObject({ ok: false, reason: 'verify_failed' });
   });
 
-  it('returns undefined when the signature is invalid', async () => {
+  it('fails with verify_failed when the signature is invalid', async () => {
     const wrongPair = crypto.generateKeyPairSync('rsa', {
       modulusLength: 2048,
     });
@@ -930,10 +961,10 @@ describe('loginWithApple', () => {
     const service = createService();
     const result = await service.loginWithApple('auth-code');
 
-    expect(result).toBeUndefined();
+    expect(result).toMatchObject({ ok: false, reason: 'verify_failed' });
   });
 
-  it('returns undefined when the kid is not in the JWKS', async () => {
+  it('fails with verify_failed when the kid is not in the JWKS', async () => {
     const idToken = jwt.sign(
       {
         iss: 'https://appleid.apple.com',
@@ -952,19 +983,36 @@ describe('loginWithApple', () => {
     const service = createService();
     const result = await service.loginWithApple('auth-code');
 
-    expect(result).toBeUndefined();
+    expect(result).toMatchObject({ ok: false, reason: 'verify_failed' });
   });
 
-  it('returns undefined when the token exchange fails', async () => {
-    mockedAxios.post = jest.fn().mockRejectedValue(new Error('network error'));
+  it('fails with token_exchange_failed and the provider error body', async () => {
+    const axiosError = Object.assign(
+      new Error('Request failed with status code 400'),
+      {
+        isAxiosError: true,
+        response: {
+          status: 400,
+          data: { error: 'invalid_grant' },
+        },
+      }
+    );
+    mockedAxios.post = jest.fn().mockRejectedValue(axiosError);
 
     const service = createService();
     const result = await service.loginWithApple('auth-code');
 
-    expect(result).toBeUndefined();
+    expect(result).toMatchObject({
+      ok: false,
+      reason: 'token_exchange_failed',
+    });
+    if (result.ok === false) {
+      expect(result.message).toContain('400');
+      expect(result.message).toContain('invalid_grant');
+    }
   });
 
-  it('returns undefined when the sub claim is missing', async () => {
+  it('fails with missing_sub when the sub claim is missing', async () => {
     const idToken = signIdToken({
       iss: 'https://appleid.apple.com',
       aud: SERVICES_ID,
@@ -978,7 +1026,7 @@ describe('loginWithApple', () => {
     const service = createService();
     const result = await service.loginWithApple('auth-code');
 
-    expect(result).toBeUndefined();
+    expect(result).toMatchObject({ ok: false, reason: 'missing_sub' });
   });
 });
 
@@ -1043,9 +1091,11 @@ describe('loginWithApple algorithm pin', () => {
     const result = await service.loginWithApple('auth-code');
 
     expect(result).toEqual({
+      ok: true,
       subject: 'apple-rsa-sub-001',
       email: 'rsa-user@example.com',
       emailVerified: true,
+      refreshToken: undefined,
     });
   });
 
@@ -1071,7 +1121,7 @@ describe('loginWithApple algorithm pin', () => {
     const service = createService();
     const result = await service.loginWithApple('auth-code');
 
-    expect(result).toBeUndefined();
+    expect(result).toMatchObject({ ok: false, reason: 'verify_failed' });
   });
 });
 

--- a/src/services/AuthenticationService.ts
+++ b/src/services/AuthenticationService.ts
@@ -28,6 +28,35 @@ const describeError = (error: unknown): string => {
   return String(error).slice(0, 200);
 };
 
+// OAuth token endpoints answer failures with { error, error_description } —
+// the part that names the actual cause (invalid_grant vs redirect_uri_mismatch
+// vs invalid_client). describeError alone reduces every one of them to
+// "AxiosError: Request failed with status code 400", which is what left the
+// user_visible_errors context useless for #3952. No secrets live in that body.
+const describeTokenExchangeError = (error: unknown): string => {
+  if (typeof error === 'object' && error != null && 'response' in error) {
+    const response = (
+      error as { response?: { status?: number; data?: unknown } }
+    ).response;
+    if (response != null) {
+      const status = `HTTP ${response.status ?? '?'}`;
+      const data = response.data;
+      if (typeof data === 'object' && data != null) {
+        const body = data as Record<string, unknown>;
+        const parts = [body.error, body.error_description].filter(
+          (value): value is string =>
+            typeof value === 'string' && value.length > 0
+        );
+        if (parts.length > 0) {
+          return `${status} ${parts.join(': ')}`.slice(0, 300);
+        }
+      }
+      return `${status} ${describeError(error)}`.slice(0, 300);
+    }
+  }
+  return describeError(error).slice(0, 300);
+};
+
 const resolveRsaSigningKey = (
   idToken: string,
   jwks: RsaJwk[]
@@ -147,6 +176,16 @@ export const __resetGoogleJwksCacheForTests = () => {
 
 export type GoogleLoginResult =
   | { ok: true; email?: string; name?: string }
+  | { ok: false; reason: string; message: string };
+
+export type AppleLoginResult =
+  | {
+      ok: true;
+      subject: string;
+      email?: string;
+      emailVerified: true;
+      refreshToken?: string;
+    }
   | { ok: false; reason: string; message: string };
 
 export interface UserWithOwner extends Users {
@@ -386,7 +425,7 @@ class AuthenticationService {
       return {
         ok: false,
         reason: 'token_exchange_failed',
-        message: describeError(error),
+        message: describeTokenExchangeError(error),
       };
     }
 
@@ -525,12 +564,19 @@ class AuthenticationService {
     );
   }
 
-  async loginWithApple(code: string) {
+  async loginWithApple(code: string): Promise<AppleLoginResult> {
     const clientId = process.env.APPLE_CLIENT_ID;
     const APPLE_REDIRECT_URI = `${process.env.DOMAIN ?? 'https://2anki.net'}/auth/apple/callback`;
     if (!clientId) {
-      return undefined;
+      return {
+        ok: false,
+        reason: 'not_configured',
+        message: 'APPLE_CLIENT_ID is not set',
+      };
     }
+
+    let idToken: string;
+    let refreshToken: string | undefined;
     try {
       const clientSecret = this.mintAppleClientSecret();
       const values = {
@@ -547,24 +593,45 @@ class AuthenticationService {
       }>('apple_login', APPLE_TOKEN_URL, qs.stringify(values), {
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       });
-      const idToken = result.data.id_token;
-      const refreshToken =
+      idToken = result.data.id_token;
+      refreshToken =
         typeof result.data.refresh_token === 'string'
           ? result.data.refresh_token
           : undefined;
+    } catch (error) {
+      return {
+        ok: false,
+        reason: 'token_exchange_failed',
+        message: describeTokenExchangeError(error),
+      };
+    }
+
+    try {
       const decoded = jwt.decode(idToken, { complete: true });
       if (!decoded || typeof decoded === 'string') {
-        return undefined;
+        return {
+          ok: false,
+          reason: 'verify_failed',
+          message: 'id_token did not decode to a JWT object',
+        };
       }
       const kid = decoded.header.kid;
       const alg = decoded.header.alg;
       if (alg !== 'RS256' || typeof kid !== 'string') {
-        return undefined;
+        return {
+          ok: false,
+          reason: 'verify_failed',
+          message: `unexpected id_token header alg=${String(alg)}`,
+        };
       }
       const jwks = await getAppleJwks();
       const jwk = jwks.find((k) => k.kid === kid);
       if (!jwk) {
-        return undefined;
+        return {
+          ok: false,
+          reason: 'verify_failed',
+          message: 'no matching signing key in Apple JWKS',
+        };
       }
       const publicKey = crypto.createPublicKey({ key: jwk, format: 'jwk' });
       const payload = jwt.verify(idToken, publicKey, {
@@ -573,28 +640,46 @@ class AuthenticationService {
         issuer: APPLE_ISSUER,
       });
       if (typeof payload === 'string') {
-        return undefined;
+        return {
+          ok: false,
+          reason: 'verify_failed',
+          message: 'unexpected string payload',
+        };
       }
       const subject = typeof payload.sub === 'string' ? payload.sub : undefined;
       if (!subject) {
-        console.info("Couldn't login with Apple: missing sub claim");
-        return undefined;
+        return {
+          ok: false,
+          reason: 'missing_sub',
+          message: 'id_token payload has no sub claim',
+        };
       }
       const emailVerified =
         payload.email_verified === true || payload.email_verified === 'true';
       if (!emailVerified) {
-        console.info("Couldn't login with Apple: email not verified");
-        return undefined;
+        return {
+          ok: false,
+          reason: 'email_not_verified',
+          message: 'Apple reports the email as unverified',
+        };
       }
       const email =
         typeof payload.email === 'string' && payload.email.length > 0
           ? payload.email
           : undefined;
-      return { subject, email, emailVerified: true as const, refreshToken };
+      return {
+        ok: true,
+        subject,
+        email,
+        emailVerified: true as const,
+        refreshToken,
+      };
     } catch (error) {
-      console.info("Couldn't login with Apple");
-      console.error(error);
-      return undefined;
+      return {
+        ok: false,
+        reason: 'verify_failed',
+        message: describeError(error),
+      };
     }
   }
 


### PR DESCRIPTION
## What

Instrumentation groundwork for #3952 (~50 signups lost at the OAuth token exchange). The prod `user_visible_errors` rows are undiagnosable today: Google failures log only `AxiosError: Request failed with status code 400` (the provider's `error`/`error_description` body — the part that distinguishes `invalid_grant` from `redirect_uri_mismatch` from `invalid_client` — was discarded), and Apple failures have NULL context because `loginWithApple` returned bare `undefined` for every failure mode.

- New `describeTokenExchangeError` captures HTTP status + the provider error body (no secrets live in that body) for Google and Apple exchanges.
- `loginWithApple` now returns a typed `AppleLoginResult` mirroring the Google shape, naming the failure: `token_exchange_failed`, `verify_failed`, `missing_sub`, `email_not_verified`, `not_configured`.
- The controller records `reason`, `message`, and the user agent on exchange failures (in-app webviews are the leading suspect for the Apple `state_mismatch` cluster; state-mismatch context also records whether the cookie or the param was missing — never their values).

**No auth decision logic changed** — every accept/reject path is identical; only what gets recorded on failure changed. Microsoft left as-is (dormant since May; noted in #3952).

#3952 stays open: this PR makes the "name the cause per provider" step possible. Verdict comes after fresh failures accrue with real context.

No changelog entry — internal observability, nothing user-visible.

## Tests

- New: Google exchange failure captures provider error body (`invalid_grant` + description + status); Apple exchange failure returns typed `token_exchange_failed` with the provider error; each Apple verify failure names its reason.
- Full server suite in the worktree: 6262 passed; the 74 failures are all the documented environmental set (PythonExitError — no venv in worktrees; getPageCount pdfinfo). `tsc -p . --noEmit` clean, `pnpm format:check` clean tree-wide.
- Sonar: local scanner not run in the worktree; gating merge on the PR analysis reporting zero open findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
