### PR TITLE
fix: return 400 when the events body is unparseable, not a 500

### DIFF
--- a/src/controllers/EventsController.test.ts
+++ b/src/controllers/EventsController.test.ts
@@ -63,6 +63,13 @@ describe('EventsController', () => {
     expect(res.status).toHaveBeenCalledWith(400);
   });
 
+  it('returns 400 when the body is unparseable (Express 5 leaves it undefined)', () => {
+    const { controller, req, res } = buildMocks({});
+    (req as { body?: unknown }).body = undefined;
+    controller.track(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
   it('returns 400 when name is not a string', () => {
     const { controller, req, res } = buildMocks({});
     req.body = { name: 42 };

--- a/src/controllers/EventsController.ts
+++ b/src/controllers/EventsController.ts
@@ -10,7 +10,7 @@ export class EventsController {
   constructor(private readonly trackEventUseCase: TrackEventUseCase) {}
 
   track(req: Request, res: Response): void {
-    const { name, props } = req.body as {
+    const { name, props } = (req.body ?? {}) as {
       name: unknown;
       props?: unknown;
     };


### PR DESCRIPTION
## What

`POST /api/events/track` returned a 500 (destructuring TypeError) whenever the POST body wasn't parseable JSON — Express 5 leaves `req.body` undefined in that case. The ops error dashboard shows 23 occurrences, all bots/probes (the real web client always sets `Content-Type: application/json`). One-line guard (`req.body ?? {}`, the same pattern `TemplatesController` already uses) so the existing name validation answers 400. Fixes #4048.

## Tests

- New regression test: `req.body === undefined` → 400 (reproduced the exact prod TypeError before the fix).
- `EventsController.test.ts` 123/123 pass; server `tsc -p . --noEmit` clean; `pnpm format:check` clean.

No changelog entry — only unparseable bot/probe requests hit this; the web client is unaffected.

## Scope note

The issue suggests sweeping other unguarded `req.body` destructures. The remaining sites are mostly on auth surfaces (`UsersControllers` login/register/reset), which I'm deliberately not touching in an unattended run — they're protected from the same noise by earlier middleware/validation to a lesser degree, but a change there deserves your eyes. Happy to follow up if you want the sweep.

Sonar: not run locally; gating merge on the PR analysis instead.
