### PR TITLE
feat: segment the upload funnel by input format and near-empty decks

### DIFF
--- a/src/lib/analytics/cardCountBucket.test.ts
+++ b/src/lib/analytics/cardCountBucket.test.ts
@@ -1,0 +1,17 @@
+import { toCardCountBucket } from './cardCountBucket';
+
+describe('toCardCountBucket', () => {
+  it('separates near-empty successes from real ones', () => {
+    expect(toCardCountBucket(0)).toBe('<3');
+    expect(toCardCountBucket(1)).toBe('<3');
+    expect(toCardCountBucket(2)).toBe('<3');
+    expect(toCardCountBucket(3)).toBe('3-49');
+  });
+
+  it('buckets the remaining ranges', () => {
+    expect(toCardCountBucket(49)).toBe('3-49');
+    expect(toCardCountBucket(50)).toBe('50-499');
+    expect(toCardCountBucket(499)).toBe('50-499');
+    expect(toCardCountBucket(500)).toBe('500+');
+  });
+});

--- a/src/lib/analytics/cardCountBucket.ts
+++ b/src/lib/analytics/cardCountBucket.ts
@@ -1,0 +1,8 @@
+export type CardCountBucket = '<3' | '3-49' | '50-499' | '500+';
+
+export function toCardCountBucket(count: number): CardCountBucket {
+  if (count < 3) return '<3';
+  if (count < 50) return '3-49';
+  if (count < 500) return '50-499';
+  return '500+';
+}

--- a/src/lib/analytics/uploadInputFormat.test.ts
+++ b/src/lib/analytics/uploadInputFormat.test.ts
@@ -1,0 +1,24 @@
+import { uploadInputFormat } from './uploadInputFormat';
+
+describe('uploadInputFormat', () => {
+  it('returns the lowercased extension of the first file for known formats', () => {
+    expect(uploadInputFormat([{ originalname: 'notes.DOCX' }])).toBe('docx');
+    expect(uploadInputFormat([{ originalname: 'sheet.xlsx' }])).toBe('xlsx');
+    expect(uploadInputFormat([{ originalname: 'deck.pdf' }])).toBe('pdf');
+  });
+
+  it('returns other for unrecognized extensions', () => {
+    expect(uploadInputFormat([{ originalname: 'weird.xyz' }])).toBe('other');
+  });
+
+  it('returns unknown when there is no usable filename', () => {
+    expect(uploadInputFormat(undefined)).toBe('unknown');
+    expect(uploadInputFormat([])).toBe('unknown');
+    expect(uploadInputFormat([{ originalname: 'noextension' }])).toBe(
+      'unknown'
+    );
+    expect(uploadInputFormat([{ originalname: 'trailingdot.' }])).toBe(
+      'unknown'
+    );
+  });
+});

--- a/src/lib/analytics/uploadInputFormat.ts
+++ b/src/lib/analytics/uploadInputFormat.ts
@@ -1,0 +1,46 @@
+// The extension of the first uploaded file, lowercased. A shape metric, never
+// the filename itself — see .claude/rules/support-confidentiality.md.
+//
+// Allowlisted rather than passed through: the value is a cohort key, and an
+// unbounded one lets any upload mint a cohort of size one. Anything unrecognised
+// buckets into 'other' so the cardinality stays fixed.
+const KNOWN_INPUT_FORMATS = new Set([
+  'zip',
+  'html',
+  'htm',
+  'md',
+  'markdown',
+  'csv',
+  'tsv',
+  'xlsx',
+  'xls',
+  'pdf',
+  'docx',
+  'doc',
+  'pptx',
+  'ppt',
+  'txt',
+  'apkg',
+  'opml',
+  'epub',
+  'xml',
+  'json',
+  'png',
+  'jpg',
+  'jpeg',
+  'webp',
+  'gif',
+]);
+
+interface NamedFile {
+  originalname?: string;
+}
+
+export function uploadInputFormat(files: NamedFile[] | undefined): string {
+  const name = files?.[0]?.originalname;
+  if (typeof name !== 'string') return 'unknown';
+  const dot = name.lastIndexOf('.');
+  if (dot < 0 || dot === name.length - 1) return 'unknown';
+  const ext = name.slice(dot + 1).toLowerCase();
+  return KNOWN_INPUT_FORMATS.has(ext) ? ext : 'other';
+}

--- a/src/lib/storage/jobs/helpers/performConversion.ts
+++ b/src/lib/storage/jobs/helpers/performConversion.ts
@@ -40,15 +40,9 @@ import { UnsupportedNotionBlockRepository } from '../../../../data_layer/Unsuppo
 import { ConversionOutputStatsRepository } from '../../../../data_layer/ConversionOutputStatsRepository';
 import { truncateDecksToCardLimit } from '../../../parser/truncateDecksToCardLimit';
 import { MonthlyLimitPartial } from '../../../../services/NotionService/helpers/conversionTruncation';
+import { toCardCountBucket } from '../../../analytics/cardCountBucket';
 
-type CardCountBucket = '<50' | '50-499' | '500+';
 type ConversionSource = 'notion' | 'upload' | 'google_drive';
-
-function toCardCountBucket(count: number): CardCountBucket {
-  if (count < 50) return '<50';
-  if (count < 500) return '50-499';
-  return '500+';
-}
 
 function toConversionSource(type?: string): ConversionSource {
   if (type === 'google_drive') return 'google_drive';

--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -1682,7 +1682,7 @@ describe('UploadService.promoteClaudeJobToUpload — async fs reads', () => {
       'conversion_succeeded',
       expect.objectContaining({
         userId: 42,
-        props: expect.objectContaining({ card_count_bucket: '<50' }),
+        props: expect.objectContaining({ card_count_bucket: '3-49' }),
       })
     );
   });

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -28,6 +28,8 @@ import { UploadFileUnavailableError } from '../usecases/uploads/UploadFileUnavai
 import { isExpectedClientFault } from '../lib/misc/isExpectedClientFault';
 import type { DeckScore } from '../lib/parser/scoreCandidateDeck';
 import type { InducedRescue } from '../lib/parser/induction/candidateRules';
+import { toCardCountBucket } from '../lib/analytics/cardCountBucket';
+import { uploadInputFormat } from '../lib/analytics/uploadInputFormat';
 import {
   CONVERSION_TRUNCATED_MESSAGE,
   FileConversionError,
@@ -154,49 +156,6 @@ function resolveUploadWarning(warnings: string[] | undefined): string | null {
     return MARKDOWN_HEURISTIC_WARNING;
   }
   return null;
-}
-
-// The extension of the first uploaded file, lowercased. A shape metric, never
-// the filename itself — see .claude/rules/support-confidentiality.md.
-//
-// Allowlisted rather than passed through: the value is a cohort key, and an
-// unbounded one lets any upload mint a cohort of size one. Anything unrecognised
-// buckets into 'other' so the cardinality stays fixed.
-const KNOWN_INPUT_FORMATS = new Set([
-  'zip',
-  'html',
-  'htm',
-  'md',
-  'markdown',
-  'csv',
-  'tsv',
-  'xlsx',
-  'xls',
-  'pdf',
-  'docx',
-  'doc',
-  'pptx',
-  'ppt',
-  'txt',
-  'apkg',
-  'opml',
-  'epub',
-  'xml',
-  'json',
-  'png',
-  'jpg',
-  'jpeg',
-  'webp',
-  'gif',
-]);
-
-function uploadInputFormat(files: UploadedFile[] | undefined): string {
-  const name = files?.[0]?.originalname;
-  if (typeof name !== 'string') return 'unknown';
-  const dot = name.lastIndexOf('.');
-  if (dot < 0 || dot === name.length - 1) return 'unknown';
-  const ext = name.slice(dot + 1).toLowerCase();
-  return KNOWN_INPUT_FORMATS.has(ext) ? ext : 'other';
 }
 
 function shippedRescueRule(
@@ -777,6 +736,9 @@ class UploadService {
         anonymousId: this.resolveAnonId(req),
         props: {
           source: this.resolveUploadSource(req),
+          input_format: uploadInputFormat(
+            req.files as UploadedFile[] | undefined
+          ),
           device: classifyDevice(req.headers?.['user-agent']),
           signup_origin: this.resolveSignupOrigin(req),
         },
@@ -802,6 +764,9 @@ class UploadService {
           anonymousId: this.resolveAnonId(req),
           props: {
             source: this.resolveUploadSource(req),
+            input_format: uploadInputFormat(
+              req.files as UploadedFile[] | undefined
+            ),
             reason: 'api_card_limit',
             signup_origin: this.resolveSignupOrigin(req),
           },
@@ -825,6 +790,9 @@ class UploadService {
           anonymousId,
           props: {
             source,
+            input_format: uploadInputFormat(
+              req.files as UploadedFile[] | undefined
+            ),
             reason: 'monthly_limit',
             signup_origin: this.resolveSignupOrigin(req),
           },
@@ -854,6 +822,9 @@ class UploadService {
           anonymousId,
           props: {
             source,
+            input_format: uploadInputFormat(
+              req.files as UploadedFile[] | undefined
+            ),
             reason: 'anonymous_cap',
             signup_origin: this.resolveSignupOrigin(req),
           },
@@ -913,6 +884,9 @@ class UploadService {
           anonymousId: this.resolveAnonId(req),
           props: {
             source: this.resolveUploadSource(req),
+            input_format: uploadInputFormat(
+              req.files as UploadedFile[] | undefined
+            ),
             reason: 'upload_incomplete',
             signup_origin: this.resolveSignupOrigin(req),
           },
@@ -1028,7 +1002,10 @@ class UploadService {
             anonymousId: this.resolveAnonId(req),
             props: {
               source: this.resolveUploadSource(req),
-              card_count_bucket: this.toCardCountBucket(totalCards),
+              input_format: uploadInputFormat(
+                req.files as UploadedFile[] | undefined
+              ),
+              card_count_bucket: toCardCountBucket(totalCards),
               signup_origin: this.resolveSignupOrigin(req),
             },
           });
@@ -1186,6 +1163,9 @@ class UploadService {
         anonymousId: this.resolveAnonId(req),
         props: {
           source: this.resolveUploadSource(req),
+          input_format: uploadInputFormat(
+            req.files as UploadedFile[] | undefined
+          ),
           reason: 'empty_deck',
           signup_origin: this.resolveSignupOrigin(req),
         },
@@ -1293,12 +1273,15 @@ class UploadService {
       }
       res.attachment(`/${first.name}`);
       const uploadSource = this.resolveUploadSource(req);
-      const bucket = this.toCardCountBucket(totalCards);
+      const bucket = toCardCountBucket(totalCards);
       track('conversion_succeeded', {
         userId: owner != null ? Number(owner) : null,
         anonymousId: this.resolveAnonId(req),
         props: {
           source: uploadSource,
+          input_format: uploadInputFormat(
+            req.files as UploadedFile[] | undefined
+          ),
           card_count_bucket: bucket,
           signup_origin: this.resolveSignupOrigin(req),
         },
@@ -1315,7 +1298,10 @@ class UploadService {
       anonymousId: this.resolveAnonId(req),
       props: {
         source: this.resolveUploadSource(req),
-        card_count_bucket: this.toCardCountBucket(totalCards),
+        input_format: uploadInputFormat(
+          req.files as UploadedFile[] | undefined
+        ),
+        card_count_bucket: toCardCountBucket(totalCards),
         signup_origin: this.resolveSignupOrigin(req),
       },
     });
@@ -1391,12 +1377,6 @@ class UploadService {
     if (req.path?.includes('google_drive')) return 'google_drive';
     if (req.path?.includes('dropbox')) return 'dropbox';
     return 'upload';
-  }
-
-  private toCardCountBucket(count: number): '<50' | '50-499' | '500+' {
-    if (count < 50) return '<50';
-    if (count < 500) return '50-499';
-    return '500+';
   }
 }
 

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -1244,7 +1244,6 @@ class UploadService {
         console.error(err);
       }
       res.attachment(`/${first.name}`);
-      const uploadSource = this.resolveUploadSource(req);
       const bucket = toCardCountBucket(totalCards);
       track('conversion_succeeded', {
         userId: owner != null ? Number(owner) : null,

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -735,12 +735,8 @@ class UploadService {
         userId: owner != null ? Number(owner) : null,
         anonymousId: this.resolveAnonId(req),
         props: {
-          source: this.resolveUploadSource(req),
-          input_format: uploadInputFormat(
-            req.files as UploadedFile[] | undefined
-          ),
+          ...this.baseFunnelProps(req),
           device: classifyDevice(req.headers?.['user-agent']),
-          signup_origin: this.resolveSignupOrigin(req),
         },
       });
 
@@ -763,12 +759,8 @@ class UploadService {
           userId: owner != null ? Number(owner) : null,
           anonymousId: this.resolveAnonId(req),
           props: {
-            source: this.resolveUploadSource(req),
-            input_format: uploadInputFormat(
-              req.files as UploadedFile[] | undefined
-            ),
+            ...this.baseFunnelProps(req),
             reason: 'api_card_limit',
-            signup_origin: this.resolveSignupOrigin(req),
           },
         });
         return res.status(402).json({
@@ -789,12 +781,8 @@ class UploadService {
           userId,
           anonymousId,
           props: {
-            source,
-            input_format: uploadInputFormat(
-              req.files as UploadedFile[] | undefined
-            ),
+            ...this.baseFunnelProps(req),
             reason: 'monthly_limit',
-            signup_origin: this.resolveSignupOrigin(req),
           },
         });
         track('paywall_shown', {
@@ -821,12 +809,8 @@ class UploadService {
           userId,
           anonymousId,
           props: {
-            source,
-            input_format: uploadInputFormat(
-              req.files as UploadedFile[] | undefined
-            ),
+            ...this.baseFunnelProps(req),
             reason: 'anonymous_cap',
-            signup_origin: this.resolveSignupOrigin(req),
           },
         });
         track('paywall_shown', {
@@ -883,12 +867,8 @@ class UploadService {
           userId: owner != null ? Number(owner) : null,
           anonymousId: this.resolveAnonId(req),
           props: {
-            source: this.resolveUploadSource(req),
-            input_format: uploadInputFormat(
-              req.files as UploadedFile[] | undefined
-            ),
+            ...this.baseFunnelProps(req),
             reason: 'upload_incomplete',
-            signup_origin: this.resolveSignupOrigin(req),
           },
         });
         return res.status(400).json({
@@ -1001,12 +981,8 @@ class UploadService {
             userId: Number(owner),
             anonymousId: this.resolveAnonId(req),
             props: {
-              source: this.resolveUploadSource(req),
-              input_format: uploadInputFormat(
-                req.files as UploadedFile[] | undefined
-              ),
+              ...this.baseFunnelProps(req),
               card_count_bucket: toCardCountBucket(totalCards),
-              signup_origin: this.resolveSignupOrigin(req),
             },
           });
         } else {
@@ -1162,12 +1138,8 @@ class UploadService {
         userId: ownerId,
         anonymousId: this.resolveAnonId(req),
         props: {
-          source: this.resolveUploadSource(req),
-          input_format: uploadInputFormat(
-            req.files as UploadedFile[] | undefined
-          ),
+          ...this.baseFunnelProps(req),
           reason: 'empty_deck',
-          signup_origin: this.resolveSignupOrigin(req),
         },
       });
       throw new EmptyDeckError();
@@ -1278,12 +1250,8 @@ class UploadService {
         userId: owner != null ? Number(owner) : null,
         anonymousId: this.resolveAnonId(req),
         props: {
-          source: uploadSource,
-          input_format: uploadInputFormat(
-            req.files as UploadedFile[] | undefined
-          ),
+          ...this.baseFunnelProps(req),
           card_count_bucket: bucket,
-          signup_origin: this.resolveSignupOrigin(req),
         },
       });
       if (owner != null) {
@@ -1297,12 +1265,8 @@ class UploadService {
       userId: owner != null ? Number(owner) : null,
       anonymousId: this.resolveAnonId(req),
       props: {
-        source: this.resolveUploadSource(req),
-        input_format: uploadInputFormat(
-          req.files as UploadedFile[] | undefined
-        ),
+        ...this.baseFunnelProps(req),
         card_count_bucket: toCardCountBucket(totalCards),
-        signup_origin: this.resolveSignupOrigin(req),
       },
     });
     if (owner != null) {
@@ -1367,6 +1331,14 @@ class UploadService {
   private resolvePersistedSource(req: express.Request): UploadSource | null {
     const body = req.body as Record<string, unknown> | undefined;
     return validateUploadSource(body?.source);
+  }
+
+  private baseFunnelProps(req: express.Request): Record<string, unknown> {
+    return {
+      source: this.resolveUploadSource(req),
+      input_format: uploadInputFormat(req.files as UploadedFile[] | undefined),
+      signup_origin: this.resolveSignupOrigin(req),
+    };
   }
 
   private resolveUploadSource(


### PR DESCRIPTION
Step 1 of https://github.com/2anki/server/issues/4062 (instrument first, fix second — issue stays open for steps 2–3).

## Why

Office-doc converter pages are the funnel's worst segment (½–⅓ of the site-wide upload→download rate), but the events can't say where those users die: no funnel event carries the upload type, and `card_count_bucket`'s lowest bucket (`<50`) hides the one-giant-card successes that are actually failures.

## What

- `upload_started`, `conversion_succeeded`, and `conversion_failed` (9 call sites in `UploadService`) now carry `input_format` — the first file's extension against the existing allowlist ('other'/'unknown' fallback keeps cardinality fixed; a shape metric, never the filename).
- `card_count_bucket` gains a `<3` bucket (`<3 | 3-49 | 50-499 | 500+`), so "succeeded but ≤2 cards" is distinguishable from real success.
- Both helpers extracted to `src/lib/analytics/` with colocated tests; the two hand-copied bucket implementations (UploadService + performConversion) collapse into one.

## Decisions made overnight (please review)

- Reused the existing `uploadInputFormat` allowlist rather than inventing a per-extension list — one vocabulary for score rows and funnel events. Assumption: first-file extension is representative (zips report 'zip', not their contents).
- Bucket rename means historical rows keep `<50` while new rows say `3-49`/`<3` — window queries spanning the boundary need a mental union. Chose honest new buckets over keeping the blind old ones. If you'd rather keep `<50` continuity, revert the bucket change and only add `input_format`.
- Notion-path events (`performConversion`) get the finer buckets but no `input_format` — `source: 'notion'` already identifies them; there is no file.
- Scope: did NOT build the result-page notice (step 3) — the issue explicitly gates it on a week of this data. Did NOT extend `/api/ops/upload-funnel` — first read can come straight off `events` props.

## Verification

- New tests for both helpers; `UploadService.test.ts` 73 passed (one bucket assertion updated `<50` → `3-49`); events + jobs suites 134 passed; `tsc -p . --noEmit` clean; tree-wide `pnpm format:check` clean.
- No web changes — server-side props only.
- Sonar: not run locally; SonarCloud PR analysis is the gate.

Funnel/MRR impact: enables the per-format upload→download read (acquisition lane) — read off `events` props `input_format` × `card_count_bucket` after a week.

no changelog entry — internal analytics instrumentation, no user-visible behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
