### PR TITLE
docs: add the five missing German docs pages behind a parity test

### DIFF
--- a/web/src/pages/DocsPage/content-parity.test.ts
+++ b/web/src/pages/DocsPage/content-parity.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+const english = import.meta.glob(
+  ['./content/**/*.{md,mdx}', '!./content/de/**'],
+  {
+    query: '?raw',
+    import: 'default',
+    eager: true,
+  }
+) as Record<string, string>;
+
+const german = import.meta.glob('./content/de/**/*.{md,mdx}', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>;
+
+// Pages that intentionally stay English-only. Legal docs need legal review
+// before translation (.claude/docs/i18n.md); the docs home falls back per-file.
+const ENGLISH_ONLY = new Set([
+  'index.mdx',
+  'reference/privacy.md',
+  'reference/terms.md',
+]);
+
+const englishPaths = Object.keys(english).map((p) =>
+  p.replace('./content/', '')
+);
+const germanPaths = new Set(
+  Object.keys(german).map((p) => p.replace('./content/de/', ''))
+);
+
+describe('German docs mirror', () => {
+  it('has a German page for every English page outside the allowlist', () => {
+    const missing = englishPaths.filter(
+      (p) => !ENGLISH_ONLY.has(p) && !germanPaths.has(p)
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it('has no German page without an English source', () => {
+    const englishSet = new Set(englishPaths);
+    const orphaned = [...germanPaths].filter((p) => !englishSet.has(p));
+    expect(orphaned).toEqual([]);
+  });
+});

--- a/web/src/pages/DocsPage/content/de/cards/duplicate-cards.md
+++ b/web/src/pages/DocsPage/content/de/cards/duplicate-cards.md
@@ -1,0 +1,67 @@
+---
+title: Deck aktualisieren, Lernfortschritt behalten
+description: Warum erneutes Hochladen früher doppelte Karten erzeugte, was jede Karte stabil hält, und wie du vorhandene Kopien loswirst.
+---
+
+Bearbeite eine Notion-Seite, konvertiere sie erneut, und 2anki aktualisiert deine bestehenden Notion-Karten, statt dir eine zweite Kopie zu geben. Jede Karte trägt eine versteckte ID, und Anki nutzt diese ID, um eine bekannte Karte von einer neuen zu unterscheiden. Diese Seite erklärt, was diese ID setzt, was sie stabil hält, und was du tun kannst, wenn du bereits Duplikate hast.
+
+Du hast schon Duplikate? [Direkt zum Aufräumen](#vorhandene-duplikate-aufräumen).
+
+## Warum du jede Karte doppelt hattest
+
+Karten wurden früher über ihren Text identifiziert. Ein einziges geändertes Wort, ein anderer Deck-Name oder eine geänderte Karten-Option, und die ID änderte sich mit. Auch dass Notion sein Exportformat stillschweigend geändert hat — passiert im Juli — hatte denselben Effekt. Anki las die geänderten Karten als brandneu und legte sie neben die Originale. So wurde aus einer kleinen Änderung eine komplette zweite Kopie des Decks.
+
+Wenn du angemeldet bist, werden Karten aus Notion an dem Notion-Block verankert, aus dem sie stammen — der driftet nicht — und 2anki merkt sich diesen Anker unter deinem Konto. Ein Deck umzubenennen oder Optionen zu ändern berührt ihre Identität nicht mehr. Nur wirklich neuer Inhalt erzeugt neue Karten.
+
+Du hast noch ein verdoppeltes Deck aus dem Juli? Räum es einmal auf (siehe unten), dann bleibt es sauber. Angemeldet kommen keine neuen Duplikate dazu, weil deine Karten bereits zu dem passen, was du importiert hast. Abgemeldet kann eine spätere Formatänderung von Notion ein Deck noch einmal aufspalten — dann einmal mehr aufräumen.
+
+## Woran 2anki erkennt, dass eine Karte dieselbe ist
+
+Melde dich vor dem Konvertieren an, dann merkt sich 2anki die ID jeder Karte unter deinem Konto — erneute Uploads landen auf denselben Karten, auch über Umbenennungen und Notion-Formatänderungen hinweg.
+
+- **Angemeldet, Notion-Toggle-Uploads**: 2anki merkt sich die ID jeder Karte unter deinem Konto, verankert am Notion-Block, aus dem sie stammt (siehe Tabelle unten). Benenne das Deck um, formuliere eine Karte um oder exportiere nach einer Notion-Formatänderung neu — dein Lernfortschritt bleibt erhalten.
+- **Abgemeldet, oder Karten ohne Notion-Block** (einfacher Text auf einer Seite, Markdown, CSV, Tabellen): Karten werden über den Deck-Namen und die Vorderseite identifiziert. Lass den Deck-Namen beim erneuten Hochladen gleich, und beachte: eine umformulierte Karte sieht Anki als neue. Lösch dann die alte Kopie.
+- **Synchronisierte Notion-Seiten**: hier ändert sich nichts. Sync läuft immer unter deinem Konto und merkt sich jede Karte über ihren Notion-Block. Ändere den Text beliebig — dein Lernfortschritt bleibt.
+
+## Was einen Notion-Toggle stabil hält
+
+Notion gibt jedem Block eine eigene ID. Manche Aktionen behalten diese ID; einige ersetzen sie durch eine neue. Ist die ID neu, kann nichts 2anki sagen, dass es dieselbe Karte ist — Anki sieht eine neue Karte. Das ist Notions Verhalten, nicht etwas, das 2anki steuert.
+
+| In Notion …                                         | Die ID des Toggles   | In Anki bekommst du                                                                      |
+| --------------------------------------------------- | -------------------- | ---------------------------------------------------------------------------------------- |
+| Überschrift oder Inhalt direkt bearbeiten           | Bleibt gleich        | Die Karte wird aktualisiert, Lernfortschritt bleibt                                      |
+| Auf der Seite ziehen oder umsortieren               | Bleibt gleich        | Keine Änderung                                                                           |
+| Unter einen anderen Toggle einrücken oder ausrücken | Bleibt gleich        | Wird je nach Karten-Optionen eventuell eine eigene Karte — oder nicht mehr               |
+| Ausschneiden und woanders einfügen                  | Wird neu             | Eine neue Karte. Die alte bleibt                                                         |
+| Den Block duplizieren                               | Wird neu             | Eine neue Karte                                                                          |
+| Auf eine andere Seite kopieren                      | Wird neu             | Eine neue Karte                                                                          |
+| Löschen                                             | Existiert nicht mehr | Die Karte fehlt bei der nächsten Konvertierung; entferne sie in Anki, wenn du sie siehst |
+
+Wenn du einen Toggle per Ausschneiden-und-Einfügen verschoben hast und jetzt ein Duplikat siehst — das ist der Grund. Um einen Toggle ohne neue Karte zu verschieben, zieh ihn stattdessen.
+
+## Und das Deck selbst?
+
+Anki ordnet Decks über den Namen zu, so wie Karten über die ID. Ändert sich der Name des Decks — weil die Seite umbenannt wurde oder sich ihr Emoji geändert hat — legt der nächste Import ein frisches Deck mit dem neuen Namen an. Deine bestehenden Karten bleiben, wo sie sind; nur neue Karten landen im frischen Deck. Im Juli hat eine Notion-Exportänderung kurzzeitig dazu geführt, dass 2anki das Emoji von selbst aus Deck-Namen entfernt hat — genau dieser Fall. Der Fehler ist behoben; Deck-Namen behalten ihr Emoji wieder. Passiert es aus einem anderen Grund, benenne das Deck in Anki vor dem Import auf den neuen Namen um, oder zieh die Streuner hinterher rüber und lösch das leere Deck.
+
+## Ein Workflow für saubere Updates
+
+- **Direkt bearbeiten.** Ändere den Text im Toggle, statt ihn zu löschen und neu zu schreiben.
+- **Per Ziehen verschieben**, nicht ausschneiden und einfügen, wenn Karte und Lernfortschritt erhalten bleiben sollen.
+- **Bei Nicht-Notion-Dateien den Deck-Namen stabil halten** und damit rechnen, dass eine umformulierte Vorderseite als neue Karte ankommt.
+- **Notion-Decks frei umbenennen und Optionen ändern.** Beides berührt die Identität dieser Karten nicht mehr.
+- **Mit Ankis Standardeinstellungen importieren.** Updates funktionieren ohne besondere Import-Optionen.
+
+## Vorhandene Duplikate aufräumen
+
+Echte Duplikate entstehen auf zwei Wegen: ein Deck, das sich während des Juli-Exportfehlers verdoppelt hat, oder — wenn du abgemeldet konvertierst — ein erneuter Upload, nachdem Notion etwas an der Seite geändert hat. Angemeldet landen Updates auf deinen bestehenden Karten, du sammelst also keine neuen Kopien.
+
+So oder so: Behalten willst du die Kopien mit deinem Lernfortschritt:
+
+1. Öffne in Anki **Browse**.
+2. Wähle das Deck und klick auf die Spalte **Created**, um nach Erstellungsdatum zu sortieren. Rechtsklick auf die Spaltenüberschrift und die Spalte **Reviews** hinzufügen, falls sie fehlt.
+3. Die gerade erstellten Kopien sind die Duplikate. Sie haben **0 Reviews**. Deine Originale sind die älteren, mit deinen echten Review-Zahlen.
+4. Wähle die 0-Review-Kopien aus und lösch sie über **Notes → Delete** in der Menüleiste.
+
+Zukünftige Re-Importe derselben Quelle aktualisieren die behaltenen Karten an Ort und Stelle.
+
+Wenn beide Kopien Lernfortschritt haben, der dir wichtig ist, [melde dich bei uns](/documentation/help/contact), bevor du etwas löschst. Manchmal können wir sie zusammenführen.

--- a/web/src/pages/DocsPage/content/de/reference/mcp.md
+++ b/web/src/pages/DocsPage/content/de/reference/mcp.md
@@ -1,0 +1,33 @@
+---
+title: MCP-Connector
+description: Der gehostete 2anki-MCP-Server — Tools, Limits und Anmeldung.
+---
+
+2anki betreibt einen gehosteten MCP-Server (Model Context Protocol), damit KI-Assistenten Anki-Decks auf deinem Konto bauen können. Einmal verbinden und mitten im Gespräch nach Karteikarten fragen — der Assistent ruft 2anki auf und liefert einen Download-Link für eine fertige `.apkg`.
+
+**Server-URL:** `https://2anki.net/mcp`
+
+Schritt-für-Schritt-Anleitungen für Claude und ChatGPT findest du unter [2anki in Claude oder ChatGPT nutzen](/documentation/start-here/use-in-claude). Der Connector steht jedem angemeldeten Konto offen — keine Freischaltung nötig.
+
+## Tools
+
+| Tool                | Was es macht                                                                     |
+| ------------------- | -------------------------------------------------------------------------------- |
+| `convert_to_deck`   | Text, Markdown, CSV/TSV oder eine URL in ein fertiges Deck verwandeln            |
+| `create_deck`       | Ein Deck aus strukturierten Karten bauen — Subdecks über ein Deck-Feld pro Karte |
+| `photo_to_deck`     | Ein Foto von Notizen, einer Buchseite oder einer Folie in Karten verwandeln      |
+| `get_deck_preview`  | Die Karten eines Decks vor dem Download anzeigen                                 |
+| `list_my_decks`     | Die Decks auf deinem Konto auflisten                                             |
+| `deck_capabilities` | Verfügbare Notiztypen und Karten-Optionen entdecken                              |
+
+## Anmeldung
+
+Der Server nutzt OAuth 2.1. Beim ersten Verbinden öffnet 2anki eine Anmelde- und Zustimmungsseite; einmal bestätigen, und die Verbindung bleibt bestehen. Du kannst sie jederzeit widerrufen, indem du den Connector in den Einstellungen des Assistenten entfernst.
+
+## Limits
+
+Konvertierungen über MCP zählen gegen dieselben Plan-Limits wie die Web-App: kostenlose Konten haben ein monatliches Kartenlimit und ein Foto-Kontingent; bezahlte Pläne konvertieren ohne Limits. Einzelne Anfragen sind auf 5 MB Text, 500 Karten pro Deck und 10 MB pro Foto begrenzt.
+
+## Feedback
+
+Etwas, das die Tools nicht können? Schreib an [support@2anki.net](mailto:support@2anki.net). Fehler gehören in die [GitHub-Issues](https://github.com/2anki/server/issues).

--- a/web/src/pages/DocsPage/content/de/start-here/use-in-claude.md
+++ b/web/src/pages/DocsPage/content/de/start-here/use-in-claude.md
@@ -1,0 +1,74 @@
+---
+title: 2anki in Claude oder ChatGPT nutzen
+description: Den 2anki-MCP-Server verbinden und Anki-Decks direkt aus einem Gespräch bauen.
+---
+
+2anki läuft als MCP-Connector, sodass ein KI-Assistent deine Anki-Decks für dich bauen kann. Füge Vorlesungsnotizen in ein Gespräch ein, frag nach Karteikarten, und bekomm einen Download-Link für eine fertige `.apkg` — ohne den Chat zu verlassen.
+
+**Der Connector steht jedem angemeldeten Konto offen.** Melde dich auf [2anki.net](https://2anki.net/) an, füge den Connector hinzu und bestätige die Zustimmungsseite einmal. Kostenlose Konten behalten ihr monatliches Kartenlimit; bezahlte Pläne konvertieren ohne Limits.
+
+## Mit Claude verbinden
+
+<ol class="steps">
+<li>
+
+**Connector-Einstellungen öffnen.** Geh in Claude (Web oder Desktop) zu **Settings → Connectors** und wähle **Add custom connector**.
+
+</li>
+<li>
+
+**Den 2anki-Server hinzufügen.** Gib `https://2anki.net/mcp` als URL ein und bestätige.
+
+</li>
+<li>
+
+**Anmelden.** Claude öffnet eine 2anki-Anmelde- und Zustimmungsseite. Einmal bestätigen; die Verbindung bleibt über Gespräche hinweg bestehen.
+
+</li>
+<li>
+
+**Nutzen.** Bitte Claude in einem beliebigen Gespräch um Karteikarten — „mach aus diesen Notizen ein Anki-Deck". Claude ruft 2anki auf und antwortet mit einem Download-Link für die `.apkg`.
+
+</li>
+</ol>
+
+## Mit ChatGPT verbinden
+
+<ol class="steps">
+<li>
+
+**Developer mode aktivieren.** Geh in ChatGPT zu **Settings → Apps & Connectors → Advanced settings** und schalte **Developer mode** ein (setzt einen bezahlten ChatGPT-Plan voraus).
+
+</li>
+<li>
+
+**Den Connector anlegen.** Wähle unter **Apps & Connectors** den Punkt **Create**, gib `https://2anki.net/mcp` als MCP-Server-URL ein und wähle **OAuth** als Anmeldemethode.
+
+</li>
+<li>
+
+**Anmelden.** ChatGPT öffnet die 2anki-Anmelde- und Zustimmungsseite. Einmal bestätigen.
+
+</li>
+<li>
+
+**Nutzen.** Beginne eine Nachricht, füge den 2anki-Connector über das Tool-Menü des Eingabefelds hinzu und frag nach einem Deck.
+
+</li>
+</ol>
+
+## Was der Assistent kann
+
+- Eingefügten Text, Notizen oder eine Dokument-Zusammenfassung in ein fertiges Deck mit Download-Link verwandeln
+- Ein Foto handschriftlicher Notizen, einer Buchseite oder einer Folie in Karten konvertieren
+- Notiztypen (Basic, umgekehrt, Lückentext) und Karten-Optionen wählen, inklusive Subdecks
+- Die Karten eines Decks vor dem Download anzeigen
+- Deine bereits erstellten Decks auflisten
+
+Kostenlose Konten behalten ihr normales monatliches Kartenlimit; bezahlte Pläne konvertieren ohne Limits — dieselben [Pläne und Limits](/documentation/reference/plans) wie in der Web-App.
+
+## Wenn etwas fehlschlägt
+
+- Wenn die Anmeldung in einer Schleife hängt oder der Assistent meldet, dass er sich nicht anmelden kann: Stell sicher, dass du auf [2anki.net](https://2anki.net/) angemeldet bist, und füge den Connector dann erneut hinzu.
+- Wenn die Verbindung nicht mehr funktioniert: Entferne den Connector und füge ihn erneut hinzu, um die Anmeldung neu zu starten.
+- Alles andere: Schreib an [support@2anki.net](mailto:support@2anki.net).


### PR DESCRIPTION
Fixes https://github.com/2anki/server/issues/4060

## Why

The German docs mirror lagged English by five pages — German readers fell back to English for duplicate-cards, mcp, use-in-claude, terms, and privacy. German is the largest non-English segment (~4.5%).

## What

- Translated `cards/duplicate-cards.md`, `reference/mcp.md`, `start-here/use-in-claude.md` into the German mirror — du register, protected strings (Anki, Notion, MCP, `.apkg`, UI button labels, URLs) kept verbatim, matching the existing `de/` pages' conventions.
- New `content-parity.test.ts` asserts every English page has a German mirror (and no orphaned German pages), so the next English page fails CI if it skips the mirror — the enforcement mechanism the issue asked to check for.

## Decisions made overnight (please review)

- **terms.md and privacy.md deliberately NOT translated** — `.claude/docs/i18n.md` forbids translating legal docs without legal review. They're allowlisted in the parity test with a comment pointing at the rule. If you get legal review done, translate them and shrink the allowlist.
- `index.mdx` (docs home) also allowlisted — it has never had a German mirror and the loader falls back per-file; treated as intentional. If wrong, translate it and remove from the allowlist.
- No changelog entry — `docs:` type per the changelog table.

## Verification

- `content-parity.test.ts`, `content-links.test.ts`, `loader.test.ts`: 18 tests green. Tree-wide `pnpm format:check` clean, web typecheck clean.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: verified via `pnpm --filter 2anki-web test:golden-path` on this branch (2 passed). Content-only markdown rendered by the existing docs loader; the links test validates every internal link in the new pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)