### PR TITLE
fix: default the App Store id so IAP redeem survives env drift

### DIFF
--- a/src/env.example
+++ b/src/env.example
@@ -65,7 +65,9 @@ APPLE_NATIVE_CLIENT_ID=''
 APPLE_IAP_BUNDLE_ID=''
 # Directory holding Apple's root CA certificates (.cer/.der/.pem) for the offline x5c chain check.
 APPLE_IAP_ROOT_CERTS_DIR=''
-# Optional numeric App Apple ID; recommended for production-environment verification.
+# Numeric App Apple ID override. Unset = the checked-in default (6775249373,
+# DEFAULT_APP_STORE_APPLE_ID) is used; Apple requires this for Production
+# verification, so redeem works with no env var at all.
 APPLE_IAP_APP_APPLE_ID=''
 # IAP receipts are always verified against both Production and Sandbox — no env knob.
 # Each JWS only validates against its matching environment; real buyers hit Production,

--- a/src/services/AppleStoreKitService/createAppleStoreKitService.test.ts
+++ b/src/services/AppleStoreKitService/createAppleStoreKitService.test.ts
@@ -9,6 +9,7 @@ import {
   createAppleStoreKitService,
   VERIFIED_ENVIRONMENTS,
 } from './createAppleStoreKitService';
+import { DEFAULT_APP_STORE_APPLE_ID } from '../AppStoreLinksService/AppStoreLinksService';
 
 jest.mock('@apple/app-store-server-library', () => {
   const actual = jest.requireActual('@apple/app-store-server-library');
@@ -64,6 +65,37 @@ describe('createAppleStoreKitService', () => {
     expect(VERIFIED_ENVIRONMENTS).toEqual([
       Environment.PRODUCTION,
       Environment.SANDBOX,
+    ]);
+  });
+
+  it('passes the env app Apple ID to every verifier when set', () => {
+    createAppleStoreKitService();
+
+    const appIds = MockedVerifier.mock.calls.map((call) => call[4]);
+    expect(appIds).toEqual([1234567890, 1234567890]);
+  });
+
+  it('falls back to the App Store default id when the env var is unset', () => {
+    delete process.env.APPLE_IAP_APP_APPLE_ID;
+
+    createAppleStoreKitService();
+
+    const appIds = MockedVerifier.mock.calls.map((call) => call[4]);
+    expect(appIds).toEqual([
+      Number(DEFAULT_APP_STORE_APPLE_ID),
+      Number(DEFAULT_APP_STORE_APPLE_ID),
+    ]);
+  });
+
+  it('falls back to the App Store default id when the env var is empty', () => {
+    process.env.APPLE_IAP_APP_APPLE_ID = '';
+
+    createAppleStoreKitService();
+
+    const appIds = MockedVerifier.mock.calls.map((call) => call[4]);
+    expect(appIds).toEqual([
+      Number(DEFAULT_APP_STORE_APPLE_ID),
+      Number(DEFAULT_APP_STORE_APPLE_ID),
     ]);
   });
 });

--- a/src/services/AppleStoreKitService/createAppleStoreKitService.ts
+++ b/src/services/AppleStoreKitService/createAppleStoreKitService.ts
@@ -11,6 +11,7 @@ import {
   AppleStoreKitService,
   type IAppleStoreKitService,
 } from './AppleStoreKitService';
+import { DEFAULT_APP_STORE_APPLE_ID } from '../AppStoreLinksService/AppStoreLinksService';
 
 function loadRootCertificates(dir: string): Buffer[] {
   return fs
@@ -58,11 +59,15 @@ export function createAppleStoreKitService(): IAppleStoreKitService {
     );
   }
 
-  const appAppleIdRaw = process.env.APPLE_IAP_APP_APPLE_ID;
-  const appAppleId =
-    appAppleIdRaw != null && appAppleIdRaw !== ''
-      ? Number.parseInt(appAppleIdRaw, 10)
-      : undefined;
+  // Apple's Production verifier hard-requires the numeric app Apple ID; an
+  // unset env var made every real-money redeem throw at construction while
+  // Sandbox (TestFlight, App Review) kept passing (#4040). The ID is public —
+  // it appears in every apps.apple.com URL — so the checked-in default is the
+  // source of truth and the env var is an override, matching
+  // AppStoreLinksService.
+  const appAppleIdRaw =
+    process.env.APPLE_IAP_APP_APPLE_ID || DEFAULT_APP_STORE_APPLE_ID;
+  const appAppleId = Number.parseInt(appAppleIdRaw, 10);
 
   const enableOnlineChecks = true;
   const verifiers = VERIFIED_ENVIRONMENTS.map(


### PR DESCRIPTION
## What

Closes #4040. `createAppleStoreKitService` now falls back to `DEFAULT_APP_STORE_APPLE_ID` (the public App Store id, already checked in for `AppStoreLinksService`) when `APPLE_IAP_APP_APPLE_ID` is unset or empty. Apple's Production verifier hard-requires the numeric id — the missing env var made every real-money redeem throw at construction while Sandbox (TestFlight/App Review) kept passing, which is why testing never caught it. The env var stays as an override; `src/env.example` documents the default.

The prod `.env` hotfix from 2026-08-09 already stopped the bleeding; this makes the class of failure impossible — the same "override, not source of truth" contract `AppStoreLinksService` has carried since the id was checked in.

No changelog entry — repairs a server misconfiguration; no user-visible behavior change from the current (hotfixed) state.

## Tests

- New: env id passed through to both verifiers; unset env → default id; empty env → default id (both failed before the fix).
- AppleStoreKitService + AppStoreLinksService suites: 15/15. `tsc -p . --noEmit` clean, `pnpm format:check` clean tree-wide.
- Sonar: gating merge on the PR analysis reporting zero open findings.
- Security review: payments surface — running `/security-review` before merge per repo rules; result will be noted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
