### PR TITLE
fix: carry extracted PDF figures into decks built on the batch path

### DIFF
--- a/src/infrastracture/adapters/fileConversion/PrepareDeck.test.ts
+++ b/src/infrastracture/adapters/fileConversion/PrepareDeck.test.ts
@@ -799,3 +799,33 @@ describe('PrepareDeck — AI media matching (#3946)', () => {
     expect(mediaArg.some((m: string) => m.endsWith('.png'))).toBe(true);
   });
 });
+
+describe('assembleParserFiles — both build paths share one file set', () => {
+  const { assembleParserFiles } = require('./PrepareDeck');
+
+  it('includes originals, converted HTML, and extracted figure images', () => {
+    const original = { name: 'notes.pdf', contents: Buffer.from('%PDF') };
+    const figure = { name: 'figure-1.png', contents: Buffer.from('png') };
+    const converted = {
+      name: 'notes.pdf.html',
+      contents: Buffer.from('<p>card</p>'),
+      extraFiles: [figure],
+    };
+
+    const all = assembleParserFiles([original], [converted]);
+
+    expect(all.map((f: { name: string }) => f.name)).toEqual([
+      'notes.pdf',
+      'notes.pdf.html',
+      'figure-1.png',
+    ]);
+  });
+
+  it('handles converters that extracted nothing', () => {
+    const original = { name: 'page.html', contents: Buffer.from('<p></p>') };
+
+    const all = assembleParserFiles([original], []);
+
+    expect(all).toEqual([original]);
+  });
+});

--- a/src/infrastracture/adapters/fileConversion/PrepareDeck.ts
+++ b/src/infrastracture/adapters/fileConversion/PrepareDeck.ts
@@ -395,6 +395,18 @@ async function convertPdfByAutoDetection(
   return convertPdfPagesToImagesFile(file, input);
 }
 
+// Both build paths must hand the parser the same file set: the originals, the
+// converted HTML, and any figure images the converters extracted (extraFiles).
+// The batched zip path once dropped the extracted images, so PDF figures went
+// missing from decks only when the upload was large enough to batch (#4054).
+export function assembleParserFiles(
+  files: DeckParserInput['files'],
+  convertedFiles: ConvertedFile[]
+): DeckParserInput['files'] {
+  const extractedImages = convertedFiles.flatMap((f) => f.extraFiles ?? []);
+  return [...files, ...convertedFiles, ...extractedImages];
+}
+
 function deckPrefixFromFilePath(htmlFileName: string): string {
   const normalized = htmlFileName.replaceAll('\\', '/');
   const lastSlash = normalized.lastIndexOf('/');
@@ -443,8 +455,7 @@ export async function PrepareDeck(
     convertedFiles.filter((f) => f.imageFallback).map((f) => f.name)
   );
 
-  const extractedPdfImages = convertedFiles.flatMap((f) => f.extraFiles ?? []);
-  const allFiles = [...files, ...convertedFiles, ...extractedPdfImages];
+  const allFiles = assembleParserFiles(files, convertedFiles);
 
   if (input.settings.claudeAIFlashcards && input.noLimits) {
     console.log('[PrepareDeck] Claude branch: collecting HTML content');
@@ -705,7 +716,7 @@ export async function prepareDeckInfoOnly(
     (file) => convertFile(file, input)
   );
   const convertedFiles = results.flatMap((r) => (r ? [r] : []));
-  const allFiles = [...files, ...convertedFiles];
+  const allFiles = assembleParserFiles(files, convertedFiles);
 
   const parser = new DeckParser({ ...input, files: allFiles });
 

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-11-pdf-figures-in-large-zips.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-11-pdf-figures-in-large-zips.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-11-pdf-figures-in-large-zips",
+  "date": "2026-08-11",
+  "type": "fix",
+  "title": "PDF figure images stay in your deck when they arrive inside a large zip"
+}


### PR DESCRIPTION
## What

Could not reproduce the exact report (anonymous emoji feedback, no file details), but code reading found a real divergence matching the symptom: `PrepareDeck` hands the parser originals + converted HTML + any figure images the converters extracted (`extraFiles`), while `prepareDeckInfoOnly` — the batched zip path — dropped the extracted images. PDF figure images silently vanished from decks exactly when the upload was big enough to batch (more files than the python cap). Fixes #4054 — please confirm against a real report if one lands with file details.

Both build paths now assemble the parser file set through one shared `assembleParserFiles` helper, so they can't drift apart again.

## Other repro directions from the issue, checked

- Notion export zip with an images folder: the extraction path (`getRelevantFiles` + workspace media) handles it; no defect found.
- Re-zipped folders with `__MACOSX`/`.DS_Store`: server strips both; additionally #4072 (folder drop) now builds clean zips client-side for the macOS auto-unzip case this issue pairs with.
- Remote (expired Notion S3) images: already covered by the expired-image notice shipped in #4022.

## Tests

- New unit tests for `assembleParserFiles` (figures included in order; empty converter case). PrepareDeck suite 30/30.
- Full server suite: 6368 pass — only the documented environmental `getPageCount` (pdfinfo) failure. tsc + `pnpm format:check` clean.

Changelog entry included.

Sonar: not run locally; gating merge on the PR analysis instead.
