### PR TITLE
fix: cap the signup-country panel at 10 rows with an others row

### DIFF
--- a/src/services/ops/PerformanceMetricsService.test.ts
+++ b/src/services/ops/PerformanceMetricsService.test.ts
@@ -1,4 +1,8 @@
-import { PerformanceMetricsService } from './PerformanceMetricsService';
+import {
+  PerformanceMetricsService,
+  capSignupCountries,
+  SIGNUP_COUNTRIES_PANEL_LIMIT,
+} from './PerformanceMetricsService';
 import { InMemoryUserVisibleErrorsRepository } from '../../data_layer/UserVisibleErrorsRepository';
 import type { IUserVisibleErrorsRepository } from '../../data_layer/UserVisibleErrorsRepository';
 
@@ -10,6 +14,35 @@ function buildMockDb() {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any;
 }
+
+describe('capSignupCountries', () => {
+  const row = (country: string, count: number) => ({ country, count });
+
+  it('caps the list at the panel limit and sums the remainder into others', () => {
+    const rows = Array.from({ length: 14 }, (_, i) =>
+      row(`C${i.toString().padStart(2, '0')}`, 100 - i)
+    );
+
+    const { top, others } = capSignupCountries(rows);
+
+    expect(top).toHaveLength(SIGNUP_COUNTRIES_PANEL_LIMIT);
+    expect(top[0]).toEqual(row('C00', 100));
+    expect(others).toBe(
+      rows
+        .slice(SIGNUP_COUNTRIES_PANEL_LIMIT)
+        .reduce((sum, r) => sum + r.count, 0)
+    );
+  });
+
+  it('returns everything with zero others when under the limit', () => {
+    const rows = [row('DE', 5), row('US', 3)];
+
+    const { top, others } = capSignupCountries(rows);
+
+    expect(top).toEqual(rows);
+    expect(others).toBe(0);
+  });
+});
 
 describe('PerformanceMetricsService.getUserVisibleErrorCounts', () => {
   it('returns empty array when no repository is provided', async () => {

--- a/src/services/ops/PerformanceMetricsService.ts
+++ b/src/services/ops/PerformanceMetricsService.ts
@@ -36,8 +36,25 @@ export interface PerformanceMetricsResponse {
   status_breakdown_24h: JobStatusBreakdown[];
   slowest_jobs_24h: SlowJob[];
   signup_countries_7d: SignupCountryBreakdownItem[];
+  signup_countries_7d_others: number;
   user_visible_errors_24h: ErrorSurfaceCount[];
   user_visible_errors_7d: ErrorSurfaceCount[];
+}
+
+// Mirrors SIGNUP_COUNTRIES_LIMIT on the Business tab: the panel shows the top
+// countries and folds the tail into one "+N others" row instead of overflowing
+// its card (#4050).
+export const SIGNUP_COUNTRIES_PANEL_LIMIT = 10;
+
+export function capSignupCountries(rows: SignupCountryBreakdownItem[]): {
+  top: SignupCountryBreakdownItem[];
+  others: number;
+} {
+  const top = rows.slice(0, SIGNUP_COUNTRIES_PANEL_LIMIT);
+  const others = rows
+    .slice(SIGNUP_COUNTRIES_PANEL_LIMIT)
+    .reduce((sum, row) => sum + row.count, 0);
+  return { top, others };
 }
 
 const TERMINAL_STATUSES = ['done', 'failed', 'cancelled', 'interrupted'];
@@ -74,7 +91,8 @@ export class PerformanceMetricsService {
       ],
       status_breakdown_24h: statuses,
       slowest_jobs_24h: slowest,
-      signup_countries_7d: countries,
+      signup_countries_7d: countries.top,
+      signup_countries_7d_others: countries.others,
       user_visible_errors_24h: errors24h,
       user_visible_errors_7d: errors7d,
     };
@@ -172,9 +190,10 @@ export class PerformanceMetricsService {
     }));
   }
 
-  private async getSignupCountries(
-    sinceDays: number
-  ): Promise<SignupCountryBreakdownItem[]> {
+  private async getSignupCountries(sinceDays: number): Promise<{
+    top: SignupCountryBreakdownItem[];
+    others: number;
+  }> {
     const rows = (await this.db('users')
       .whereNotNull('signup_country')
       .where(
@@ -186,9 +205,11 @@ export class PerformanceMetricsService {
       .count<{ signup_country: string; count: string }[]>('* as count')
       .groupBy('signup_country')
       .orderBy('count', 'desc')) as { signup_country: string; count: string }[];
-    return rows.map((row) => ({
-      country: row.signup_country,
-      count: Number(row.count),
-    }));
+    return capSignupCountries(
+      rows.map((row) => ({
+        country: row.signup_country,
+        count: Number(row.count),
+      }))
+    );
   }
 }

--- a/web/src/pages/OpsPage/PerformanceTab.tsx
+++ b/web/src/pages/OpsPage/PerformanceTab.tsx
@@ -176,7 +176,10 @@ const renderSlowestJobs = (
   );
 };
 
-const renderCountries = (rows: SignupCountryBreakdownItem[]) => {
+const renderCountries = (
+  rows: SignupCountryBreakdownItem[],
+  othersCount: number
+) => {
   if (rows.length === 0) {
     return (
       <p className={styles.emptyHint}>
@@ -205,6 +208,15 @@ const renderCountries = (rows: SignupCountryBreakdownItem[]) => {
           </li>
         );
       })}
+      {othersCount > 0 && (
+        <li className={styles.statusRow}>
+          <span className={`${styles.statusLabel} ${styles.numericMuted}`}>
+            +{othersCount} others
+          </span>
+          <span className={styles.statusBarWrap} />
+          <span className={styles.numericMuted}>—</span>
+        </li>
+      )}
     </ul>
   );
 };
@@ -284,8 +296,13 @@ export default function PerformanceTab() {
           isLoading={isInitial}
           isEmpty={(data?.signup_countries_7d.length ?? 0) === 0}
           emptyText="No countries captured yet."
+          autoHeight
         >
-          {data != null && renderCountries(data.signup_countries_7d)}
+          {data != null &&
+            renderCountries(
+              data.signup_countries_7d,
+              data.signup_countries_7d_others ?? 0
+            )}
         </ChartPanel>
       </div>
     </>

--- a/web/src/pages/OpsPage/performanceTypes.ts
+++ b/web/src/pages/OpsPage/performanceTypes.ts
@@ -30,4 +30,5 @@ export interface PerformanceMetricsResponse {
   status_breakdown_24h: JobStatusBreakdown[];
   slowest_jobs_24h: SlowJob[];
   signup_countries_7d: SignupCountryBreakdownItem[];
+  signup_countries_7d_others?: number;
 }


### PR DESCRIPTION
## What

The "Signup countries, last 7d" panel on `/ops/system` overflowed its fixed-height card — the server returned every country with ≥1 signup (30–40 rows) and the panel had no `autoHeight`. Fixes #4050.

- Server caps the list at 10 (`SIGNUP_COUNTRIES_PANEL_LIMIT`, mirroring the Business tab's `SIGNUP_COUNTRIES_LIMIT`) and returns the tail summed as `signup_countries_7d_others`.
- The panel renders the same muted `+N others` row `SignupCountriesChart` already ships, and gets `autoHeight` like the "Slowest 20 jobs" panel.

## Tests

- New unit tests for `capSignupCountries` (cap + remainder sum; under-limit passthrough). 6/6 service tests pass.
- OpsPage web tests 206/206; server tsc, web typecheck, `pnpm format:check` clean.

No changelog entry — internal ops surface only.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: machine-backed via `pnpm --filter 2anki-web test:golden-path` (2 passed). The others-row markup is an exact mirror of the shipped `SignupCountriesChart` pattern on an auth-gated ops tab; not separately exercised in a browser.

Sonar: not run locally; gating merge on the PR analysis instead.
