### PR TITLE
fix: keep the typed name when saving a note type as a copy

### DIFF
--- a/web/src/pages/TemplatesPage/EditorPage.tsx
+++ b/web/src/pages/TemplatesPage/EditorPage.tsx
@@ -341,7 +341,9 @@ function EditorBody({ initialStarter, shouldFork }: Readonly<EditorBodyProps>) {
     setSaving(true);
     setSaveError(null);
     try {
-      const starterToSave = shouldFork ? duplicateStarter(draft) : draft;
+      const starterToSave = shouldFork
+        ? duplicateStarter(draft, initialStarter.name)
+        : draft;
       await saveUserTemplate(starterToSave);
       setSavedAt(Date.now());
       if (starterToSave.id !== draft.id) {

--- a/web/src/pages/TemplatesPage/lib/buildNoteType.test.ts
+++ b/web/src/pages/TemplatesPage/lib/buildNoteType.test.ts
@@ -47,4 +47,17 @@ describe('duplicateStarter', () => {
     copy.noteType.tmpls[0].qfmt = 'mutated';
     expect(original.noteType.tmpls[0].qfmt).not.toBe('mutated');
   });
+
+  it('keeps a custom name when the draft was renamed from its source', () => {
+    const original = buildEmptyNoteType('basic');
+    const renamed = { ...original, name: 'Alex Super Clean Basic' };
+    const copy = duplicateStarter(renamed, original.name);
+    expect(copy.name).toBe('Alex Super Clean Basic');
+  });
+
+  it('appends (copy) when the draft name matches its source', () => {
+    const original = buildEmptyNoteType('basic');
+    const copy = duplicateStarter(original, original.name);
+    expect(copy.name).toBe(`${original.name} (copy)`);
+  });
 });

--- a/web/src/pages/TemplatesPage/lib/buildNoteType.ts
+++ b/web/src/pages/TemplatesPage/lib/buildNoteType.ts
@@ -109,11 +109,15 @@ export function buildEmptyNoteType(baseType: BaseType): NoteTypeStarter {
   };
 }
 
-export function duplicateStarter(starter: NoteTypeStarter): NoteTypeStarter {
+export function duplicateStarter(
+  starter: NoteTypeStarter,
+  sourceName: string = starter.name
+): NoteTypeStarter {
+  const renamed = starter.name.trim() !== sourceName.trim();
   return {
     ...starter,
     id: randomId(),
-    name: `${starter.name} (copy)`,
+    name: renamed ? starter.name : `${starter.name} (copy)`,
     noteType: {
       ...starter.noteType,
       tmpls: starter.noteType.tmpls.map((t) => ({ ...t })),

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-13-note-type-copy-name.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-13-note-type-copy-name.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-13-note-type-copy-name",
+  "date": "2026-08-13",
+  "type": "fix",
+  "title": "Saving a note type as a copy keeps the name you typed instead of adding (copy)"
+}


### PR DESCRIPTION
## Summary
Editing a preset note type you don't own forks it on save ("Save as copy"). The fork helper appended ` (copy)` to whatever name the draft had — including a custom name typed before the first save ("Alex Super Clean Basic" became "Alex Super Clean Basic (copy)").

`duplicateStarter` now takes the source template's name and appends ` (copy)` only when the draft name still matches it. A renamed draft keeps its name verbatim. The preset-picker path (new template from a preset) is unchanged — the name there always matches the source, so it still gets the suffix.

## Test plan
- New Vitest cases in `buildNoteType.test.ts`: renamed draft keeps its name; unchanged name still gets ` (copy)`. Watched the renamed-draft case fail on the old code first.
- Full web suite: 2841 passed, 1 failed pre-fix (the new case); scoped rerun post-fix green (21/21 across buildNoteType + EditorPage).
- `pnpm format:check`, web `typecheck`, web `lint` clean.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: verified via `pnpm --filter 2anki-web test:golden-path` (2 passed, 375px viewport, zero console errors). The fork-save rename scenario itself is covered by the new unit tests.

## Changelog
`2026-08-13-note-type-copy-name.json` included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)