### PR TITLE
fix: stamp signup_origin onto server-emitted funnel events

### DIFF
--- a/src/data_layer/UsersRepository.ts
+++ b/src/data_layer/UsersRepository.ts
@@ -457,6 +457,20 @@ class UsersRepository {
     }));
   }
 
+  async getSignupOriginsByIds(
+    userIds: number[]
+  ): Promise<Map<number, string | null>> {
+    if (userIds.length === 0) return new Map();
+    const rows = (await this.database(this.table)
+      .whereIn('id', userIds)
+      .whereNotNull('signup_origin')
+      .select('id', 'signup_origin')) as {
+      id: number;
+      signup_origin: string;
+    }[];
+    return new Map(rows.map((row) => [Number(row.id), row.signup_origin]));
+  }
+
   markOnboarded(id: string | number) {
     return this.database(this.table)
       .where({ id })

--- a/src/services/events/EventsSink.test.ts
+++ b/src/services/events/EventsSink.test.ts
@@ -133,4 +133,69 @@ describe('EventsSink', () => {
       clearIntervalSpy.mockRestore();
     }
   });
+
+  describe('signup_origin enrichment', () => {
+    it('stamps signup_origin from the resolver onto rows with a user and no origin', async () => {
+      const { repo, inserted } = makeFakeRepository();
+      const resolver = jest.fn().mockResolvedValue(new Map([[1, '/nclex']]));
+      const sink = new EventsSink(repo, {
+        flushThreshold: 1,
+        signupOriginResolver: resolver,
+      });
+
+      sink.record({ ...baseRow, name: 'checkout_completed' });
+      await sink.waitForPendingFlush();
+
+      expect(resolver).toHaveBeenCalledWith([1]);
+      expect(inserted[0][0].props).toEqual({
+        source: 'upload',
+        signup_origin: '/nclex',
+      });
+    });
+
+    it('never overrides an origin the event already carries', async () => {
+      const { repo, inserted } = makeFakeRepository();
+      const resolver = jest.fn().mockResolvedValue(new Map([[1, '/nclex']]));
+      const sink = new EventsSink(repo, {
+        flushThreshold: 1,
+        signupOriginResolver: resolver,
+      });
+
+      sink.record({ ...baseRow, props: { signup_origin: '/mcat' } });
+      await sink.waitForPendingFlush();
+
+      expect(resolver).not.toHaveBeenCalled();
+      expect(inserted[0][0].props).toEqual({ signup_origin: '/mcat' });
+    });
+
+    it('leaves anonymous rows untouched and skips the resolver', async () => {
+      const { repo, inserted } = makeFakeRepository();
+      const resolver = jest.fn().mockResolvedValue(new Map());
+      const sink = new EventsSink(repo, {
+        flushThreshold: 1,
+        signupOriginResolver: resolver,
+      });
+
+      sink.record({ ...baseRow, user_id: null, anonymous_id: 'anon-1' });
+      await sink.waitForPendingFlush();
+
+      expect(resolver).not.toHaveBeenCalled();
+      expect(inserted[0][0].props).toEqual({ source: 'upload' });
+    });
+
+    it('still inserts unenriched rows when the resolver fails', async () => {
+      const { repo, inserted } = makeFakeRepository();
+      const resolver = jest.fn().mockRejectedValue(new Error('db down'));
+      const sink = new EventsSink(repo, {
+        flushThreshold: 1,
+        signupOriginResolver: resolver,
+      });
+
+      sink.record(baseRow);
+      await sink.waitForPendingFlush();
+
+      expect(inserted).toHaveLength(1);
+      expect(inserted[0][0].props).toEqual({ source: 'upload' });
+    });
+  });
 });

--- a/src/services/events/EventsSink.ts
+++ b/src/services/events/EventsSink.ts
@@ -3,6 +3,15 @@ import { IEventsRepository, EventRow } from '../../data_layer/EventsRepository';
 export const EVENTS_FLUSH_THRESHOLD = 100;
 export const EVENTS_FLUSH_INTERVAL_MS = 5000;
 
+// Looks up users.signup_origin for a batch of user ids. Wired at the instance
+// level so server-emitted funnel events (Stripe webhook checkout_completed,
+// worker paywall_shown) attribute to a landing page instead of the null
+// bucket (#4051) — browser events already carry the origin from the
+// first_touch cookie and are left untouched.
+export type SignupOriginResolver = (
+  userIds: number[]
+) => Promise<Map<number, string | null>>;
+
 export class EventsSink {
   private buffer: EventRow[] = [];
 
@@ -15,6 +24,7 @@ export class EventsSink {
     private readonly options: {
       flushThreshold?: number;
       flushIntervalMs?: number;
+      signupOriginResolver?: SignupOriginResolver;
     } = {}
   ) {}
 
@@ -43,9 +53,35 @@ export class EventsSink {
     const rows = this.buffer;
     this.buffer = [];
     if (rows.length === 0) return;
+    await this.enrichSignupOrigins(rows);
     await this.repository.insertEvents(rows).catch((error) => {
       console.error(`[events] dropping ${rows.length} event(s):`, error);
     });
+  }
+
+  private async enrichSignupOrigins(rows: EventRow[]): Promise<void> {
+    const resolver = this.options.signupOriginResolver;
+    if (resolver == null) return;
+    const needing = rows.filter(
+      (row) =>
+        row.user_id != null &&
+        (row.props as Record<string, unknown>)?.signup_origin == null
+    );
+    if (needing.length === 0) return;
+    const userIds = [...new Set(needing.map((row) => Number(row.user_id)))];
+    let origins: Map<number, string | null>;
+    try {
+      origins = await resolver(userIds);
+    } catch (error) {
+      console.error('[events] signup_origin enrichment failed:', error);
+      return;
+    }
+    for (const row of needing) {
+      const origin = origins.get(Number(row.user_id));
+      if (origin != null) {
+        row.props = { ...row.props, signup_origin: origin };
+      }
+    }
   }
 
   waitForPendingFlush(): Promise<void> {

--- a/src/services/events/eventsSinkInstance.ts
+++ b/src/services/events/eventsSinkInstance.ts
@@ -1,12 +1,17 @@
 import { EventsSink } from './EventsSink';
 import { EventsRepository } from '../../data_layer/EventsRepository';
+import UsersRepository from '../../data_layer/UsersRepository';
 import { getDatabase } from '../../data_layer';
 
 let sink: EventsSink | null = null;
 
 export const getEventsSink = (): EventsSink => {
   if (sink == null) {
-    sink = new EventsSink(new EventsRepository(getDatabase()));
+    const usersRepository = new UsersRepository(getDatabase());
+    sink = new EventsSink(new EventsRepository(getDatabase()), {
+      signupOriginResolver: (userIds) =>
+        usersRepository.getSignupOriginsByIds(userIds),
+    });
     sink.start();
   }
   return sink;


### PR DESCRIPTION
## What

Server-emitted funnel events (`checkout_completed` from the Stripe webhook, worker-side `paywall_shown`) carried no `signup_origin` — they have no request cookie — so paid conversions all grouped under the `null` origin and download→paid per landing page was unreadable. Fixes #4051.

`users.signup_origin` already exists and is populated at signup, so no migration: the events sink now batch-looks it up at flush time for rows that have a `user_id` and no origin, and stamps it into props.

- One batched query per flush (flushes are ≤1 per 5s), only when eligible rows exist.
- A cookie-supplied `signup_origin` is never overridden (matches the controller's existing precedence).
- Anonymous rows are untouched — origin for those is only knowable browser-side, which the first_touch cookie path already handles.
- Bonus: logged-in users whose first_touch cookie has expired (old accounts, new devices) now attribute correctly too, since enrichment applies to any user-attached row missing an origin.
- Resolver failure degrades to unenriched inserts — events are never dropped for attribution.

## Tests

- 4 new sink tests: stamps origin; never overrides; skips anonymous rows (resolver not called); inserts unenriched on resolver failure. 15/15 events tests pass.
- Full server suite: 674/675 suites — only the documented environmental `getPageCount` (pdfinfo) failure. tsc + `pnpm format:check` clean.

No changelog entry — internal analytics attribution, no user-visible behavior change.

Sonar: not run locally; gating merge on the PR analysis instead.
