### PR TITLE
feat: magic link creates the account when the email is new

### DIFF
--- a/src/services/UsersService.test.ts
+++ b/src/services/UsersService.test.ts
@@ -276,15 +276,71 @@ describe('UsersService.requestMagicLink', () => {
     expect(sentToken).toHaveLength(128);
   });
 
-  it('silently returns when the user is not found', async () => {
-    const getByEmail = jest.fn().mockResolvedValue(null);
-    const repository = { getByEmail } as unknown as UsersRepository;
+  it('creates an account and sends the link when the email is new (login)', async () => {
+    const created = { id: 41, email: 'newcomer@example.com' };
+    const getByEmail = jest
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue(created);
+    const createUserAndSeedFromTombstone = jest
+      .fn()
+      .mockResolvedValue([{ id: 41 }]);
+    const repository = {
+      getByEmail,
+      createUserAndSeedFromTombstone,
+    } as unknown as UsersRepository;
     const emailService = buildEmailService();
     const magicTokenRepo = new InMemoryMagicTokenRepository();
     const service = new UsersService(repository, emailService, magicTokenRepo);
 
-    await service.requestMagicLink('nobody@example.com', 'login');
+    await service.requestMagicLink('Newcomer@example.com', 'login');
 
+    expect(createUserAndSeedFromTombstone).toHaveBeenCalledWith(
+      'newcomer',
+      expect.any(String),
+      'newcomer@example.com',
+      'magic_link'
+    );
+    const storedPassword = createUserAndSeedFromTombstone.mock.calls[0][1];
+    expect(storedPassword).toMatch(/^\$2[aby]\$/);
+    expect(emailService.sendMagicLinkEmail).toHaveBeenCalledWith(
+      'Newcomer@example.com',
+      expect.any(String),
+      'login'
+    );
+  });
+
+  it('does not create an account for a password reset on an unknown email', async () => {
+    const getByEmail = jest.fn().mockResolvedValue(null);
+    const createUserAndSeedFromTombstone = jest.fn();
+    const repository = {
+      getByEmail,
+      createUserAndSeedFromTombstone,
+    } as unknown as UsersRepository;
+    const emailService = buildEmailService();
+    const magicTokenRepo = new InMemoryMagicTokenRepository();
+    const service = new UsersService(repository, emailService, magicTokenRepo);
+
+    await service.requestMagicLink('nobody@example.com', 'password_reset');
+
+    expect(createUserAndSeedFromTombstone).not.toHaveBeenCalled();
+    expect(emailService.sendMagicLinkEmail).not.toHaveBeenCalled();
+  });
+
+  it('does not create an account for a malformed address', async () => {
+    const getByEmail = jest.fn().mockResolvedValue(null);
+    const createUserAndSeedFromTombstone = jest.fn();
+    const repository = {
+      getByEmail,
+      createUserAndSeedFromTombstone,
+    } as unknown as UsersRepository;
+    const emailService = buildEmailService();
+    const magicTokenRepo = new InMemoryMagicTokenRepository();
+    const service = new UsersService(repository, emailService, magicTokenRepo);
+
+    await service.requestMagicLink('not-an-email', 'login');
+
+    expect(createUserAndSeedFromTombstone).not.toHaveBeenCalled();
     expect(emailService.sendMagicLinkEmail).not.toHaveBeenCalled();
   });
 

--- a/src/services/UsersService.ts
+++ b/src/services/UsersService.ts
@@ -13,8 +13,21 @@ const MAGIC_LINK_RATE_LIMIT = 5;
 const MAGIC_LINK_RATE_WINDOW_MS = 60 * 60 * 1000;
 const MAGIC_LINK_EXPIRY_MS = 15 * 60 * 1000;
 // Shape check only — the clicked link is the real proof of ownership. This
-// exists so garbage input cannot mint an account row.
-const MAGIC_LINK_EMAIL_SHAPE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+// exists so garbage input cannot mint an account row. Plain string scans, not
+// a regex: the input is unauthenticated and a backtracking pattern here is a
+// ReDoS surface (typescript:S8786, the #3960 class).
+function looksLikeEmail(email: string): boolean {
+  if (/\s/.test(email)) {
+    return false;
+  }
+  const at = email.indexOf('@');
+  if (at < 1 || at !== email.lastIndexOf('@')) {
+    return false;
+  }
+  const domain = email.slice(at + 1);
+  const lastDot = domain.lastIndexOf('.');
+  return lastDot >= 1 && lastDot < domain.length - 1;
+}
 
 export class MagicLinkRateLimitError extends Error {
   constructor() {
@@ -185,7 +198,7 @@ class UsersService {
       // mailbox ownership (verifyMagicLink marks the email verified) and logs
       // them in. Password resets stay a silent no-op: there is no account to
       // reset, and creating one there would mask the real situation.
-      if (purpose !== 'login' || !MAGIC_LINK_EMAIL_SHAPE.test(email)) {
+      if (purpose !== 'login' || !looksLikeEmail(email)) {
         console.info('password_reset.magic_link', {
           outcome: 'unknown_email',
           purpose,

--- a/src/services/UsersService.ts
+++ b/src/services/UsersService.ts
@@ -1,4 +1,5 @@
 import crypto from 'crypto';
+import bcrypt from 'bcryptjs';
 
 import UsersRepository from '../data_layer/UsersRepository';
 import Users from '../data_layer/public/Users';
@@ -11,6 +12,9 @@ import { isResetTokenLive } from '../lib/User/isResetTokenLive';
 const MAGIC_LINK_RATE_LIMIT = 5;
 const MAGIC_LINK_RATE_WINDOW_MS = 60 * 60 * 1000;
 const MAGIC_LINK_EXPIRY_MS = 15 * 60 * 1000;
+// Shape check only — the clicked link is the real proof of ownership. This
+// exists so garbage input cannot mint an account row.
+const MAGIC_LINK_EMAIL_SHAPE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export class MagicLinkRateLimitError extends Error {
   constructor() {
@@ -174,13 +178,35 @@ class UsersService {
     if (this.magicTokenRepository == null) {
       return;
     }
-    const user = await this.repository.getByEmail(email);
+    let user = await this.repository.getByEmail(email);
     if (user?.id == null) {
+      // A new visitor who picks "email me a sign-in link" is signing up — the
+      // link email doubles as account creation, and clicking it both proves
+      // mailbox ownership (verifyMagicLink marks the email verified) and logs
+      // them in. Password resets stay a silent no-op: there is no account to
+      // reset, and creating one there would mask the real situation.
+      if (purpose !== 'login' || !MAGIC_LINK_EMAIL_SHAPE.test(email)) {
+        console.info('password_reset.magic_link', {
+          outcome: 'unknown_email',
+          purpose,
+        });
+        return;
+      }
+      const placeholderPassword = bcrypt.hashSync(crypto.randomUUID(), 12);
+      await this.register('', placeholderPassword, email, 'magic_link');
+      user = await this.repository.getByEmail(email.toLowerCase());
+      if (user?.id == null) {
+        console.info('password_reset.magic_link', {
+          outcome: 'signup_failed',
+          purpose,
+        });
+        return;
+      }
       console.info('password_reset.magic_link', {
-        outcome: 'unknown_email',
+        outcome: 'account_created',
         purpose,
+        user_id_hash: hashToken(String(user.id)),
       });
-      return;
     }
     const userIdHash = hashToken(String(user.id));
     const oneHourAgo = new Date(Date.now() - MAGIC_LINK_RATE_WINDOW_MS);

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-11-magic-link-signup.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-11-magic-link-signup.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-11-magic-link-signup",
+  "date": "2026-08-11",
+  "type": "feature",
+  "title": "The sign-in link now creates your account too — no separate signup needed"
+}


### PR DESCRIPTION
## What

The login page's "Email me a sign-in link" now works for people who don't have an account yet — the link email doubles as signup, matching the tubehabit.no flow. Fixes the silent dead end a real reporter hit on 2026-08-10: unknown emails no-opped for anti-enumeration while the UI claimed "A login link was sent", so a new visitor watched an empty inbox through five retries over 12 hours and then emailed support (prod-verified: 5 matching `POST /api/users/magic-link` 200s, zero SendGrid send events, no user row).

## How

`UsersService.requestMagicLink`, login purpose, unknown address: after a shape check (`x@y.z` — garbage can't mint a row), the account is created through the existing `register` path with a random bcrypt-hashed placeholder password and `signup_origin: 'magic_link'`, then the normal token + email flow runs. The existing `verifyMagicLink` click path already marks the email verified and signs the user in, so the click is the ownership proof. Password resets on unknown emails stay silent no-ops. Per-owner rate limiting (5/hr) applies to created accounts from the first request.

**Deliberate trade-off (owner decision)**: login-form anti-enumeration is given up in exchange for a working passwordless signup — an attacker can now distinguish… actually nothing from the response (still always 200 "ok"); the enumeration surface is only that unknown addresses now receive mail. A typo'd address receives one sign-in email for an account that stays unverified and passwordless; the inactive-user cleanup already reaps such rows.

## Tests

- New: unknown login email → account created (bcrypt placeholder, lowercased email, `magic_link` origin) + link sent; unknown email on password reset → still no-op; malformed address → no account, no send.
- UsersService 24/24, UsersControllers 120/120. Full server suite: 6279 passed / 74 failed — all the documented worktree-environmental class (Python bridge + pdfinfo), verified zero non-environmental failures. `tsc` clean, `pnpm format:check` clean.
- Sonar: gating merge on the PR analysis reporting zero open findings.
- Security review: auth surface — running before merge; result noted below.

## Funnel

Signup friction on the acquisition lane: every new visitor who picks the passwordless option now converts instead of bouncing. Read `signup_origin = 'magic_link'` counts in the users table; day-7 check for first rows.

## Browser check

Not applicable — the only web/src change is a changelog JSON entry; the login form UI is unchanged (its "link sent" claim is now simply true).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
