### PR TITLE
fix: let forced-MCQ chat turns clarify instead of emitting a quiz card

### DIFF
--- a/src/usecases/chat/ChatUseCase.test.ts
+++ b/src/usecases/chat/ChatUseCase.test.ts
@@ -1031,11 +1031,42 @@ describe('ChatUseCase', () => {
       const callArg = anthropic.messages.stream.mock.calls[0][0];
       expect(callArg.tools).toEqual([
         expect.objectContaining({ name: 'emit_mcq_cards' }),
+        expect.objectContaining({ name: 'reply_without_cards' }),
       ]);
-      expect(callArg.tool_choice).toEqual({
-        type: 'tool',
-        name: 'emit_mcq_cards',
+      expect(callArg.tool_choice).toEqual({ type: 'any' });
+    });
+
+    it('surfaces a reply_without_cards clarification as a normal reply', async () => {
+      const { messagesRepo, useCase } = buildUseCaseWithBlocks([
+        {
+          type: 'tool_use',
+          name: 'reply_without_cards',
+          input: {
+            message:
+              'Your file did not come through — attach it again and I will make the quiz.',
+          },
+        },
+      ]);
+
+      const result = await useCase.execute({
+        user: FREE_USER,
+        content: 'make a quiz from my file',
+        conversationHistory: [],
+        templateSlug: 'mcq',
       });
+
+      expect(result.cards).toBeUndefined();
+      expect(result.content).toBe(
+        'Your file did not come through — attach it again and I will make the quiz.'
+      );
+      const persisted = await messagesRepo.listForConversation({
+        userId: FREE_USER.owner,
+        conversationId: result.conversationId,
+      });
+      const assistantTurn = persisted.find((m) => m.role === 'assistant');
+      expect(assistantTurn?.content).toBe(
+        'Your file did not come through — attach it again and I will make the quiz.'
+      );
     });
 
     it('raises max_tokens on the MCQ tool path so structured output is not truncated', async () => {

--- a/src/usecases/chat/ChatUseCase.ts
+++ b/src/usecases/chat/ChatUseCase.ts
@@ -82,6 +82,29 @@ const MCQ_TOOL: Anthropic.Tool = {
   },
 };
 
+const CLARIFY_TOOL_NAME = 'reply_without_cards';
+
+// With the MCQ tool forced outright, a turn that cannot produce cards (missing
+// attachment, ambiguous request) had no channel except a quiz card — prod
+// showed a 1-card MCQ asking the user how to proceed (#4056). tool_choice
+// "any" plus this escape tool keeps the structured-output guarantee for real
+// card turns while letting the model answer like a person when it has to.
+const CLARIFY_TOOL: Anthropic.Tool = {
+  name: CLARIFY_TOOL_NAME,
+  description:
+    'Use ONLY when you cannot produce the requested multiple-choice cards this turn — for example a referenced file is missing or the request needs clarification. The message is shown to the user as a normal chat reply. Never use this to deliver card content.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      message: {
+        type: 'string',
+        description: 'The short reply shown to the user',
+      },
+    },
+    required: ['message'],
+  },
+};
+
 const FREE_MONTHLY_LIMIT = 20;
 const MODEL = 'claude-sonnet-5';
 const MAX_HISTORY_TURNS = 10;
@@ -512,6 +535,23 @@ export function extractMcqCardsFromToolUse(
   return cards.length > 0 ? cards : undefined;
 }
 
+export function extractClarifyMessageFromToolUse(
+  content: Anthropic.ContentBlock[]
+): string | undefined {
+  const toolBlock = content.find(
+    (block): block is Anthropic.ToolUseBlock =>
+      block.type === 'tool_use' && block.name === CLARIFY_TOOL_NAME
+  );
+  if (toolBlock == null) return undefined;
+  const input = toolBlock.input;
+  if (input == null || typeof input !== 'object') return undefined;
+  const message = (input as Record<string, unknown>).message;
+  if (typeof message !== 'string' || message.trim().length === 0) {
+    return undefined;
+  }
+  return message.trim();
+}
+
 export class ChatUseCase {
   constructor(
     private readonly messagesRepo: IChatMessagesRepository,
@@ -714,8 +754,8 @@ export class ChatUseCase {
       messages,
       ...(mcqForced
         ? {
-            tools: [MCQ_TOOL],
-            tool_choice: { type: 'tool', name: MCQ_TOOL_NAME },
+            tools: [MCQ_TOOL, CLARIFY_TOOL],
+            tool_choice: { type: 'any' },
           }
         : {}),
     });
@@ -735,6 +775,17 @@ export class ChatUseCase {
     if (mcqForced) {
       const mcqCards = extractMcqCardsFromToolUse(finalMessage.content);
       if (mcqCards == null) {
+        const clarification = extractClarifyMessageFromToolUse(
+          finalMessage.content
+        );
+        if (clarification != null) {
+          await this.persistAssistantTurn(
+            user.owner,
+            conversationId,
+            clarification
+          );
+          return { content: clarification, conversationId };
+        }
         throw new McqExtractionFailedError();
       }
       const persistedContent = embedMcqCardsAsJsonBlock(

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-11-chat-mcq-clarifications.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-11-chat-mcq-clarifications.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-11-chat-mcq-clarifications",
+  "date": "2026-08-11",
+  "type": "fix",
+  "title": "Chat answers in plain words instead of a quiz card when it needs to ask you something"
+}


### PR DESCRIPTION
## What

With the Multiple choice note type selected, the MCQ tool was forced outright (`tool_choice: {type:'tool'}`), so a turn that couldn't produce cards — missing attachment, ambiguous request — had no channel except a quiz card. Prod showed a 1-card MCQ asking the user how to proceed. Fixes #4056.

Now the MCQ path sends `tool_choice: {type:'any'}` with two tools: `emit_mcq_cards` (unchanged) and a `reply_without_cards` escape whose `message` is surfaced and persisted as a normal assistant reply. Structured output stays guaranteed for real card turns; clarifications read like a person wrote them.

## Decisions made overnight (please review)

- Escape mechanism: chose a second tool + `tool_choice: any` over `tool_choice: auto` + prompt steering — `any` still forces structured output (no risk of the model writing cards as prose), while `auto` would reopen the prose-cards failure the forced tool was added to prevent. Assumption: the tool description ("use ONLY when you cannot produce cards") is enough steering; if quiz turns start coming back as text replies, tighten the description or add a system-prompt line.
- Tool name: `reply_without_cards`. Rename if you prefer.
- When neither tool yields usable output, the existing `McqExtractionFailedError` behavior is unchanged.

## Tests

- New: a `reply_without_cards` tool call surfaces and persists as a normal reply with no cards; tool list/choice assertion updated to the new shape.
- Chat suites 192/192 pass; server tsc + `pnpm format:check` clean.

Changelog entry included (user-visible fix).

Sonar: not run locally; gating merge on the PR analysis instead.
