### PR TITLE
fix: let typed requests and the composer pick the chat note type

### DIFF
--- a/src/usecases/chat/ChatUseCase.test.ts
+++ b/src/usecases/chat/ChatUseCase.test.ts
@@ -1711,6 +1711,9 @@ describe('regenerate with attachments', () => {
 
     const userRow = messagesRepo.getAll().find((r) => r.role === 'user');
     expect(userRow?.had_binary_attachments).toBe(false);
+  });
+});
+
 describe('typed format requests override the template default', () => {
   const MCQ_JSON =
     '```json\n[{"front": "Capital of Norway?", "options": ["Bergen", "Oslo", "Trondheim", "Stavanger"], "correct_index": 1}]\n```';

--- a/src/usecases/chat/ChatUseCase.test.ts
+++ b/src/usecases/chat/ChatUseCase.test.ts
@@ -937,14 +937,18 @@ describe('ChatUseCase', () => {
       });
     });
 
-    it('drops an MCQ card for a free user', async () => {
+    it('extracts an MCQ card for a free user', async () => {
       const { useCase } = buildUseCase(MCQ_RESPONSE_TEXT);
       const result = await useCase.execute({
         user: FREE_USER,
         content: 'quiz me',
         conversationHistory: [],
       });
-      expect(result.cards).toBeUndefined();
+      expect(result.cards).toHaveLength(1);
+      expect(result.cards![0]).toMatchObject({
+        options: ['Lipase', 'Amylase', 'Protease', 'Lactase'],
+        correctIndex: 1,
+      });
     });
 
     it('drops malformed MCQ (3 options) and keeps surrounding valid cards', async () => {
@@ -986,7 +990,7 @@ describe('ChatUseCase', () => {
       expect(callArg.system[0].text).toContain('<ruby>三<rt>さん</rt></ruby>');
     });
 
-    it('does not add MCQ instructions to the system prompt for free users', async () => {
+    it('adds MCQ instructions to the system prompt for free users too', async () => {
       const { anthropic, useCase } = buildUseCase('reply');
       await useCase.execute({
         user: FREE_USER,
@@ -994,7 +998,7 @@ describe('ChatUseCase', () => {
         conversationHistory: [],
       });
       const callArg = anthropic.messages.stream.mock.calls[0][0];
-      expect(callArg.system[0].text).not.toMatch(/correct_index/);
+      expect(callArg.system[0].text).toMatch(/correct_index/);
     });
   });
 
@@ -1707,5 +1711,91 @@ describe('regenerate with attachments', () => {
 
     const userRow = messagesRepo.getAll().find((r) => r.role === 'user');
     expect(userRow?.had_binary_attachments).toBe(false);
+describe('typed format requests override the template default', () => {
+  const MCQ_JSON =
+    '```json\n[{"front": "Capital of Norway?", "options": ["Bergen", "Oslo", "Trondheim", "Stavanger"], "correct_index": 1}]\n```';
+
+  it('parses MCQ cards for a free user who asked for them in text', async () => {
+    const { useCase } = buildUseCase(`Here you go:\n${MCQ_JSON}`);
+
+    const result = await useCase.execute({
+      user: FREE_USER,
+      content: 'make mcq cards about Norway',
+      conversationHistory: [],
+      templateSlug: 'basic',
+    });
+
+    expect(result.cards).toEqual([
+      expect.objectContaining({
+        front: 'Capital of Norway?',
+        options: ['Bergen', 'Oslo', 'Trondheim', 'Stavanger'],
+        correctIndex: 1,
+      }),
+    ]);
+  });
+
+  it('gives free users the MCQ format spec in the system prompt', async () => {
+    const { anthropic, useCase } = buildUseCase('answer');
+
+    await useCase.execute({
+      user: FREE_USER,
+      content: 'question',
+      conversationHistory: [],
+      templateSlug: 'basic',
+    });
+
+    const callArg = anthropic.messages.stream.mock.calls[0][0];
+    expect(callArg.system[0].text).toContain('correct_index');
+  });
+
+  it('keeps cloze cards when the model declares Format: cloze on a basic template', async () => {
+    const { useCase } = buildUseCase(
+      'Deck: Chemistry\nFormat: cloze\n```json\n[{"front": "Water is {{c1::H2O}}.", "back": ""}]\n```'
+    );
+
+    const result = await useCase.execute({
+      user: FREE_USER,
+      content: 'give me fill-in-the-blank cards',
+      conversationHistory: [],
+      templateSlug: 'basic',
+    });
+
+    expect(result.cards).toEqual([
+      { front: 'Water is {{c1::H2O}}.', back: '' },
+    ]);
+    expect(result.contentBefore ?? '').not.toMatch(/Format:/);
+    expect(result.deckName).toBe('Chemistry');
+  });
+
+  it('keeps cloze cards when the user asked for cloze even without a declaration', async () => {
+    const { useCase } = buildUseCase(
+      '```json\n[{"front": "Water is {{c1::H2O}}.", "back": ""}]\n```'
+    );
+
+    const result = await useCase.execute({
+      user: FREE_USER,
+      content: 'cloze cards please',
+      conversationHistory: [],
+      templateSlug: 'basic',
+    });
+
+    expect(result.cards).toEqual([
+      { front: 'Water is {{c1::H2O}}.', back: '' },
+    ]);
+  });
+
+  it('still normalizes stray cloze on basic when nobody asked for it', async () => {
+    const { useCase } = buildUseCase(
+      '```json\n[{"front": "Water is {{c1::H2O}}.", "back": ""}]\n```'
+    );
+
+    const result = await useCase.execute({
+      user: FREE_USER,
+      content: 'make cards about water',
+      conversationHistory: [],
+      templateSlug: 'basic',
+    });
+
+    expect(result.cards?.[0].front).not.toContain('{{c1::');
   });
 });

--- a/src/usecases/chat/ChatUseCase.ts
+++ b/src/usecases/chat/ChatUseCase.ts
@@ -213,6 +213,15 @@ function foldAttachmentIntoContent(
   return `${attachmentText}\n\n${content}`;
 }
 
+function textOfMessageContent(
+  content: Anthropic.MessageParam['content']
+): string {
+  if (typeof content === 'string') return content;
+  return content
+    .map((block) => (block.type === 'text' ? block.text : ''))
+    .join('\n');
+}
+
 export class ChatRateLimitError extends Error {
   readonly resetDate: string;
 
@@ -360,20 +369,35 @@ function parseCardArray(
   return cards.length > 0 ? cards : undefined;
 }
 
+/// The model writes `Format: cloze` on its own line before the JSON block
+/// when it honors an explicit cloze request on a non-cloze note type (see
+/// the template suffixes). The declaration lifts the stray-cloze
+/// normalization for that reply and never renders as conversation text.
+const FORMAT_CLOZE_LINE = /(?:^|\n)[ \t]*Format:[ \t]*cloze[ \t]*(?=\n|$)/i;
+
+function stripFormatLine(before: string): string {
+  return before.replace(FORMAT_CLOZE_LINE, '').trim();
+}
+
 export function extractCards(
   text: string,
   mcqAllowed = false,
   forbidCloze = false
 ): ExtractCardsResult {
+  const effectiveForbidCloze = forbidCloze && !FORMAT_CLOZE_LINE.test(text);
   const fencedMatch = /```json\s*([\s\S]*?)```/.exec(text);
   if (fencedMatch != null) {
-    const cards = parseCardArray(fencedMatch[1], mcqAllowed, forbidCloze);
+    const cards = parseCardArray(
+      fencedMatch[1],
+      mcqAllowed,
+      effectiveForbidCloze
+    );
     if (cards != null) {
       const before = text.slice(0, fencedMatch.index).trim();
       const after = text
         .slice(fencedMatch.index + fencedMatch[0].length)
         .trim();
-      const { deckName, rest } = splitDeckName(before);
+      const { deckName, rest } = splitDeckName(stripFormatLine(before));
       return {
         cards,
         contentBefore: rest.length > 0 ? rest : undefined,
@@ -385,11 +409,11 @@ export function extractCards(
 
   const rawMatch = /((?:^|\n)\s*)(\[\s*\{[\s\S]*\}\s*\])/.exec(text);
   if (rawMatch != null) {
-    const cards = parseCardArray(rawMatch[2], mcqAllowed, forbidCloze);
+    const cards = parseCardArray(rawMatch[2], mcqAllowed, effectiveForbidCloze);
     if (cards != null) {
       const before = text.slice(0, rawMatch.index).trim();
       const after = text.slice(rawMatch.index + rawMatch[0].length).trim();
-      const { deckName, rest } = splitDeckName(before);
+      const { deckName, rest } = splitDeckName(stripFormatLine(before));
       return {
         cards,
         contentBefore: rest.length > 0 ? rest : undefined,
@@ -664,12 +688,9 @@ export class ChatUseCase {
       ? params.templateSlug
       : 'basic';
     const mcqForced = resolvedTemplate === 'mcq';
-    const mcqAllowed = user.patreon || mcqForced;
 
     const templateSuffix = templatePromptSuffix(resolvedTemplate);
-    const baseSystemPrompt = mcqAllowed
-      ? `${STUDY_ASSISTANT_SYSTEM_PROMPT}\n\n${MCQ_PROMPT_ADDITION}`
-      : STUDY_ASSISTANT_SYSTEM_PROMPT;
+    const baseSystemPrompt = `${STUDY_ASSISTANT_SYSTEM_PROMPT}\n\n${MCQ_PROMPT_ADDITION}`;
     const systemPromptText =
       templateSuffix.length > 0
         ? `${baseSystemPrompt}\n\n${templateSuffix.trim()}`
@@ -738,10 +759,19 @@ export class ChatUseCase {
       assistantContent
     );
 
-    const forbidCloze = templateForbidsCloze(resolvedTemplate);
+    const userAskedCloze = /\bcloze\b/i.test(
+      textOfMessageContent(params.userContent)
+    );
+    const forbidCloze =
+      templateForbidsCloze(resolvedTemplate) && !userAskedCloze;
+    if (userAskedCloze && templateForbidsCloze(resolvedTemplate)) {
+      console.info('[chat] honoring cloze request over note type', {
+        template: resolvedTemplate,
+      });
+    }
     const { cards, contentBefore, contentAfter, deckName } = extractCards(
       assistantContent,
-      mcqAllowed,
+      true,
       forbidCloze
     );
 

--- a/src/usecases/chat/chatTemplates.test.ts
+++ b/src/usecases/chat/chatTemplates.test.ts
@@ -17,26 +17,29 @@ describe('isChatCardTemplate', () => {
 });
 
 describe('templatePromptSuffix', () => {
-  it('returns a non-empty suffix for basic that forbids cloze and mcq', () => {
+  it('describes basic front/back as a default that yields to explicit requests', () => {
     const suffix = templatePromptSuffix('basic');
     expect(suffix.length).toBeGreaterThan(0);
     expect(suffix).toMatch(/front/i);
     expect(suffix).toMatch(/back/i);
-    expect(suffix).toMatch(/\{\{c/);
-    expect(suffix).toMatch(/cloze/i);
-    expect(suffix).toMatch(/multiple.choice|mcq/i);
+    expect(suffix).toMatch(/unless the user explicitly asks/i);
+    expect(suffix).toMatch(/Format: cloze/);
+    expect(suffix).not.toMatch(/TEMPLATE OVERRIDE/);
   });
 
-  it('returns a non-empty suffix for basic-and-reversed', () => {
+  it('returns a suffix for basic-and-reversed that yields to explicit requests', () => {
     const suffix = templatePromptSuffix('basic-and-reversed');
     expect(suffix.length).toBeGreaterThan(0);
     expect(suffix).toMatch(/both directions/i);
+    expect(suffix).toMatch(/unless the user explicitly asks/i);
   });
 
-  it('returns a cloze-specific suffix for cloze template', () => {
+  it('returns a cloze-specific suffix that yields to explicit requests', () => {
     const suffix = templatePromptSuffix('cloze');
     expect(suffix).toMatch(/cloze/i);
     expect(suffix).toMatch(/\{\{c1::/);
+    expect(suffix).toMatch(/unless the user explicitly asks/i);
+    expect(suffix).not.toMatch(/TEMPLATE OVERRIDE/);
   });
 
   it('returns an mcq-specific suffix for mcq template', () => {

--- a/src/usecases/chat/chatTemplates.ts
+++ b/src/usecases/chat/chatTemplates.ts
@@ -14,22 +14,24 @@ export function isChatCardTemplate(value: unknown): value is ChatCardTemplate {
   );
 }
 
+const YIELD_TO_REQUEST = `Unless the user explicitly asks for a different card format in their latest message, follow this note type for every card. If they do ask for another format (in any language), honor their request using the card formats described earlier — and when you emit cloze cards this way, write \`Format: cloze\` on its own line immediately before the JSON block.`;
+
 const TEMPLATE_PROMPT_SUFFIX: Record<ChatCardTemplate, string> = {
   basic: `
-TEMPLATE OVERRIDE — basic front/back (this overrides any earlier instruction about cloze or multiple-choice cards):
+DEFAULT NOTE TYPE — basic front/back. ${YIELD_TO_REQUEST}
 
-EVERY card you emit must be a plain front/back pair. For each card:
+By default every card is a plain front/back pair:
 - "front" holds the question or prompt
 - "back" holds the answer and must be non-empty
-- Do NOT use {{cN::...}} cloze syntax anywhere
-- Do NOT produce multiple-choice (MCQ) cards or answer-option lists`,
+- No {{cN::...}} cloze syntax, no answer-option lists`,
   'basic-and-reversed': `
-TEMPLATE OVERRIDE — basic + reverse:
+DEFAULT NOTE TYPE — basic + reverse. ${YIELD_TO_REQUEST}
+
 Each card will appear in Anki as BOTH a question→answer AND answer→question pair. Make sure every card makes sense in both directions (e.g. terms and definitions, language pairs).`,
   cloze: `
-TEMPLATE OVERRIDE — cloze deletion (this overrides any earlier instruction about front/back cards):
+DEFAULT NOTE TYPE — cloze deletion. ${YIELD_TO_REQUEST}
 
-EVERY card you emit must be a cloze deletion. Do not produce any front/back Q&A pairs in this conversation. For each card:
+By default every card is a cloze deletion. For each card:
 - "front" contains the full sentence with the answer wrapped as {{c1::answer}}
 - "back" is the empty string ""
 - Use {{c1::...}}, {{c2::...}} for multiple blanks in the same sentence

--- a/web/src/components/ChatPanel/ChatPanel.module.css
+++ b/web/src/components/ChatPanel/ChatPanel.module.css
@@ -626,3 +626,9 @@
   color: var(--color-text-secondary);
   margin-left: auto;
 }
+
+.composerTemplateRow {
+  display: flex;
+  justify-content: flex-start;
+  margin-bottom: 0.5rem;
+}

--- a/web/src/components/ChatPanel/ChatPanel.test.tsx
+++ b/web/src/components/ChatPanel/ChatPanel.test.tsx
@@ -823,11 +823,11 @@ describe('ChatPanel — template selector', () => {
     ).toBeInTheDocument();
   });
 
-  it('does not render the template selector in the empty state', () => {
+  it('renders the composer template selector in the empty state', () => {
     renderChatPanel();
     expect(
-      screen.queryByRole('button', { name: /Note type/i })
-    ).not.toBeInTheDocument();
+      screen.getByRole('button', { name: 'Note type: Basic' })
+    ).toBeInTheDocument();
   });
 
   it('renders the template selector on the last assistant turn even with no cards', () => {
@@ -1142,9 +1142,10 @@ describe('ChatPanel — template selector', () => {
       initialMessages: [{ role: 'user', content: 'spring boot' }],
       initialConversationId: 7,
     });
-    expect(
-      screen.queryByRole('button', { name: /Note type/i })
-    ).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Note type: Basic' }));
+    fireEvent.click(
+      screen.getByRole('option', { name: /Cloze/ }).querySelector('button')!
+    );
     expect(mockPost).not.toHaveBeenCalled();
   });
 });
@@ -1308,5 +1309,67 @@ describe('ChatPanel — regenerate with attachments', () => {
         )
       ).toBeInTheDocument();
     });
+describe('ChatPanel — typed note type requests', () => {
+  beforeEach(() => {
+    mockPost.mockReset();
+    mockPatch.mockReset();
+    mockGet.mockResolvedValue({ used: 0, limit: 20 });
+  });
+
+  it('adopts the produced note type and skips regenerate on reselect', async () => {
+    mockPost.mockResolvedValueOnce(
+      makeSseResponse([
+        {
+          event: 'done',
+          data: {
+            content: '```json\n[{"front":"X is {{c1::Y}}.","back":""}]\n```',
+            conversationId: 7,
+            cards: [{ front: 'X is {{c1::Y}}.', back: '' }],
+          },
+        },
+      ])
+    );
+    renderChatPanel({ initialTemplateSlug: 'basic', initialConversationId: 7 });
+    fireEvent.change(screen.getByRole('textbox', { name: 'Message input' }), {
+      target: { value: 'cloze please' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
+
+    await waitFor(() => {
+      expect(mockPatch).toHaveBeenCalledWith(
+        '/api/chat/conversations/7/template',
+        { templateSlug: 'cloze' }
+      );
+    });
+
+    mockPost.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: 'Note type: Cloze' }));
+    fireEvent.click(
+      screen.getByRole('option', { name: /Cloze/ }).querySelector('button')!
+    );
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('shows a note type control in the empty composer', () => {
+    renderChatPanel();
+    expect(
+      screen.getByRole('button', { name: 'Note type: Basic' })
+    ).toBeInTheDocument();
+  });
+
+  it('shows exactly one note type control once an assistant reply exists', () => {
+    renderChatPanel({
+      initialMessages: [
+        { role: 'user', content: 'q' },
+        {
+          role: 'assistant',
+          content: 'r',
+          cards: [{ front: 'a', back: 'b' }],
+        },
+      ],
+    });
+    expect(screen.getAllByRole('button', { name: /Note type/ })).toHaveLength(
+      1
+    );
   });
 });

--- a/web/src/components/ChatPanel/ChatPanel.test.tsx
+++ b/web/src/components/ChatPanel/ChatPanel.test.tsx
@@ -1309,6 +1309,9 @@ describe('ChatPanel — regenerate with attachments', () => {
         )
       ).toBeInTheDocument();
     });
+  });
+});
+
 describe('ChatPanel — typed note type requests', () => {
   beforeEach(() => {
     mockPost.mockReset();

--- a/web/src/components/ChatPanel/ChatPanel.tsx
+++ b/web/src/components/ChatPanel/ChatPanel.tsx
@@ -15,6 +15,7 @@ import CardPreview from '../../pages/Chat/CardPreview';
 import ConsentModal from '../ConsentModal/ConsentModal';
 import { ALLOWED_ATTACHMENT_TYPES, ATTACHMENT_ACCEPT } from './attachmentTypes';
 import styles from './ChatPanel.module.css';
+import { TemplateSelector } from './TemplateSelector';
 
 export interface ChatCard {
   front: string;
@@ -716,6 +717,7 @@ export default function ChatPanel({
     (monthlyLimit ?? FREE_MONTHLY_LIMIT) - messagesUsedThisMonth;
 
   const readyChips = chips.filter((c) => c.state === 'idle');
+  const hasAssistantTurn = messages.some((m) => m.role === 'assistant');
   const canSend =
     (inputValue.trim().length > 0 || readyChips.length > 0) &&
     !isLoading &&
@@ -881,6 +883,7 @@ export default function ChatPanel({
         prev.trim().length > 0 ? prev : provisionalTitle
       );
       onConversationCreated?.(result.conversationId, provisionalTitle);
+      adoptProducedTemplate(result.cards, result.conversationId);
       if (result.cards != null && result.cards.length > 0) {
         onCardsGenerated?.(result.cards);
       }
@@ -974,6 +977,20 @@ export default function ChatPanel({
     }
   }
 
+  function adoptProducedTemplate(
+    cards: ChatCard[] | undefined,
+    conversationId: number
+  ) {
+    if (cards == null || cards.length === 0) return;
+    const produced = effectiveTemplateForCards(cards, activeTemplate);
+    if (produced === activeTemplate) return;
+    setActiveTemplate(produced);
+    onTemplateChange?.(produced);
+    patch(`/api/chat/conversations/${conversationId}/template`, {
+      templateSlug: produced,
+    }).catch(() => {});
+  }
+
   function handleTemplateChange(slug: ChatCardTemplate) {
     const lastAssistant = findLastAssistantIdx(messages);
     const lastTurnCards =
@@ -1060,6 +1077,7 @@ export default function ChatPanel({
       );
       setMessagesUsedThisMonth((n) => n + 1);
       setActiveConversationId(result.conversationId);
+      adoptProducedTemplate(result.cards, result.conversationId);
       if (result.cards != null && result.cards.length > 0) {
         onCardsGenerated?.(result.cards);
       }
@@ -1182,6 +1200,13 @@ export default function ChatPanel({
               {cameFromUpload ? t('heading.withFile') : t('heading.studying')}
             </h1>
             <div className={styles.emptyComposer}>
+              <div className={styles.composerTemplateRow}>
+                <TemplateSelector
+                  value={activeTemplate}
+                  onChange={handleTemplateChange}
+                  disabled={isLoading}
+                />
+              </div>
               <ComposerPill {...composerProps} />
               {networkError != null && (
                 <p className={styles.networkError}>{networkError}</p>
@@ -1305,6 +1330,15 @@ export default function ChatPanel({
                   <a href="/pricing" className={styles.limitPanelLink}>
                     {t('limitPanel.seePlans')}
                   </a>
+                </div>
+              )}
+              {!hasAssistantTurn && (
+                <div className={styles.composerTemplateRow}>
+                  <TemplateSelector
+                    value={activeTemplate}
+                    onChange={handleTemplateChange}
+                    disabled={isLoading}
+                  />
                 </div>
               )}
               <ComposerPill {...composerProps} />

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-11-chat-note-type-requests.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-11-chat-note-type-requests.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-11-chat-note-type-requests",
+  "date": "2026-08-11",
+  "type": "fix",
+  "title": "Chat follows typed note type requests — cloze and multiple choice for everyone — and shows the picker before your first message"
+}


### PR DESCRIPTION
## Summary

Typing "make MCQ cards" or "cloze please" in chat got refused — the Note Type selector appended a hard TEMPLATE OVERRIDE the model obeyed over the user's request ("per current format rules"). MCQ was also premium-gated on the typed/spontaneous path while the selector handed it to every tier, and no format control existed before the first reply, so the first send always ran the Basic default.

Decision (Alexander): customers can use any note type we provide, by typing or by control. Trio synthesis in session; conflict on keeping the MCQ text-gate resolved to ungating (the selector already gives MCQ to free users — the gate protected nothing).

## Changes

**Server**
- `chatTemplates.ts`: the four suffixes become defaults that yield to an explicit format request in the user's latest message. The forced-MCQ (`mcq` slug) tool path is untouched.
- Cloze honored safely: the model declares `Format: cloze` before the JSON block (stripped from rendered prose); `extractCards` lifts stray-cloze normalization only on that declaration, plus a keyword backup on the user's message. **The #3908 protection stays**: undeclared, unrequested cloze on a basic template still normalizes (regression-tested).
- MCQ format spec + parsing apply to all tiers (`mcqAllowed` premium branch removed). Two old tests asserting the gate were replaced with their inverse.
- A log line marks when a cloze request overrides the note type, so prod shows the honor path firing.

**Web**
- Done-frames adopt the produced shape: `activeTemplate` silently syncs to `effectiveTemplateForCards`, persists to `/template`, and reselecting the shown type no longer fires a spurious regenerate.
- The composer shows the existing `TemplateSelector` (same state, zero new strings) until the first assistant reply exists — first sends carry a chosen note type. After that the card-table selector is the single control.
- Changelog entry included. No new i18n keys.

## Tests

- Server: 232 passing across chat suites — new coverage: typed MCQ parsed for free users, MCQ spec in every prompt, `Format: cloze` declaration honored + stripped, keyword-requested cloze honored, stray cloze still normalized.
- Web: 58 passing in `ChatPanel` — new: template adoption + no-spurious-regenerate, composer selector in empty state, single-selector invariant after replies; two tests encoding the old no-composer-selector contract updated.
- Full server suite green except documented environmental `getPageCount` pdfinfo failure; full web vitest (2834), both typechecks, tree-wide format all clean.

Sonar: local scan not run (Docker down); PR decoration + zero-open-findings API check before merge, as with #4045/#4046.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: machine-backed — golden-path spec green (2 passed) on this branch post-rebase; new behavior covered by component tests at the network edge. Worth a quick manual look at /chat for the composer selector placement before merge if you want visual confirmation.
