### PR TITLE
fix: let chat accept a file with no message typed

### DIFF
--- a/src/controllers/ChatController.test.ts
+++ b/src/controllers/ChatController.test.ts
@@ -586,3 +586,64 @@ describe('ChatController.regenerateMessage', () => {
     });
   });
 });
+
+describe('ChatController.sendMessage — file-only messages', () => {
+  it('accepts a file with no text and substitutes the default instruction', async () => {
+    const { execute, controller, res } = buildMocks();
+    execute.mockResolvedValueOnce({ content: 'ok', conversationId: 1 });
+
+    await controller.sendMessage(buildReq({ content: '' }, [makeFile()]), res);
+
+    expect(res.status).not.toHaveBeenCalledWith(400);
+    expect(execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: 'Create flashcards from the attached file.',
+        attachments: [expect.objectContaining({ mimeType: 'application/pdf' })],
+      })
+    );
+  });
+
+  it('substitutes the plural instruction when several files are attached', async () => {
+    const { execute, controller, res } = buildMocks();
+    execute.mockResolvedValueOnce({ content: 'ok', conversationId: 1 });
+
+    await controller.sendMessage(
+      buildReq({ content: '' }, [makeFile(), makeFile()]),
+      res
+    );
+
+    expect(execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: 'Create flashcards from the attached files.',
+      })
+    );
+  });
+
+  it('treats whitespace-only content with a file as file-only', async () => {
+    const { execute, controller, res } = buildMocks();
+    execute.mockResolvedValueOnce({ content: 'ok', conversationId: 1 });
+
+    await controller.sendMessage(
+      buildReq({ content: '   ' }, [makeFile()]),
+      res
+    );
+
+    expect(execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: 'Create flashcards from the attached file.',
+      })
+    );
+  });
+
+  it('reports the attachment problem, not missing content, when the only file is invalid', async () => {
+    const { controller, res } = buildMocks();
+    const bigFile = makeFile({ size: 11 * 1024 * 1024 });
+
+    await controller.sendMessage(buildReq({ content: '' }, [bigFile]), res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: expect.stringContaining('10 MB'),
+    });
+  });
+});

--- a/src/controllers/ChatController.ts
+++ b/src/controllers/ChatController.ts
@@ -185,6 +185,18 @@ function hasConsented(locals: Record<string, unknown>): boolean {
   return locals.chat_consent_at != null;
 }
 
+function resolveContent(
+  rawContent: unknown,
+  attachmentCount: number
+): string | null {
+  const content = typeof rawContent === 'string' ? rawContent.trim() : '';
+  if (content.length > 0) return content;
+  if (attachmentCount === 0) return null;
+  return attachmentCount === 1
+    ? FILE_ONLY_INSTRUCTION_SINGLE
+    : FILE_ONLY_INSTRUCTION_MULTI;
+}
+
 class ChatController {
   constructor(private readonly chatUseCase: ChatUseCase) {}
 
@@ -208,18 +220,13 @@ class ChatController {
       return;
     }
 
-    const rawContent = req.body?.content;
-    let content = typeof rawContent === 'string' ? rawContent.trim() : '';
-
-    if (content.length === 0) {
-      if (validation.attachments.length === 0) {
-        res.status(400).json({ error: 'content is required' });
-        return;
-      }
-      content =
-        validation.attachments.length === 1
-          ? FILE_ONLY_INSTRUCTION_SINGLE
-          : FILE_ONLY_INSTRUCTION_MULTI;
+    const content = resolveContent(
+      req.body?.content,
+      validation.attachments.length
+    );
+    if (content == null) {
+      res.status(400).json({ error: 'content is required' });
+      return;
     }
 
     const owner = res.locals.owner as number;

--- a/src/controllers/ChatController.ts
+++ b/src/controllers/ChatController.ts
@@ -66,6 +66,11 @@ function contentMatchesMime(buffer: Buffer, mimeType: string): boolean {
 const ATTACH_REJECTED_MESSAGE =
   'Files work here as PDF, image, .zip, .docx, .md, or .txt.';
 
+const FILE_ONLY_INSTRUCTION_SINGLE =
+  'Create flashcards from the attached file.';
+const FILE_ONLY_INSTRUCTION_MULTI =
+  'Create flashcards from the attached files.';
+
 function sseWrite(res: Response, event: string, data: unknown): void {
   res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
 }
@@ -194,12 +199,27 @@ class ChatController {
       return;
     }
 
+    const rawFiles = Array.isArray(req.files)
+      ? (req.files as Express.Multer.File[])
+      : [];
+    const validation = validateAttachments(rawFiles);
+    if (!validation.ok) {
+      res.status(400).json({ error: validation.error });
+      return;
+    }
+
     const rawContent = req.body?.content;
-    const content = typeof rawContent === 'string' ? rawContent.trim() : '';
+    let content = typeof rawContent === 'string' ? rawContent.trim() : '';
 
     if (content.length === 0) {
-      res.status(400).json({ error: 'content is required' });
-      return;
+      if (validation.attachments.length === 0) {
+        res.status(400).json({ error: 'content is required' });
+        return;
+      }
+      content =
+        validation.attachments.length === 1
+          ? FILE_ONLY_INSTRUCTION_SINGLE
+          : FILE_ONLY_INSTRUCTION_MULTI;
     }
 
     const owner = res.locals.owner as number;
@@ -211,15 +231,6 @@ class ChatController {
       res.status(400).json({
         error: `content must be ${MAX_CONTENT_LENGTH} characters or fewer`,
       });
-      return;
-    }
-
-    const rawFiles = Array.isArray(req.files)
-      ? (req.files as Express.Multer.File[])
-      : [];
-    const validation = validateAttachments(rawFiles);
-    if (!validation.ok) {
-      res.status(400).json({ error: validation.error });
       return;
     }
 

--- a/web/src/components/ChatPanel/ChatPanel.test.tsx
+++ b/web/src/components/ChatPanel/ChatPanel.test.tsx
@@ -54,11 +54,12 @@ vi.mock('../../lib/backend/api', () => ({
   del: vi.fn(),
 }));
 
-import { get, patch, post } from '../../lib/backend/api';
+import { get, patch, post, postMultipart } from '../../lib/backend/api';
 
 const mockPost = post as ReturnType<typeof vi.fn>;
 const mockGet = get as ReturnType<typeof vi.fn>;
 const mockPatch = patch as ReturnType<typeof vi.fn>;
+const mockPostMultipart = postMultipart as ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   mockUseUserLocals.mockReturnValue(consentedLocals);
@@ -1213,5 +1214,61 @@ describe('ChatPanel — monthly usage counter', () => {
     expect(
       screen.queryByText(/messages left this month/)
     ).not.toBeInTheDocument();
+  });
+});
+
+describe('ChatPanel — file-only send', () => {
+  beforeEach(() => {
+    mockPost.mockReset();
+    mockPostMultipart.mockReset();
+    mockGet.mockResolvedValue({ used: 0, limit: 20 });
+  });
+
+  function attachPdf(name: string) {
+    const input = document.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement;
+    const file = new File(['%PDF'], name, { type: 'application/pdf' });
+    fireEvent.change(input, { target: { files: [file] } });
+  }
+
+  it('sends a file with no text as the default instruction', async () => {
+    mockPostMultipart.mockResolvedValueOnce(
+      makeSseResponse([
+        { event: 'done', data: { content: 'Cards', conversationId: 1 } },
+      ])
+    );
+    renderChatPanel();
+    attachPdf('notes.pdf');
+    await screen.findByRole('button', { name: 'Remove notes.pdf' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
+
+    await waitFor(() => {
+      expect(mockPostMultipart).toHaveBeenCalled();
+    });
+    const formData = mockPostMultipart.mock.calls[0][1] as FormData;
+    expect(formData.get('content')).toBe(
+      'Create flashcards from the attached file.'
+    );
+  });
+
+  it('shows the default instruction as the user message bubble', async () => {
+    mockPostMultipart.mockResolvedValueOnce(
+      makeSseResponse([
+        { event: 'done', data: { content: 'Cards', conversationId: 1 } },
+      ])
+    );
+    renderChatPanel();
+    attachPdf('notes.pdf');
+    await screen.findByRole('button', { name: 'Remove notes.pdf' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Create flashcards from the attached file.')
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/web/src/components/ChatPanel/ChatPanel.tsx
+++ b/web/src/components/ChatPanel/ChatPanel.tsx
@@ -586,6 +586,15 @@ function ComposerPill({
   );
 }
 
+function resolveOutgoingContent(
+  rawContent: string,
+  fileCount: number,
+  t: (key: string, opts?: Record<string, unknown>) => string
+): string {
+  if (rawContent.trim().length > 0) return rawContent;
+  return t('composer.fileOnlyPrompt', { count: fileCount });
+}
+
 export default function ChatPanel({
   initialPrompt,
   cameFromUpload,
@@ -781,10 +790,7 @@ export default function ChatPanel({
 
   async function sendMessage(rawContent: string) {
     if (!rawContent.trim() && readyChips.length === 0) return;
-    const content =
-      rawContent.trim().length > 0
-        ? rawContent
-        : t('composer.fileOnlyPrompt', { count: readyChips.length });
+    const content = resolveOutgoingContent(rawContent, readyChips.length, t);
 
     const userMessage: Message = { role: 'user', content };
     const nextMessages = [...messages, userMessage];

--- a/web/src/components/ChatPanel/ChatPanel.tsx
+++ b/web/src/components/ChatPanel/ChatPanel.tsx
@@ -779,8 +779,12 @@ export default function ChatPanel({
     );
   }
 
-  async function sendMessage(content: string) {
-    if (!content.trim() && readyChips.length === 0) return;
+  async function sendMessage(rawContent: string) {
+    if (!rawContent.trim() && readyChips.length === 0) return;
+    const content =
+      rawContent.trim().length > 0
+        ? rawContent
+        : t('composer.fileOnlyPrompt', { count: readyChips.length });
 
     const userMessage: Message = { role: 'user', content };
     const nextMessages = [...messages, userMessage];

--- a/web/src/lib/i18n/locales/de/chat.json
+++ b/web/src/lib/i18n/locales/de/chat.json
@@ -39,6 +39,8 @@
     "studyingPlaceholder": "Was lernst du gerade?",
     "messageInput": "Nachrichteneingabe",
     "sendMessage": "Nachricht senden",
+    "fileOnlyPrompt_one": "Erstelle Karten aus der angehängten Datei.",
+    "fileOnlyPrompt_other": "Erstelle Karten aus den angehängten Dateien.",
     "region": "Chat-Editor mit Datei-Ablagebereich",
     "scrollToBottom": "Nach unten scrollen"
   },

--- a/web/src/lib/i18n/locales/en/chat.json
+++ b/web/src/lib/i18n/locales/en/chat.json
@@ -39,6 +39,8 @@
     "studyingPlaceholder": "What are you studying?",
     "messageInput": "Message input",
     "sendMessage": "Send message",
+    "fileOnlyPrompt_one": "Create flashcards from the attached file.",
+    "fileOnlyPrompt_other": "Create flashcards from the attached files.",
     "region": "Chat composer with file drop zone",
     "scrollToBottom": "Scroll to bottom"
   },

--- a/web/src/lib/i18n/locales/es/chat.json
+++ b/web/src/lib/i18n/locales/es/chat.json
@@ -39,6 +39,8 @@
     "studyingPlaceholder": "¿Qué estás estudiando?",
     "messageInput": "Campo del mensaje",
     "sendMessage": "Enviar mensaje",
+    "fileOnlyPrompt_one": "Crea tarjetas a partir del archivo adjunto.",
+    "fileOnlyPrompt_other": "Crea tarjetas a partir de los archivos adjuntos.",
     "region": "Redactor de chat con zona para soltar archivos",
     "scrollToBottom": "Ir al final"
   },

--- a/web/src/lib/i18n/locales/fr/chat.json
+++ b/web/src/lib/i18n/locales/fr/chat.json
@@ -39,6 +39,8 @@
     "studyingPlaceholder": "Qu'est-ce que tu étudies ?",
     "messageInput": "Saisie du message",
     "sendMessage": "Envoyer le message",
+    "fileOnlyPrompt_one": "Crée des cartes à partir du fichier joint.",
+    "fileOnlyPrompt_other": "Crée des cartes à partir des fichiers joints.",
     "region": "Rédacteur de conversation avec zone de dépôt de fichiers",
     "scrollToBottom": "Aller en bas"
   },

--- a/web/src/lib/i18n/locales/it/chat.json
+++ b/web/src/lib/i18n/locales/it/chat.json
@@ -39,6 +39,8 @@
     "studyingPlaceholder": "Cosa stai studiando?",
     "messageInput": "Campo del messaggio",
     "sendMessage": "Invia il messaggio",
+    "fileOnlyPrompt_one": "Crea carte dal file allegato.",
+    "fileOnlyPrompt_other": "Crea carte dai file allegati.",
     "region": "Editor della chat con area di rilascio file",
     "scrollToBottom": "Scorri in fondo"
   },

--- a/web/src/lib/i18n/locales/ja/chat.json
+++ b/web/src/lib/i18n/locales/ja/chat.json
@@ -39,6 +39,7 @@
     "studyingPlaceholder": "何を勉強していますか？",
     "messageInput": "メッセージ入力",
     "sendMessage": "メッセージを送信",
+    "fileOnlyPrompt_other": "添付ファイルからカードを作成してください。",
     "region": "ファイルドロップゾーン付きのチャット入力欄",
     "scrollToBottom": "一番下へスクロール"
   },

--- a/web/src/lib/i18n/locales/nl/chat.json
+++ b/web/src/lib/i18n/locales/nl/chat.json
@@ -39,6 +39,8 @@
     "studyingPlaceholder": "Wat ben je aan het leren?",
     "messageInput": "Berichtinvoer",
     "sendMessage": "Bericht versturen",
+    "fileOnlyPrompt_one": "Maak kaarten van het bijgevoegde bestand.",
+    "fileOnlyPrompt_other": "Maak kaarten van de bijgevoegde bestanden.",
     "region": "Chatvenster met bestandssleepzone",
     "scrollToBottom": "Naar beneden scrollen"
   },

--- a/web/src/lib/i18n/locales/pl/chat.json
+++ b/web/src/lib/i18n/locales/pl/chat.json
@@ -39,6 +39,10 @@
     "studyingPlaceholder": "Czego się uczysz?",
     "messageInput": "Pole wiadomości",
     "sendMessage": "Wyślij wiadomość",
+    "fileOnlyPrompt_one": "Utwórz karty z załączonego pliku.",
+    "fileOnlyPrompt_few": "Utwórz karty z załączonych plików.",
+    "fileOnlyPrompt_many": "Utwórz karty z załączonych plików.",
+    "fileOnlyPrompt_other": "Utwórz karty z załączonych plików.",
     "region": "Edytor czatu ze strefą upuszczania plików",
     "scrollToBottom": "Przewiń na dół"
   },

--- a/web/src/lib/i18n/locales/pt/chat.json
+++ b/web/src/lib/i18n/locales/pt/chat.json
@@ -39,6 +39,8 @@
     "studyingPlaceholder": "O que você está estudando?",
     "messageInput": "Campo de mensagem",
     "sendMessage": "Enviar mensagem",
+    "fileOnlyPrompt_one": "Crie cartões a partir do arquivo anexado.",
+    "fileOnlyPrompt_other": "Crie cartões a partir dos arquivos anexados.",
     "region": "Compositor de chat com zona de soltar arquivos",
     "scrollToBottom": "Rolar até o fim"
   },

--- a/web/src/lib/i18n/locales/ru/chat.json
+++ b/web/src/lib/i18n/locales/ru/chat.json
@@ -39,6 +39,10 @@
     "studyingPlaceholder": "Что ты изучаешь?",
     "messageInput": "Поле сообщения",
     "sendMessage": "Отправить сообщение",
+    "fileOnlyPrompt_one": "Создай карты из прикреплённого файла.",
+    "fileOnlyPrompt_few": "Создай карты из прикреплённых файлов.",
+    "fileOnlyPrompt_many": "Создай карты из прикреплённых файлов.",
+    "fileOnlyPrompt_other": "Создай карты из прикреплённых файлов.",
     "region": "Поле ввода чата с зоной перетаскивания файлов",
     "scrollToBottom": "Прокрутить вниз"
   },

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-11-chat-file-only.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-11-chat-file-only.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-11-chat-file-only",
+  "date": "2026-08-11",
+  "type": "fix",
+  "title": "Chat accepts an attached file with no message"
+}


### PR DESCRIPTION
## Summary

Attaching a file in chat and hitting send with an empty input returned a raw `400 content is required`. The composer enables send on attachments alone, but the API required non-empty text before it ever looked at the files — so file-only messages were impossible from a UI that invites them.

## Changes

- **Server** (`ChatController`): attachments are validated first; a file-only message now gets a default instruction ("Create flashcards from the attached file(s).") instead of a 400. Empty content with no files still 400s. An invalid file with empty content now reports the attachment problem instead of the misleading content error.
- **Web** (`ChatPanel`): a file-only send injects the same instruction localized, so the sent bubble, stored history, and follow-up turns all carry consistent text. New `composer.fileOnlyPrompt` key added to all 10 locales with full CLDR plural forms (ru/pl `_one/_few/_many/_other`, ja `_other`).
- Changelog entry included.

Substituting real text (rather than allowing empty content through) keeps downstream safe: an empty text block would be rejected by the Anthropic API, and an empty persisted user message would poison follow-up history turns and regenerate.

## Tests

- Server: 4 new controller tests (file-only single/plural/whitespace, invalid-file error precedence) — `ChatController.test.ts` 40/40 green.
- Web: 2 new `ChatPanel` tests (FormData carries the instruction; bubble renders it) — 54/54 green.
- Full server suite green except the documented environmental `getPageCount` pdfinfo failure; full web suite green (2830 tests). `pnpm format:check` clean tree-wide.

Sonar: local scan not run (Docker down, MCP unreachable); relying on PR decoration — will verify zero open findings via the issues API before merge.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: machine-backed — `pnpm --filter 2anki-web test:golden-path` green (2 passed) on this branch; chat file-only path itself covered by the new component tests at the network edge.
