### PR TITLE
fix: rescue zip decks when the batch build drops or kills entries

### DIFF
--- a/create_deck/create_deck.py
+++ b/create_deck/create_deck.py
@@ -270,6 +270,10 @@ def run_batch(manifest_path, template_dir):
     with open(manifest_path, "r", encoding="utf-8") as f:
         entries = json.load(f)
 
+    # One failing entry must not abort the batch: the caller retries entries
+    # that produced no output line individually, so report the failure on
+    # stderr and keep building the rest (#4028 shipped zero decks because a
+    # single bad page killed every deck in its chunk).
     for entry in entries:
         input_path = entry["input"]
         output_path = _clamp_output_path(entry["output"])
@@ -278,12 +282,7 @@ def run_batch(manifest_path, template_dir):
         original_cwd = os.getcwd()
         try:
             os.chdir(deck_dir)
-            try:
-                apkg_path = build_one_deck(input_path, template_dir)
-            except Exception as exc:
-                raise RuntimeError(
-                    f"Failed to build deck from {input_path}: {exc}"
-                ) from exc
+            apkg_path = build_one_deck(input_path, template_dir)
 
             if apkg_path and apkg_path != output_path:
                 os.replace(apkg_path, output_path)
@@ -294,6 +293,11 @@ def run_batch(manifest_path, template_dir):
                     sys.stdout.write(apkg_path + "\n")
                 except UnicodeEncodeError:
                     sys.stdout.buffer.write((apkg_path + "\n").encode("utf-8"))
+        except Exception as exc:
+            print(
+                f"Failed to build deck from {input_path}: {exc}",
+                file=sys.stderr,
+            )
         finally:
             os.chdir(original_cwd)
 

--- a/create_deck/create_deck.py
+++ b/create_deck/create_deck.py
@@ -293,7 +293,7 @@ def run_batch(manifest_path, template_dir):
                     sys.stdout.write(apkg_path + "\n")
                 except UnicodeEncodeError:
                     sys.stdout.buffer.write((apkg_path + "\n").encode("utf-8"))
-        except Exception as exc:
+        except Exception as exc:  # pylint: disable=broad-exception-caught
             print(
                 f"Failed to build deck from {input_path}: {exc}",
                 file=sys.stderr,

--- a/create_deck/tests/test_batch_mode.py
+++ b/create_deck/tests/test_batch_mode.py
@@ -170,7 +170,36 @@ class TestBatchMode:
                 text=True,
                 cwd=tmpdir,
             )
-            assert result.returncode != 0
+            assert result.returncode == 0
+            assert "nonexistent" in result.stderr
+            assert result.stdout.strip() == ""
+
+    def test_batch_continues_past_failing_entry(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            good = _write_deck_workspace(tmpdir, "Good Deck", "good.jpg")
+
+            manifest_path = os.path.join(tmpdir, "manifest.json")
+            with open(manifest_path, "w") as f:
+                json.dump(
+                    [
+                        {
+                            "input": "/nonexistent/deck_info.json",
+                            "output": "/tmp/out.apkg",
+                        },
+                        {"input": good["input"], "output": good["output"]},
+                    ],
+                    f,
+                )
+
+            result = subprocess.run(
+                [PYTHON, str(SCRIPT), "--batch", manifest_path, str(TEMPLATE_DIR)],
+                capture_output=True,
+                text=True,
+                cwd=good["subdir"],
+            )
+            assert result.returncode == 0, f"stderr: {result.stderr}"
+            assert os.path.exists(good["output"]), "good apkg missing"
+            assert good["output"] in result.stdout
             assert "nonexistent" in result.stderr
 
     def test_empty_deck_in_batch_exits_cleanly(self):

--- a/src/usecases/uploads/getPackagesFromZip.test.ts
+++ b/src/usecases/uploads/getPackagesFromZip.test.ts
@@ -346,7 +346,7 @@ describe('getPackagesFromZip — batch concurrency', () => {
     expect(runBatchCallCount).toBeLessThanOrEqual(2);
   });
 
-  it('drops a chunk whose batch build fails and warns instead of aborting', async () => {
+  it('rebuilds every deck individually when the whole batch build fails', async () => {
     const fileCount = 8;
     const fileNames = Array.from(
       { length: fileCount },
@@ -371,6 +371,20 @@ describe('getPackagesFromZip — batch concurrency', () => {
       })
     );
 
+    mockPrepareDeck.mockImplementation(({ name }: { name: string }) =>
+      Promise.resolve({
+        name,
+        apkg: Buffer.from('fake-apkg'),
+        deck: [],
+        cardCount: 1,
+        mcqCount: 0,
+        mcqSkippedCount: 0,
+        droppedImageCount: 0,
+        expiredNotionImageCount: 0,
+        emptyBackCount: 0,
+      })
+    );
+
     mockCardGeneratorClass.mockImplementation(() => ({
       runBatch: jest.fn().mockRejectedValue(new Error('Python batch failed')),
     }));
@@ -385,10 +399,136 @@ describe('getPackagesFromZip — batch concurrency', () => {
       workspace
     );
 
-    expect(result.packages).toEqual([]);
+    expect(result.packages).toHaveLength(fileCount);
     expect(
-      result.warnings?.some((w) => w.includes('could not be converted'))
-    ).toBe(true);
+      result.warnings?.some((w) => w.includes('could not be converted')) ??
+        false
+    ).toBe(false);
+  });
+
+  it('retries a deck individually when the batch produced no apkg for it', async () => {
+    const fileCount = 8;
+    const fileNames = Array.from(
+      { length: fileCount },
+      (_, i) => `deck${i}.html`
+    );
+
+    mockZipHandlerClass.mockImplementation(() => ({
+      build: jest.fn().mockResolvedValue(undefined),
+      getFileNames: jest.fn().mockReturnValue(fileNames),
+      files: fileNames.map((name) => ({ name, contents: '<html></html>' })),
+    }));
+
+    mockPrepareDeckInfoOnly.mockImplementation(({ name }: { name: string }) =>
+      Promise.resolve({
+        deckInfoPath: `/fake/${name}/deck_info.json`,
+        outputPath: `/fake/${name}/out.apkg`,
+        name,
+        inputFileName: name,
+        deck: [],
+        cardCount: 1,
+        needsIndividualBuild: false,
+      })
+    );
+
+    mockPrepareDeck.mockImplementation(({ name }: { name: string }) =>
+      Promise.resolve({
+        name,
+        apkg: Buffer.from('fake-apkg'),
+        deck: [],
+        cardCount: 1,
+        mcqCount: 0,
+        mcqSkippedCount: 0,
+        droppedImageCount: 0,
+        expiredNotionImageCount: 0,
+        emptyBackCount: 0,
+      })
+    );
+
+    mockCardGeneratorClass.mockImplementation(() => ({
+      runBatch: jest
+        .fn()
+        .mockImplementation((entries: Array<{ output: string }>) =>
+          Promise.resolve(
+            entries
+              .filter((e) => !e.output.includes('deck3.html'))
+              .map((e) => e.output)
+          )
+        ),
+    }));
+
+    jest
+      .spyOn(require('node:fs'), 'readFileSync')
+      .mockReturnValue(Buffer.from('fake-apkg'));
+
+    const settings = new CardOption({});
+    const workspace = { location: FAKE_WORKSPACE_LOCATION } as Workspace;
+
+    const result = await getPackagesFromZip(
+      Buffer.from('fake-zip') as unknown as Uint8Array,
+      false,
+      settings,
+      workspace
+    );
+
+    expect(result.packages).toHaveLength(fileCount);
+    const retriedNames = mockPrepareDeck.mock.calls.map((call) => call[0].name);
+    expect(retriedNames).toEqual(['deck3.html']);
+  });
+
+  it('does not retry a deck the batch skipped because it had zero cards', async () => {
+    const fileCount = 8;
+    const fileNames = Array.from(
+      { length: fileCount },
+      (_, i) => `deck${i}.html`
+    );
+
+    mockZipHandlerClass.mockImplementation(() => ({
+      build: jest.fn().mockResolvedValue(undefined),
+      getFileNames: jest.fn().mockReturnValue(fileNames),
+      files: fileNames.map((name) => ({ name, contents: '<html></html>' })),
+    }));
+
+    mockPrepareDeckInfoOnly.mockImplementation(({ name }: { name: string }) =>
+      Promise.resolve({
+        deckInfoPath: `/fake/${name}/deck_info.json`,
+        outputPath: `/fake/${name}/out.apkg`,
+        name,
+        inputFileName: name,
+        deck: [],
+        cardCount: name === 'deck5.html' ? 0 : 1,
+        needsIndividualBuild: false,
+      })
+    );
+
+    mockCardGeneratorClass.mockImplementation(() => ({
+      runBatch: jest
+        .fn()
+        .mockImplementation((entries: Array<{ output: string }>) =>
+          Promise.resolve(
+            entries
+              .filter((e) => !e.output.includes('deck5.html'))
+              .map((e) => e.output)
+          )
+        ),
+    }));
+
+    jest
+      .spyOn(require('node:fs'), 'readFileSync')
+      .mockReturnValue(Buffer.from('fake-apkg'));
+
+    const settings = new CardOption({});
+    const workspace = { location: FAKE_WORKSPACE_LOCATION } as Workspace;
+
+    const result = await getPackagesFromZip(
+      Buffer.from('fake-zip') as unknown as Uint8Array,
+      false,
+      settings,
+      workspace
+    );
+
+    expect(result.packages).toHaveLength(fileCount - 1);
+    expect(mockPrepareDeck).not.toHaveBeenCalled();
   });
 
   it('skips one file that fails to convert in the batch path and returns the rest', async () => {

--- a/src/usecases/uploads/getPackagesFromZip.ts
+++ b/src/usecases/uploads/getPackagesFromZip.ts
@@ -120,19 +120,40 @@ async function buildDeckBatch(
     }
   });
 
-  const batchEntries = preparedResults
-    .filter((r) => !r.needsIndividualBuild)
-    .map((r) => ({ input: r.deckInfoPath, output: r.outputPath }));
+  const batchResults = preparedResults.filter((r) => !r.needsIndividualBuild);
+  const batchEntries = batchResults.map((r) => ({
+    input: r.deckInfoPath,
+    output: r.outputPath,
+  }));
 
-  const stragglers = preparedResults.filter((r) => r.needsIndividualBuild);
+  const stragglers: { inputFileName: string }[] = preparedResults.filter(
+    (r) => r.needsIndividualBuild
+  );
 
   if (batchEntries.length > 0) {
     const gen = new CardGenerator(workspace.location);
-    const apkgPaths = await gen.runBatch(batchEntries);
+    // The Python batch reports each built deck by printing its output path;
+    // pairing by that path (never by position) keeps one skipped entry from
+    // shifting every deck after it. A deck the batch failed to build — or a
+    // batch process that died outright — retries on the individual path below
+    // instead of silently shipping nothing (#4028).
+    let producedPaths = new Set<string>();
+    try {
+      producedPaths = new Set(await gen.runBatch(batchEntries));
+    } catch (error) {
+      console.warn(
+        '[batch-build] batch deck build failed, rebuilding decks individually',
+        error
+      );
+    }
 
-    const batchResults = preparedResults.filter((r) => !r.needsIndividualBuild);
-    batchResults.forEach((result, i) => {
-      if (!apkgPaths[i]) return;
+    batchResults.forEach((result) => {
+      if (!producedPaths.has(result.outputPath)) {
+        if (result.cardCount > 0) {
+          stragglers.push(result);
+        }
+        return;
+      }
       const pkg = new Package(
         result.name,
         result.cardCount,

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-11-zip-exports-convert-reliably.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-11-zip-exports-convert-reliably.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-11-zip-exports-convert-reliably",
+  "date": "2026-08-11",
+  "type": "fix",
+  "title": "Notion workspace exports convert even when one page in the zip fails"
+}


### PR DESCRIPTION
## What

Makes the batched zip build path (#3956) resilient so a real Notion workspace export can no longer ship zero packages. Fixes #4028.

Could not reproduce the exact failing artifact from the report (synthetic replicas pass, as the issue notes) — but code reading pinned two defects in the batch path that produce exactly the reported shape, and both are fixed with characterization tests. Please confirm against a real failing export when one is available.

## The two defects

1. **One failing page killed its whole chunk.** `create_deck.py --batch` raised `RuntimeError` on the first entry that failed, so the python process died non-zero and the JS side marked every deck in that chunk failed. A systematic per-page failure (e.g. media resolution) → every chunk dies → zero packages. Small uploads (≤ python cap) take the all-in-one path and never batch — which is why the issue's synthetic replicas passed while real many-page exports failed.
2. **Produced apkgs were paired to decks by stdout position.** Any entry the batch skipped (zero cards, or a failure had it continued) shifted every deck after it; `if (!apkgPaths[i]) return;` then silently dropped decks with no warning and no failure record.

## The fix

- Python batch mode reports a failing entry on stderr and keeps building the rest (exit 0).
- JS pairs produced apkgs to decks by **output path**, never by position.
- Any deck with cards that got no apkg — or a whole batch process that died — is **rebuilt individually** through the existing straggler path instead of vanishing. Worst case is a slower conversion, never an empty one.
- Decks that legitimately produced zero cards are not retried.

## Tests

- Python: batch continues past a failing entry, builds the rest, exit 0, failure on stderr (`test_batch_mode.py`, 12 pass; full create_deck suite 64 pass).
- Jest: whole-batch failure → all decks rebuilt individually; missing single apkg → only that deck retried; zero-card decks not retried (`getPackagesFromZip.test.ts`, 14 pass).
- Full server suite: 676/677 suites pass, 6367 tests — only the documented environmental `getPageCount` (pdfinfo) failures.
- `pnpm format:check` clean; server `tsc -p . --noEmit` clean.

Sonar: not run locally pre-push; gating merge on the PR analysis (zero open findings) instead.

## Diagnosis notes (for the issue trail)

The remaining unknown is *which* per-page failure the real exports trip — this PR removes the amplification (one page → whole chunk → zero packages) and the silent drop, so if a page still fails it now converts the rest and warns honestly. The zip-census logging from #4030 should name the culprit page shape on the next prod occurrence.
