### PR TITLE
fix: tell users their zip was incomplete instead of no cards found

### DIFF
--- a/src/lib/zip/fallback/excludeExtractionArtifacts.test.ts
+++ b/src/lib/zip/fallback/excludeExtractionArtifacts.test.ts
@@ -1,0 +1,42 @@
+import { excludeExtractionArtifacts } from './excludeExtractionArtifacts';
+
+describe('excludeExtractionArtifacts', () => {
+  const archiveCopy = '/tmp/workspaces/w/755758d5-617c-4bf1-a778-34cc0948f728';
+  const stdoutLog = '/tmp/workspaces/w/tar_stdout.log';
+  const stderrLog = '/tmp/workspaces/w/tar_stderr.log';
+
+  it('drops the uploaded archive copy and the tar logs, keeps extracted files', () => {
+    const files = [
+      { name: archiveCopy, contents: new Uint8Array([1]) },
+      { name: stdoutLog, contents: new Uint8Array([2]) },
+      { name: stderrLog, contents: new Uint8Array([3]) },
+      {
+        name: '/tmp/workspaces/w/Private & Shared/Page abc.html',
+        contents: new Uint8Array([4]),
+      },
+      {
+        name: '/tmp/workspaces/w/ExportBlock-abc-Part-1.zip',
+        contents: new Uint8Array([5]),
+      },
+    ];
+
+    const kept = excludeExtractionArtifacts(files, [
+      archiveCopy,
+      stdoutLog,
+      stderrLog,
+    ]);
+
+    expect(kept.map((f) => f.name)).toEqual([
+      '/tmp/workspaces/w/Private & Shared/Page abc.html',
+      '/tmp/workspaces/w/ExportBlock-abc-Part-1.zip',
+    ]);
+  });
+
+  it('keeps an extracted extensionless page that is not an artifact', () => {
+    const kept = excludeExtractionArtifacts(
+      [{ name: '/tmp/workspaces/w/Untitled Page', contents: new Uint8Array() }],
+      [archiveCopy, stdoutLog, stderrLog]
+    );
+    expect(kept).toHaveLength(1);
+  });
+});

--- a/src/lib/zip/fallback/excludeExtractionArtifacts.ts
+++ b/src/lib/zip/fallback/excludeExtractionArtifacts.ts
@@ -1,0 +1,14 @@
+import { File } from './types';
+
+// listFiles sweeps the whole extraction workspace, which also holds the
+// uploaded archive's own temp copy (extensionless, so it passes
+// isZipContentFileSupported's no-extension rule and reaches conversion as
+// garbage — the prod #4028 signature) and bsdtar's log files. Only what the
+// archive actually contained may flow onward.
+export function excludeExtractionArtifacts(
+  files: File[],
+  artifactPaths: string[]
+): File[] {
+  const artifacts = new Set(artifactPaths);
+  return files.filter((file) => !artifacts.has(file.name));
+}

--- a/src/lib/zip/fallback/unpack.ts
+++ b/src/lib/zip/fallback/unpack.ts
@@ -2,6 +2,7 @@ import { spawn } from 'node:child_process';
 import { createWriteStream } from 'node:fs';
 import { join } from 'node:path';
 
+import { excludeExtractionArtifacts } from './excludeExtractionArtifacts';
 import { listFiles } from './listFiles';
 import { File } from './types';
 
@@ -24,7 +25,17 @@ export function unpack(filePath: string, workspace: string): Promise<File[]> {
 
     decompressProcess.on('close', () => {
       // We are not reading the status code because we support partial extraction
-      listFiles(workspace).then(resolve).catch(reject);
+      listFiles(workspace)
+        .then((files) =>
+          resolve(
+            excludeExtractionArtifacts(files, [
+              filePath,
+              stdoutLogPath,
+              stderrLogPath,
+            ])
+          )
+        )
+        .catch(reject);
     });
   });
 }

--- a/src/lib/zip/zip.test.tsx
+++ b/src/lib/zip/zip.test.tsx
@@ -5,12 +5,20 @@ import { strToU8, zipSync } from 'fflate';
 
 import {
   ZipHandler,
+  INCOMPLETE_ZIP_MESSAGE,
   MAX_IN_MEMORY_BYTES,
   MAX_EXTRACTED_BYTES,
   MAX_BATCH_EXTRACT_BYTES,
 } from './zip';
 import { MAX_OLD_GENERATION_SIZE_MB } from '../conversionMemoryLimits';
 import CardOption from '../parser/Settings';
+import { processAndPrepareArchiveData } from './fallback/processAndPrepareArchiveData';
+
+jest.mock('./fallback/processAndPrepareArchiveData');
+
+const mockedFallback = processAndPrepareArchiveData as jest.MockedFunction<
+  typeof processAndPrepareArchiveData
+>;
 
 function makeSpillDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'ziphandler-spill-'));
@@ -295,5 +303,93 @@ describe('ZipHandler disk spill', () => {
     const entry = handler.files.find((f) => f.name === 'page.html');
     expect(entry?.contents).toBe('<p>real deck</p>');
     expect(fs.existsSync(path.join(spill, 'page.html'))).toBe(false);
+  });
+});
+
+describe('ZipHandler incomplete archives (#4028)', () => {
+  // A file grabbed mid-download or mid-sync ends before its central
+  // directory, so fflate throws code 13 and the bsdtar fallback runs.
+  function truncated(zip: Uint8Array): Uint8Array {
+    return zip.slice(0, zip.length - 30);
+  }
+
+  beforeEach(() => {
+    mockedFallback.mockReset();
+  });
+
+  it('tells the user the zip is incomplete when nothing can be recovered', async () => {
+    mockedFallback.mockResolvedValue([]);
+    const handler = new ZipHandler(10);
+
+    await expect(
+      handler.build(
+        truncated(buildZip({ 'page.html': '<p>hi</p>' })),
+        false,
+        new CardOption({}),
+        makeSpillDir()
+      )
+    ).rejects.toThrow(INCOMPLETE_ZIP_MESSAGE);
+  });
+
+  it('still reports incomplete when the fallback recovers a nested zip that is also truncated', async () => {
+    mockedFallback.mockResolvedValueOnce([
+      {
+        name: '/tmp/workspaces/x/ExportBlock-abc-Part-1.zip',
+        contents: truncated(buildZip({ 'Inner Page.html': '<p>lost</p>' })),
+      },
+    ]);
+    // The recovered nested zip fails its own unzip and re-enters the
+    // fallback, which recovers nothing further from the stump.
+    mockedFallback.mockResolvedValueOnce([]);
+    const handler = new ZipHandler(10);
+
+    await expect(
+      handler.build(
+        truncated(buildZip({ 'page.html': '<p>hi</p>' })),
+        false,
+        new CardOption({}),
+        makeSpillDir()
+      )
+    ).rejects.toThrow(INCOMPLETE_ZIP_MESSAGE);
+  });
+
+  it('recurses into a complete nested zip the fallback recovered', async () => {
+    const inner = buildZip({ 'Recovered Page.html': '<p>saved</p>' });
+    mockedFallback.mockResolvedValue([
+      { name: '/tmp/workspaces/x/ExportBlock-abc-Part-1.zip', contents: inner },
+    ]);
+    const handler = new ZipHandler(10);
+
+    await handler.build(
+      truncated(buildZip({ 'page.html': '<p>hi</p>' })),
+      false,
+      new CardOption({}),
+      makeSpillDir()
+    );
+
+    expect(handler.getFileNames()).toContain('Recovered Page.html');
+  });
+
+  it('keeps directly recovered supported files without throwing', async () => {
+    mockedFallback.mockResolvedValue([
+      {
+        name: '/tmp/workspaces/x/Private & Shared/Page abc.html',
+        contents: strToU8('<p>recovered</p>'),
+      },
+    ]);
+    const handler = new ZipHandler(10);
+
+    await handler.build(
+      truncated(buildZip({ 'page.html': '<p>hi</p>' })),
+      false,
+      new CardOption({}),
+      makeSpillDir()
+    );
+
+    expect(handler.getFileNames()).toEqual(
+      expect.arrayContaining([
+        '/tmp/workspaces/x/Private & Shared/Page abc.html',
+      ])
+    );
   });
 });

--- a/src/lib/zip/zip.tsx
+++ b/src/lib/zip/zip.tsx
@@ -12,6 +12,7 @@ import {
 } from '../storage/checks';
 import { processAndPrepareArchiveData } from './fallback/processAndPrepareArchiveData';
 import { isSafeZipEntryName } from './isSafeZipEntryName';
+import { isZipContentFileSupported } from '../../usecases/uploads/isZipContentFileSupported';
 import CardOption from '../parser/Settings';
 import { getRandomUUID } from '../../shared/helpers/getRandomUUID';
 import { convertImageToHTML } from '../../infrastracture/adapters/fileConversion/convertImageToHTML';
@@ -59,6 +60,25 @@ const MAX_BATCH_EXTRACT_BYTES = 128 * 1024 * 1024;
 
 function formatGigabytes(bytes: number): string {
   return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}
+
+// Real prod failures (#4028) were zips that end mid-entry with no central
+// directory — files grabbed while the export was still downloading or a cloud
+// folder was still syncing. fflate needs the end-of-central-directory record,
+// so these throw code 13 and land in the bsdtar fallback; when even that
+// recovers nothing usable, the honest answer is "incomplete", not "no cards".
+const INCOMPLETE_ZIP_MESSAGE =
+  'This zip file is incomplete — it ends before its file index, which usually means it was still downloading or syncing when it was uploaded. Wait for the download to finish, then upload it again.';
+
+// The name is what survives the upload worker's thread boundary (errors cross
+// it as { message, name }), so jobFailureReason matches on it, not the class.
+class IncompleteZipError extends Error {
+  code = 'ZIP_INVALID';
+
+  constructor() {
+    super(INCOMPLETE_ZIP_MESSAGE);
+    this.name = 'IncompleteZipError';
+  }
 }
 
 // Back a spilled entry with a lazy disk read so every consumer that reads
@@ -264,7 +284,7 @@ class ZipHandler {
 
       this.addCombinedHTMLToFiles(paying, settings);
     } catch (error: unknown) {
-      await this.handleZipError(error, zipData, paying);
+      await this.handleZipError(error, zipData, paying, settings);
     }
   }
 
@@ -332,16 +352,42 @@ ${this.combinedHTML}
   private async handleZipError(
     error: unknown,
     zipData: Uint8Array,
-    paying: boolean
+    paying: boolean,
+    settings: CardOption
   ) {
     const isArchiveProcessingError = (error as { code?: number }).code === 13;
-
-    if (isArchiveProcessingError) {
-      const foundFiles = await processAndPrepareArchiveData(zipData, paying);
-      this.files.push(...foundFiles);
-      console.log('Processed files using fallback method:');
-    } else {
+    if (!isArchiveProcessingError) {
       throw error;
+    }
+
+    const foundFiles = await processAndPrepareArchiveData(zipData, paying);
+    console.log('Processed files using fallback method:');
+    for (const file of foundFiles) {
+      if (
+        /\.zip$/i.test(file.name) &&
+        file.contents instanceof Uint8Array &&
+        this.zipFileCount < this.maxZipFiles
+      ) {
+        // bsdtar reads sequentially and often recovers a nested export part
+        // intact even when the outer archive is truncated. Recurse so its
+        // pages convert; a nested part that is itself truncated fails its own
+        // fallback below and is skipped rather than aborting the recovery.
+        this.zipFileCount++;
+        try {
+          await this.processZip(file.contents, paying, settings);
+        } catch {
+          console.warn('Recovered nested zip was itself unreadable, skipping');
+        }
+        continue;
+      }
+      this.files.push(file);
+    }
+
+    const anySupported = this.files.some((f) =>
+      isZipContentFileSupported(f.name)
+    );
+    if (!anySupported) {
+      throw new IncompleteZipError();
     }
   }
 
@@ -353,6 +399,8 @@ ${this.combinedHTML}
 export {
   ZipHandler,
   File,
+  IncompleteZipError,
+  INCOMPLETE_ZIP_MESSAGE,
   MAX_IN_MEMORY_BYTES,
   MAX_EXTRACTED_BYTES,
   MAX_BATCH_EXTRACT_BYTES,

--- a/src/usecases/jobs/jobFailureReason.test.ts
+++ b/src/usecases/jobs/jobFailureReason.test.ts
@@ -236,12 +236,21 @@ describe('jobFailureReasonFromError', () => {
     expect(reason).toContain('upload limit');
   });
 
-  it('classifies ZIP_INVALID code as zip error message', () => {
-    const err = new Error('bad zip') as Error & { code?: string };
+  it('passes an IncompleteZipError message through to the user', () => {
+    const err = new Error(
+      'This zip file is incomplete — it ends before its file index, which usually means it was still downloading or syncing when it was uploaded. Wait for the download to finish, then upload it again.'
+    ) as Error & { code?: string };
     err.code = 'ZIP_INVALID';
     const reason = jobFailureReasonFromError(err, 'job-zi');
-    expect(reason).toContain("Couldn't read this zip");
-    expect(reason).toContain('Markdown & CSV export');
+    expect(reason).toContain('incomplete');
+    expect(reason).toContain('upload it again');
+  });
+
+  it('matches an IncompleteZipError by name after the worker boundary strips the code', () => {
+    const err = new Error('This zip file is incomplete — truncated upload.');
+    err.name = 'IncompleteZipError';
+    const reason = jobFailureReasonFromError(err, 'job-zi2');
+    expect(reason).toBe('This zip file is incomplete — truncated upload.');
   });
 
   it('classifies pdfinfo_password error prefix as password-protected message', () => {

--- a/src/usecases/jobs/jobFailureReason.ts
+++ b/src/usecases/jobs/jobFailureReason.ts
@@ -131,7 +131,7 @@ export function jobFailureReasonCode(error: unknown): JobFailureReasonCode {
   if (hasCode(error, 'APKG_TOO_LARGE')) {
     return 'apkg_too_large';
   }
-  if (hasCode(error, 'ZIP_INVALID')) {
+  if (hasCode(error, 'ZIP_INVALID') || hasName(error, 'IncompleteZipError')) {
     return 'zip_invalid';
   }
   if (error instanceof Error && error.message.startsWith('pdfinfo_password')) {
@@ -202,8 +202,8 @@ export function jobFailureReasonFromError(
   if (hasCode(error, 'APKG_TOO_LARGE')) {
     return "This deck is over Anki's 100 MB upload limit. Split it by toggling fewer pages, or upload directly to Anki desktop.";
   }
-  if (hasCode(error, 'ZIP_INVALID')) {
-    return "Couldn't read this zip. Make sure it's the Markdown & CSV export from Notion, not the HTML export.";
+  if (hasCode(error, 'ZIP_INVALID') || hasName(error, 'IncompleteZipError')) {
+    return (error as Error).message;
   }
   if (error instanceof Error && error.message.startsWith('pdfinfo_password')) {
     return 'This PDF is password-protected. Remove the password and try again.';

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-09-incomplete-zip-error.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-09-incomplete-zip-error.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-09-incomplete-zip-error",
+  "date": "2026-08-09",
+  "type": "fix",
+  "title": "Half-downloaded zip uploads now say they're incomplete instead of \"No cards found\""
+}


### PR DESCRIPTION
## What

Root-causes #4028 and replaces the misleading outcome. The workspace-export zips that "convert to zero cards" are **truncated uploads**: prod fallback workspaces from today (11:26–11:30) hold archives that end mid-DEFLATE with no end-of-central-directory record — the file was grabbed while still downloading or syncing. The regression suspect #3956 is exonerated: a realistic multi-part export replica (3 nested parts, 42 pages, images, `Private & Shared/` tree) converts 42/42 through the current pipeline.

The failure chain was: fflate throws code 13 (no EOCD) → bsdtar fallback runs → `listFiles` sweeps the whole extraction workspace and returns **its own artifacts** — the extensionless uploaded-archive copy passes `isZipContentFileSupported`'s no-extension rule and flows into conversion as binary garbage → zero packages → "No cards found". Exactly what prod logs show (`count: 1`, the raw archive path in PrepareDeck; census `unreadable: true`).

## How

- `excludeExtractionArtifacts`: the fallback no longer returns the uploaded archive copy or the tar logs — only what the archive actually contained.
- `handleZipError` recurses into recovered nested `ExportBlock-…-Part-N.zip` files (bsdtar often salvages them intact when only the outer tail is missing), bounded by the existing nesting cap; a nested part that is itself truncated is skipped, not fatal.
- When nothing usable is recovered, `IncompleteZipError` (code `ZIP_INVALID`, name matched across the worker thread boundary) tells the user the truth: "This zip file is incomplete — it ends before its file index… Wait for the download to finish, then upload it again."
- The previously **dead** `ZIP_INVALID` allowlist entry (nothing ever threw it, and its copy gave wrong guidance) now carries the real message.

## Tests

- New: truncated zip with nothing recoverable → incomplete-zip error, not "no cards"; truncated outer + intact nested part → nested pages convert; truncated outer + truncated nested → incomplete-zip error; artifact exclusion keeps real extensionless pages.
- Full server suite: 6341 passed / 2 failed — both the documented environmental `getPageCount` pdfinfo failures. `tsc -p . --noEmit` clean, `pnpm format:check` clean tree-wide.
- Sonar: gating merge on the PR analysis reporting zero open findings.

## Browser check

Not applicable — the only web/src change is a changelog JSON entry.

## Follow-up left in #4028

Why truncated files reach the server *complete-looking* (client picks a half-downloaded file vs a transfer drop) can't be distinguished server-side; the honest error covers both. The issue gets a comment with the evidence and stays open only if Alexander wants the client-side half (pre-upload EOCD check in the browser is possible and cheap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
