### PR TITLE
fix: run the main deck conversion on Claude Sonnet 5

### DIFF
--- a/src/lib/claude/ClaudeService.ts
+++ b/src/lib/claude/ClaudeService.ts
@@ -798,7 +798,7 @@ async function generateDeckInfoFromChunk(
   onProgress?.(`claude:chunk:${chunkIndex + 1}:${totalChunks}`);
 
   console.log('[Claude] Sending request to Claude API', {
-    model: 'claude-sonnet-4-5',
+    model: 'claude-sonnet-5',
     promptBytes: userMessage.length,
     maxTokens: CHUNK_MAX_TOKENS,
     mediaFilesCount: availableMediaFiles.length,
@@ -811,7 +811,7 @@ async function generateDeckInfoFromChunk(
   const runStream = async (): Promise<Message> => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const stream = (client.messages as any).stream({
-      model: 'claude-sonnet-4-5',
+      model: 'claude-sonnet-5',
       max_tokens: CHUNK_MAX_TOKENS,
       system: [
         {


### PR DESCRIPTION
## Why

https://github.com/2anki/server/pull/4033 moved the vision and file-conversion paths to Claude Sonnet 5 and shipped a changelog entry claiming AI conversions run on it — but the highest-volume path, the chunked deck builder in `ClaudeService.ts` (the `claude-ai-flashcards` upload option and the zero-card rescue), stayed pinned to `claude-sonnet-4-5`. This completes the announced switch.

## What

Two-line change: the model string in the chunk stream call and its request log.

## Safety

- Request shape matches what #4033 smoke-tested live against `claude-sonnet-5`: system block with `cache_control`, no sampling params, no `budget_tokens`, no last-assistant-turn prefill.
- Sonnet 5 runs adaptive thinking inside `max_tokens`; `CHUNK_MAX_TOKENS` is already 16384 and the truncated-chunk halving retry (`runChunkWithTruncationRetry`) covers residual truncation risk.
- `ClaudeService.test.ts`: 124 passed. `tsc -p . --noEmit` clean.

No changelog entry — the user-facing announcement already shipped with #4033 (`2026-08-09-sonnet-5-conversions.json`); this PR makes that entry true for the main path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)