### PR TITLE
fix: rescue Notion pages that ship one giant card as success

### DIFF
--- a/src/services/NotionService/BlockHandler/BlockHandler.degenerateRescue.test.ts
+++ b/src/services/NotionService/BlockHandler/BlockHandler.degenerateRescue.test.ts
@@ -1,0 +1,256 @@
+import BlockHandler from './BlockHandler';
+import CardOption from '../../../lib/parser/Settings/CardOption';
+import CustomExporter from '../../../lib/parser/exporters/CustomExporter';
+import ParserRules from '../../../lib/parser/ParserRules';
+import Workspace from '../../../lib/parser/WorkSpace';
+import NotionAPIWrapper from '../NotionAPIWrapper';
+import { setupTests } from '../../../test/configure-jest';
+
+beforeEach(() => setupTests());
+
+function richText(content: string) {
+  return {
+    type: 'text' as const,
+    text: { content, link: null },
+    annotations: {
+      bold: false,
+      italic: false,
+      strikethrough: false,
+      underline: false,
+      code: false,
+      color: 'default' as const,
+    },
+    plain_text: content,
+    href: null,
+  };
+}
+
+function block(type: string, content: string, hasChildren = false) {
+  return {
+    object: 'block',
+    id: `${type}-${content.slice(0, 16)}`,
+    parent: { type: 'page_id', page_id: 'page-1' },
+    created_time: '',
+    last_edited_time: '',
+    created_by: { object: 'user', id: 'u' },
+    last_edited_by: { object: 'user', id: 'u' },
+    has_children: hasChildren,
+    archived: false,
+    in_trash: false,
+    type,
+    [type]: { rich_text: [richText(content)], color: 'default' },
+  };
+}
+
+function todo(content: string, checked: boolean) {
+  return {
+    object: 'block',
+    id: `to_do-${content.slice(0, 16)}`,
+    parent: { type: 'page_id', page_id: 'page-1' },
+    created_time: '',
+    last_edited_time: '',
+    created_by: { object: 'user', id: 'u' },
+    last_edited_by: { object: 'user', id: 'u' },
+    has_children: false,
+    archived: false,
+    in_trash: false,
+    type: 'to_do',
+    to_do: { rich_text: [richText(content)], color: 'default', checked },
+  };
+}
+
+function blockList(results: unknown[]) {
+  return {
+    object: 'list',
+    results,
+    next_cursor: null,
+    has_more: false,
+    type: 'block',
+    block: {},
+  };
+}
+
+function makeApi(childrenById: Record<string, unknown[]>): NotionAPIWrapper {
+  return {
+    getPage: jest.fn().mockResolvedValue({
+      id: 'page-1',
+      object: 'page',
+      created_time: '',
+      last_edited_time: '',
+    }),
+    getPageTitle: jest.fn().mockResolvedValue('Study Notes'),
+    getTopLevelTags: jest.fn().mockResolvedValue([]),
+    getBlocks: jest
+      .fn()
+      .mockImplementation(({ id }: { id: string }) =>
+        Promise.resolve(blockList(childrenById[id] ?? []))
+      ),
+  } as unknown as NotionAPIWrapper;
+}
+
+function makeHandler(api: NotionAPIWrapper, settings = new CardOption({})) {
+  return new BlockHandler(
+    new CustomExporter('', new Workspace(true, 'fs').location),
+    api,
+    settings
+  );
+}
+
+const oversizedBack =
+  'Photosynthesis converts light energy into chemical energy stored in glucose. '.repeat(
+    20
+  );
+
+function headingPairs() {
+  return [
+    block('heading_2', 'What is the cell membrane?'),
+    block(
+      'paragraph',
+      'A lipid bilayer that separates the cell interior from its surroundings.'
+    ),
+    block('heading_2', 'What is the nucleus?'),
+    block('paragraph', 'The organelle that houses the genetic material.'),
+    block('heading_2', 'What are mitochondria?'),
+    block('paragraph', 'Organelles that generate most of the chemical energy.'),
+    block('heading_2', 'What is the cytoplasm?'),
+    block('paragraph', 'The gel-like fluid that fills the interior of a cell.'),
+  ];
+}
+
+describe('degenerate-yield rescue on the page branch', () => {
+  it('splits a single oversized toggle card into the page headings', async () => {
+    const toggle = block('toggle', 'Cell biology overview', true);
+    const api = makeApi({
+      'page-1': [toggle, ...headingPairs()],
+      [toggle.id]: [block('paragraph', oversizedBack)],
+    });
+    const handler = makeHandler(api);
+
+    const decks = await handler.findFlashcards({
+      parentType: 'page',
+      topLevelId: 'page-1',
+      rules: new ParserRules(),
+      decks: [],
+      parentName: '',
+    });
+
+    expect(decks).toHaveLength(1);
+    const cards = decks[0].cards;
+    expect(cards.length).toBeGreaterThanOrEqual(3);
+    expect(cards[0].name).toContain('cell membrane');
+    expect(cards[0].back).toContain('lipid bilayer');
+    expect(handler.inducedRule).toMatchObject({
+      rule: 'heading',
+      outcome: 'rescue_shipped',
+    });
+  });
+
+  it('counts the rescued cards rather than the discarded oversized card', async () => {
+    const toggle = block('toggle', 'Cell biology overview', true);
+    const api = makeApi({
+      'page-1': [toggle, ...headingPairs()],
+      [toggle.id]: [block('paragraph', oversizedBack)],
+    });
+    const handler = makeHandler(api);
+
+    await handler.findFlashcards({
+      parentType: 'page',
+      topLevelId: 'page-1',
+      rules: new ParserRules(),
+      decks: [],
+      parentName: '',
+    });
+
+    expect(handler.cardCount).toBe(4);
+    expect(handler.emptyBackCount).toBe(0);
+  });
+
+  it('leaves a legitimate small deck of short cards untouched', async () => {
+    const first = block('toggle', 'What is spaced repetition?', true);
+    const second = block('toggle', 'What is active recall?', true);
+    const api = makeApi({
+      'page-1': [first, second, ...headingPairs()],
+      [first.id]: [
+        block('paragraph', 'Reviews spaced further apart over time.'),
+      ],
+      [second.id]: [
+        block(
+          'paragraph',
+          'Retrieving a fact from memory rather than rereading.'
+        ),
+      ],
+    });
+    const handler = makeHandler(api);
+
+    const decks = await handler.findFlashcards({
+      parentType: 'page',
+      topLevelId: 'page-1',
+      rules: new ParserRules(),
+      decks: [],
+      parentName: '',
+    });
+
+    expect(decks[0].cards).toHaveLength(2);
+    expect(handler.inducedRule).toBeUndefined();
+  });
+
+  it('keeps the oversized card and records rescue_rejected below the floor', async () => {
+    const toggle = block('toggle', 'Cell biology overview', true);
+    const api = makeApi({
+      'page-1': [
+        toggle,
+        block('heading_2', 'What is the cell membrane?'),
+        block(
+          'paragraph',
+          'A lipid bilayer that separates the cell interior from its surroundings.'
+        ),
+      ],
+      [toggle.id]: [block('paragraph', oversizedBack)],
+    });
+    const handler = makeHandler(api);
+
+    const decks = await handler.findFlashcards({
+      parentType: 'page',
+      topLevelId: 'page-1',
+      rules: new ParserRules(),
+      decks: [],
+      parentName: '',
+    });
+
+    expect(decks[0].cards).toHaveLength(1);
+    expect(decks[0].cards[0].back).toContain('Photosynthesis');
+    expect(handler.inducedRule).toMatchObject({
+      outcome: 'rescue_rejected',
+    });
+  });
+
+  it('never shreds an oversized MCQ card into structural cards', async () => {
+    const question = `Which organelle is the site of aerobic respiration? ${'Consider the role each structure plays in energy metabolism before answering. '.repeat(
+      14
+    )}`;
+    const toggle = block('toggle', question, true);
+    const api = makeApi({
+      'page-1': [toggle, ...headingPairs()],
+      [toggle.id]: [
+        todo('The nucleus', false),
+        todo('The mitochondria', true),
+        todo('The ribosome', false),
+        todo('The lysosome', false),
+      ],
+    });
+    const handler = makeHandler(api, new CardOption({ 'mcq-enabled': 'true' }));
+
+    const decks = await handler.findFlashcards({
+      parentType: 'page',
+      topLevelId: 'page-1',
+      rules: new ParserRules(),
+      decks: [],
+      parentName: '',
+    });
+
+    const cards = decks.flatMap((deck) => deck.cards);
+    expect(cards).toHaveLength(1);
+    expect(cards[0].isValidMCQNote()).toBe(true);
+    expect(handler.inducedRule).toBeUndefined();
+  });
+});

--- a/src/services/NotionService/BlockHandler/BlockHandler.ts
+++ b/src/services/NotionService/BlockHandler/BlockHandler.ts
@@ -52,6 +52,7 @@ import {
   mergeInducedRescue,
 } from '../../../lib/parser/induction/candidateRules';
 import { runInduction } from '../../../lib/parser/induction/rankCandidates';
+import { scoreCandidateDeck } from '../../../lib/parser/scoreCandidateDeck';
 import {
   ConversionTruncation,
   hasRuleBasedSubDecks,
@@ -1111,7 +1112,7 @@ class BlockHandler {
   // added.
   private rescueEmptyCards(cards: Note[], blocks: GetBlockResponse[]): Note[] {
     if (Deck.hasUsableCards(cards)) {
-      return cards;
+      return this.rescueDegenerateYield(cards, blocks);
     }
     const rescued = this.induceRescueDeck(blocks);
     if (rescued == null) {
@@ -1120,6 +1121,69 @@ class BlockHandler {
     this.discountCards(cards);
     this.accountForRescuedCards(rescued);
     return rescued;
+  }
+
+  // The silent twin of the empty deck: a walk that produces one or two cards
+  // whose backs hold the whole page ships as "success" while the substance never
+  // becomes reviewable cards. Runs the same block-level candidate loop as the
+  // empty rescue, but the winner must beat the score of the giant card it
+  // replaces, not just clear the floor. Losing records rescue_rejected and keeps
+  // the original cards; winning replaces them and records rescue_shipped, so the
+  // Downloads notice fires on both delivery transports.
+  //
+  // The mean-chars trigger sits at 1000 from a prod Notion-path sweep: the
+  // degenerate cluster (pages that shipped <=2 cards from a large body) had a
+  // mean of ~1509 chars/card, while legitimate small decks sat at <=622 and a
+  // healthy deck runs ~230. Image-only backs strip to ~0 visible chars and so
+  // self-exclude. MCQ and input cards are user-authored quiz structure and are
+  // never re-induced.
+  private rescueDegenerateYield(
+    cards: Note[],
+    blocks: GetBlockResponse[]
+  ): Note[] {
+    const DEGENERATE_MIN_MEAN_CARD_CHARS = 1000;
+    const cleaned = Deck.CleanCards([...cards]);
+    if (cleaned.length < 1 || cleaned.length > 2) {
+      return cards;
+    }
+    if (
+      cleaned.every((card) => card.isValidMCQNote() || card.isValidInputNote())
+    ) {
+      return cards;
+    }
+    const docChars = blocksPlainTextLength(blocks);
+    const existingScore = scoreCandidateDeck(cleaned, docChars);
+    if (
+      existingScore.cardChars / cleaned.length <
+      DEGENERATE_MIN_MEAN_CARD_CHARS
+    ) {
+      return cards;
+    }
+    const { winner, best } = runInduction(
+      this.rescueCandidateRules(),
+      (rule) =>
+        induceNotesFromBlocks(blocks, rule, this.settings, new TagRegistry()),
+      docChars
+    );
+    if (winner == null || winner.score.score <= existingScore.score) {
+      const judged = winner ?? best;
+      if (judged != null) {
+        this.recordInducedRule({
+          rule: judged.rule,
+          outcome: 'rescue_rejected',
+          score: judged.score,
+        });
+      }
+      return cards;
+    }
+    this.recordInducedRule({
+      rule: winner.rule,
+      outcome: 'rescue_shipped',
+      score: winner.score,
+    });
+    this.discountCards(cards);
+    this.accountForRescuedCards(winner.cards);
+    return winner.cards;
   }
 
   private async buildDeckFromBlockChildren(

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-09-notion-giant-card-split.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-09-notion-giant-card-split.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-09-notion-giant-card-split",
+  "date": "2026-08-09",
+  "type": "fix",
+  "title": "Notion pages that came back as one giant card now split into real flashcards"
+}


### PR DESCRIPTION
## What
Adds a degenerate-yield rescue to the Notion conversion path: when a page's block walk produces one or two usable cards whose backs hold the whole page, the deck is re-induced from the page's own structure (headings, lists, quotes, Q:/A:) instead of shipping one oversized card as a "success."

## Why
Closes #4009. The upload path already rescues this shape (`DeckParser.induceRicherDeck`, #3955), but `BlockHandler.rescueEmptyCards` gated solely on `Deck.hasUsableCards(cards)` — one giant card counts as usable, so the conversion recorded `shipped`, never entered induction, and the user got a single oversized card with no signal anything went wrong. It fails silently, so it doesn't even generate a support signal.

The upload path's `docChars >= 20_000` trigger can't be ported: the Notion census (`blocksPlainTextLength`) reads only each block's own `rich_text`, under-counting by ~an order of magnitude on exactly the pages this catches. So the trigger here is a per-card density gate instead — mean visible chars/card. Calibration gap from a prod Notion-path sweep: the degenerate cluster ran a median back of 1556–7936 chars with 13–43 char fronts (mean chars/card ~1509), while legitimate small decks sat at backs <= 311 chars; a healthy deck runs ~230 chars/card. A threshold of 1000 sits cleanly in the 311-vs-1556 gap.

## How
`rescueEmptyCards` now calls a new private `rescueDegenerateYield(cards, blocks)` when `hasUsableCards` is true (the empty rescue still runs when false — mutually exclusive). `rescueDegenerateYield`:
1. `Deck.CleanCards` → guard on 1–2 cleaned cards.
2. Skip if every cleaned card is `isValidMCQNote() || isValidInputNote()` (user-authored quiz structure).
3. `existingScore = scoreCandidateDeck(cleaned, docChars)`; skip unless `cardChars / cleaned.length >= 1000` (`DEGENERATE_MIN_MEAN_CARD_CHARS`).
4. Runs the same `runInduction` loop as the empty rescue over the blocks already in memory — zero extra Notion requests. `rescueCandidateRules()` returns `[]` for cloze/cherry, so those modes no-op.
5. Accept the winner only if it clears the >=3-card floor AND strictly beats `existingScore.score`. On accept: `rescue_shipped` + `discountCards`/`accountForRescuedCards` bookkeeping (mirrors the empty rescue). On reject: `rescue_rejected` recording the judged candidate's score.

No new outcome values, no env flags, no new notices — reuses the existing `rescue_shipped`/`rescue_rejected` vocabulary that already rides `CompleteJobUseCase` into the Downloads structure-rescue notice.

## Measuring success
`conversion_rule_scores` rows: a shipped degenerate rescue records `outcome='rescue_shipped'` with `was_fallback` semantics on the Notion (`engine='parser'`) path. Watch the degenerate-ship rate fall for rescuable pages (metric line below).

## Testing
New suite `BlockHandler.degenerateRescue.test.ts` (5 tests, all green), outside-in through `findFlashcards` with the Notion API mocked at the SDK boundary only:
- oversized single toggle card + >=3 heading siblings → rescue ships, `rescue_shipped`, deck has >=3 cards, rescued cards counted.
- legitimate small deck (2 short cards) → untouched, no induced rule.
- oversized card but induction below the floor (1 heading pair) → original kept, `rescue_rejected`.
- oversized MCQ card → never shredded, no induced rule.

Full server suite: **6266 passed, 74 failed** — every one of the 74 failures is the documented worktree-environmental class (Python `.apkg` bridge `PythonExitError` across `DeckParser*`/canary/golden suites, and `getPageCount` pdfinfo), confirmed by grepping the run for any non-environmental assertion diff (none). The `BlockHandler.*` + `induction` + `scoreCandidateDeck` + `performConversion` suites I touched all pass. `pnpm format:check` (tree-wide, CI's exact command) and `npx tsc -p . --noEmit` both clean.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px

Notes: server-side conversion logic; the only web change is a changelog JSON. The user-visible effect (a Notion page that used to return one giant card now returns real cards) needs a live Notion page to observe and can't be exercised from a static preview — left for the maintainer's own conversion check.

## Decisions made overnight (please review)
- **Threshold 1000 (`DEGENERATE_MIN_MEAN_CARD_CHARS`)** — trio-decided; sits in the 311-vs-1556 calibration gap. Image-only backs strip to ~0 visible chars and self-exclude below it.
- **Strict-improvement acceptance** — trio-decided; the winner must beat the giant card's score, not merely clear the floor (mirrors the upload path's higher bar), else `rescue_rejected` and the original cards are kept.
- **Notice copy — NOT done, existing notice copy left as is.** The existing Downloads structure-rescue notice (`downloadsx:structureRescued.text`, "Cards built from the {{structure}} on this page, which had no toggles.") fires automatically off `rescue_shipped`. Its "which had no toggles" clause is empty-rescue-specific and now slightly inaccurate for the split-a-toggle case, but generalizing it touches all 10 locales and was deliberately deferred out of this PR's scope. Flagging for a follow-up if worth it.
- **Not built:** no nested-toggle descent (rescue runs only over blocks already in memory — zero extra Notion requests), no dedicated `rescue_rejected` user notice, no env flags, no new outcome vocabulary.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-08-09-notion-giant-card-split.json` — "Notion pages that came back as one giant card now split into real flashcards" (type `fix`, user voice).

## Risks
Bounded: the rescue only runs on 1–2-card conversions with mean back >= 1000 chars, never on a deck that already produces a healthy set of cards, and only replaces the cards when a strictly better, floor-clearing deck exists. Cloze/cherry modes no-op. Rollback is a straight revert.

## Goal alignment
Mission-direct: "drop something in, get a clean deck back." A Notion page that silently returns one unusable card is the failure this repairs, on the higher-volume conversion path. Metric: Degenerate-ship rate — shipped Notion conversions with card_count<=2 and mean chars/card>=1000 — should fall toward ~0 for rescuable pages; read in conversion_rule_scores; day-7 check 2026-08-13, verdict 2026-09-05.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
