### PR TITLE
fix: return-rate query runs one scan, times out, reports errors

### DIFF
--- a/src/services/ops/ReturnRateMetricsService.test.ts
+++ b/src/services/ops/ReturnRateMetricsService.test.ts
@@ -41,14 +41,14 @@ describe('ReturnRateMetricsService — generated SQL', () => {
     );
   });
 
-  it('builds the returns query finding each identity/source next conversion', () => {
+  it('builds the returns query as a single scan with a LEAD window, never a correlated subquery', () => {
     expect(normalizeCutoff(service.buildReturnsQuery(NOW).toString())).toBe(
       "select COALESCE(e1.user_id::text, e1.anonymous_id) as owner, COALESCE(e1.props->>'source', 'unknown') as source_type, " +
         '"e1"."created_at" as "anchor_at", ' +
-        '(SELECT MIN(e2.created_at) FROM events e2 ' +
-        'WHERE COALESCE(e2.user_id::text, e2.anonymous_id) = COALESCE(e1.user_id::text, e1.anonymous_id) ' +
-        "AND COALESCE(e2.props->>'source', 'unknown') = COALESCE(e1.props->>'source', 'unknown') " +
-        "AND e2.name = 'conversion_succeeded' AND e2.created_at > e1.created_at) as first_return_at " +
+        'LEAD(e1.created_at) OVER (' +
+        'PARTITION BY COALESCE(e1.user_id::text, e1.anonymous_id), ' +
+        "COALESCE(e1.props->>'source', 'unknown') " +
+        'ORDER BY e1.created_at) as first_return_at ' +
         'from "events" as "e1" ' +
         'where "e1"."name" = \'conversion_succeeded\' and "e1"."created_at" >= \'<CUTOFF>\' ' +
         'and COALESCE(e1.user_id::text, e1.anonymous_id) IS NOT NULL'
@@ -160,7 +160,7 @@ describe('computeReturnRates — return-rate windows', () => {
 });
 
 describe('ReturnRateMetricsService — graceful failure', () => {
-  it('returns null windows when the query throws', async () => {
+  it('returns null windows and surfaces the error when the query throws', async () => {
     const failing = { raw: jest.fn() } as unknown as Knex;
     const service = new ReturnRateMetricsService(failing);
 
@@ -170,5 +170,7 @@ describe('ReturnRateMetricsService — graceful failure', () => {
     expect(result.overall['7d']).toBeNull();
     expect(result.overall['14d']).toBeNull();
     expect(result.overall['30d']).toBeNull();
+    expect(typeof result.error).toBe('string');
+    expect((result.error ?? '').length).toBeGreaterThan(0);
   });
 });

--- a/src/services/ops/ReturnRateMetricsService.ts
+++ b/src/services/ops/ReturnRateMetricsService.ts
@@ -21,12 +21,18 @@ export interface ReturnRateMetricsResponse {
   overall: ReturnRateWindow;
   by_source_type: ReturnRateBySourceType[] | null;
   as_of: string;
+  error?: string;
 }
 
 const CONVERSION_EVENT = 'conversion_succeeded';
 const SECONDS_PER_DAY = 24 * 60 * 60;
 const LOOKBACK_DAYS = 90;
 const UNKNOWN_SOURCE = 'unknown';
+
+// The ops page auto-refreshes; a query that outlives the refresh interval
+// stacks concurrent copies until the pool starves (#4049 — eight 4-minute
+// copies observed live). Cancel server-side rather than letting them pile up.
+const QUERY_TIMEOUT_MS = 30_000;
 
 export interface CohortMember {
   owner: string;
@@ -139,11 +145,12 @@ export class ReturnRateMetricsService {
         this.fetchCohort(now),
         this.fetchReturns(now),
       ]);
-    } catch {
+    } catch (err) {
       return {
         overall: { '7d': null, '14d': null, '30d': null },
         by_source_type: null,
         as_of,
+        error: err instanceof Error ? err.message : String(err),
       };
     }
 
@@ -194,25 +201,25 @@ export class ReturnRateMetricsService {
         ]),
         'e1.created_at as anchor_at',
         this.database.raw(
-          '(SELECT MIN(e2.created_at) FROM events e2' +
-            ' WHERE COALESCE(e2.user_id::text, e2.anonymous_id) =' +
-            ' COALESCE(e1.user_id::text, e1.anonymous_id)' +
-            " AND COALESCE(e2.props->>'source', ?) =" +
-            " COALESCE(e1.props->>'source', ?)" +
-            ' AND e2.name = ?' +
-            ' AND e2.created_at > e1.created_at' +
-            ') as first_return_at',
-          [UNKNOWN_SOURCE, UNKNOWN_SOURCE, CONVERSION_EVENT]
+          'LEAD(e1.created_at) OVER (' +
+            'PARTITION BY COALESCE(e1.user_id::text, e1.anonymous_id), ' +
+            "COALESCE(e1.props->>'source', ?) " +
+            'ORDER BY e1.created_at) as first_return_at',
+          [UNKNOWN_SOURCE]
         )
       );
   }
 
   private fetchCohort(now: Date): Promise<CohortMember[]> {
-    return this.buildCohortQuery(now) as Promise<CohortMember[]>;
+    return this.buildCohortQuery(now).timeout(QUERY_TIMEOUT_MS, {
+      cancel: true,
+    }) as Promise<CohortMember[]>;
   }
 
   private async fetchReturns(now: Date): Promise<ReturnRecord[]> {
-    const rows = (await this.buildReturnsQuery(now)) as Array<{
+    const rows = (await this.buildReturnsQuery(now).timeout(QUERY_TIMEOUT_MS, {
+      cancel: true,
+    })) as Array<{
       owner: string;
       source_type: string;
       anchor_at: string;

--- a/web/src/pages/OpsPage/ReturnRateTab.tsx
+++ b/web/src/pages/OpsPage/ReturnRateTab.tsx
@@ -98,6 +98,12 @@ export default function ReturnRateTab() {
         </div>
       )}
 
+      {data?.error != null && (
+        <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>
+          Return-rate query failed on the server: {data.error}
+        </div>
+      )}
+
       <div className={styles.grid}>
         <MetricCard
           title="Returned within 7 days"

--- a/web/src/pages/OpsPage/returnRateTypes.ts
+++ b/web/src/pages/OpsPage/returnRateTypes.ts
@@ -19,4 +19,5 @@ export interface ReturnRateMetricsResponse {
   overall: ReturnRateWindow;
   by_source_type: ReturnRateBySourceType[] | null;
   as_of: string;
+  error?: string;
 }


### PR DESCRIPTION
## What

Fixes the return-rate ops query that was starving the prod DB pool. Fixes #4049.

1. **O(n²) → single scan.** `buildReturnsQuery` computed `first_return_at` with a correlated subquery per cohort row over the unindexable `COALESCE(user_id::text, anonymous_id)` expression. Replaced with `LEAD(created_at) OVER (PARTITION BY identity, source ORDER BY created_at)` — identical semantics (the correlated `MIN(later)` is exactly the next event, which is what LEAD returns; `fetchReturns`/`computeReturnRates` reduce per-key downstream, unchanged).
2. **30s query timeout with server-side cancel** (`.timeout(30_000, { cancel: true })` on both ops queries) so the auto-refresh can never stack 4–6-minute copies again (8 were observed live).
3. **Errors surface instead of the silent `catch {}`** — the response now carries `error?: string` (mirrors `UploadFunnelService`), and the Return-rate tab renders it in the same danger banner pattern `UploadFunnelTab` uses. "Empty" and "broken" are distinguishable now.

## Tests

- Generated-SQL assertion via pg-dialect knex `toString()` (per `.claude/rules/testing.md` raw-SQL rule): the returns query is asserted to be the LEAD single-scan shape — a reintroduced correlated subquery fails the test.
- Graceful-failure test now asserts the `error` field is populated.
- 8/8 service tests pass; OpsPage web tests 206/206; server tsc, web typecheck, `pnpm format:check` clean.

No changelog entry — internal ops surface only.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: machine-backed via `pnpm --filter 2anki-web test:golden-path` (2 passed). The changed banner itself is an exact mirror of UploadFunnelTab's shipped `data?.error` banner on an auth-gated ops tab; not separately exercised in a browser.

Sonar: not run locally; gating merge on the PR analysis instead.
