### PR TITLE
feat: add Download link to the navbar for anonymous visitors

### DIFF
--- a/web/src/components/NavigationBar/components/RightSide.test.tsx
+++ b/web/src/components/NavigationBar/components/RightSide.test.tsx
@@ -56,4 +56,19 @@ describe('RightSide (anonymous nav)', () => {
       screen.queryByRole('link', { name: 'Documentation' })
     ).not.toBeInTheDocument();
   });
+
+  it('shows a Download link to /app for logged-out visitors', () => {
+    render(<RightSide path="/" isLoggedIn={false} />);
+    expect(screen.getByRole('link', { name: 'Download' })).toHaveAttribute(
+      'href',
+      '/app'
+    );
+  });
+
+  it('omits the Download link for logged-in visitors', () => {
+    render(<RightSide path="/" isLoggedIn />);
+    expect(
+      screen.queryByRole('link', { name: 'Download' })
+    ).not.toBeInTheDocument();
+  });
 });

--- a/web/src/components/NavigationBar/components/RightSide.tsx
+++ b/web/src/components/NavigationBar/components/RightSide.tsx
@@ -27,6 +27,11 @@ export function RightSide({ path, isLoggedIn }: Readonly<RightSideProps>) {
           {t('nav.pricing')}
         </NavbarItem>
       )}
+      {!isLoggedIn && (
+        <NavbarItem href="/app" path={path}>
+          {t('nav.download')}
+        </NavbarItem>
+      )}
       <NavbarItem href="/login#login" path={path}>
         {t('nav.login')}
       </NavbarItem>

--- a/web/src/lib/i18n/locales/de/common.json
+++ b/web/src/lib/i18n/locales/de/common.json
@@ -18,6 +18,7 @@
     "resources": "Ressourcen",
     "docs": "Doku",
     "pricing": "Preise",
+    "download": "Herunterladen",
     "whatsNew": "Neuigkeiten",
     "account": "Konto",
     "logout": "Abmelden",

--- a/web/src/lib/i18n/locales/en/common.json
+++ b/web/src/lib/i18n/locales/en/common.json
@@ -18,6 +18,7 @@
     "resources": "Resources",
     "docs": "Docs",
     "pricing": "Pricing",
+    "download": "Download",
     "whatsNew": "What's new",
     "account": "Account",
     "logout": "Log out",

--- a/web/src/lib/i18n/locales/es/common.json
+++ b/web/src/lib/i18n/locales/es/common.json
@@ -18,6 +18,7 @@
     "resources": "Recursos",
     "docs": "Documentación",
     "pricing": "Precios",
+    "download": "Descargar",
     "whatsNew": "Novedades",
     "account": "Cuenta",
     "logout": "Cerrar sesión",

--- a/web/src/lib/i18n/locales/fr/common.json
+++ b/web/src/lib/i18n/locales/fr/common.json
@@ -18,6 +18,7 @@
     "resources": "Ressources",
     "docs": "Docs",
     "pricing": "Tarifs",
+    "download": "Télécharger",
     "whatsNew": "Nouveautés",
     "account": "Compte",
     "logout": "Se déconnecter",

--- a/web/src/lib/i18n/locales/it/common.json
+++ b/web/src/lib/i18n/locales/it/common.json
@@ -18,6 +18,7 @@
     "resources": "Risorse",
     "docs": "Documentazione",
     "pricing": "Prezzi",
+    "download": "Scarica",
     "whatsNew": "Novità",
     "account": "Account",
     "logout": "Esci",

--- a/web/src/lib/i18n/locales/ja/common.json
+++ b/web/src/lib/i18n/locales/ja/common.json
@@ -18,6 +18,7 @@
     "resources": "リソース",
     "docs": "ドキュメント",
     "pricing": "料金",
+    "download": "ダウンロード",
     "whatsNew": "新着情報",
     "account": "アカウント",
     "logout": "ログアウト",

--- a/web/src/lib/i18n/locales/nl/common.json
+++ b/web/src/lib/i18n/locales/nl/common.json
@@ -18,6 +18,7 @@
     "resources": "Bronnen",
     "docs": "Documentatie",
     "pricing": "Prijzen",
+    "download": "Downloaden",
     "whatsNew": "Wat is er nieuw",
     "account": "Account",
     "logout": "Uitloggen",

--- a/web/src/lib/i18n/locales/pl/common.json
+++ b/web/src/lib/i18n/locales/pl/common.json
@@ -18,6 +18,7 @@
     "resources": "Zasoby",
     "docs": "Dokumentacja",
     "pricing": "Cennik",
+    "download": "Pobierz",
     "whatsNew": "Co nowego",
     "account": "Konto",
     "logout": "Wyloguj się",

--- a/web/src/lib/i18n/locales/pt/common.json
+++ b/web/src/lib/i18n/locales/pt/common.json
@@ -18,6 +18,7 @@
     "resources": "Recursos",
     "docs": "Documentação",
     "pricing": "Preços",
+    "download": "Baixar",
     "whatsNew": "Novidades",
     "account": "Conta",
     "logout": "Sair",

--- a/web/src/lib/i18n/locales/ru/common.json
+++ b/web/src/lib/i18n/locales/ru/common.json
@@ -18,6 +18,7 @@
     "resources": "Ресурсы",
     "docs": "Документация",
     "pricing": "Цены",
+    "download": "Скачать",
     "whatsNew": "Что нового",
     "account": "Аккаунт",
     "logout": "Выйти",

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-11-navbar-download-link.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-11-navbar-download-link.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-11-navbar-download-link",
+  "date": "2026-08-11",
+  "type": "feature",
+  "title": "Download link in the navigation bar takes you to the 2anki app"
+}


### PR DESCRIPTION
## What

Adds a "Download" item to the marketing navbar, visible only to anonymous visitors, linking to the native app page at `/app`.

- Shown when logged out, hidden when logged in (logged-in users have the app shell, not this navbar).
- Label localized in all 10 locales (`nav.download` in `common.json`), reusing each locale's established translation of "Download".
- Changelog entry included.

Requested by Alexander (2026-08-11): "adding 'Download' to navbar for anon users which sends you to /app".

## Tests

- `RightSide.test.tsx`: anonymous visitors see the Download link pointing at `/app`; logged-in visitors don't.
- Full web suite green (2836 tests), typecheck, lint, `pnpm format:check` all pass.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: machine-backed via `pnpm --filter 2anki-web test:golden-path` (2 passed — landing + signed-in dashboard at 375px, console-error assertions on).

## Funnel impact

Acquisition-facing: gives anonymous visitors a direct nav path to the app download page. Metric: visits to /app from nav (page views on /app).
