### PR TITLE
fix: surface zero-card python exits as empty-deck, not our-end

### DIFF
--- a/src/lib/anki/CardGenerator.batch.test.ts
+++ b/src/lib/anki/CardGenerator.batch.test.ts
@@ -144,3 +144,30 @@ describe('CardGenerator.runBatch', () => {
     expect(mockedSpawn.mock.calls[0][2]).toMatchObject({ cwd: workspace });
   });
 });
+
+describe('CardGenerator.run zero-card sentinel', () => {
+  const workspace = '/tmp/test-workspace';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedExistsSync.mockReturnValue(false);
+  });
+
+  it('rejects with PythonZeroCardsError when Python exits cleanly with no cards', async () => {
+    mockedSpawn.mockReturnValue(
+      makeProcessStub('No cards generated; exiting cleanly', 0)
+    );
+
+    const gen = new CardGenerator(workspace);
+    await expect(gen.run()).rejects.toMatchObject({
+      name: 'PythonZeroCardsError',
+    });
+  });
+
+  it('keeps the generic error for a missing apkg path without the sentinel', async () => {
+    mockedSpawn.mockReturnValue(makeProcessStub('some unrelated output', 0));
+
+    const gen = new CardGenerator(workspace);
+    await expect(gen.run()).rejects.toMatchObject({ name: 'Error' });
+  });
+});

--- a/src/lib/anki/CardGenerator.ts
+++ b/src/lib/anki/CardGenerator.ts
@@ -10,6 +10,10 @@ import {
   resolvePath,
 } from '../constants';
 import { buildPythonExitError } from './buildPythonExitError';
+import {
+  PYTHON_NO_CARDS_SENTINEL,
+  PythonZeroCardsError,
+} from './PythonZeroCardsError';
 
 function tryCommand(command: string): boolean {
   try {
@@ -133,6 +137,9 @@ class CardGenerator {
         const output = stdoutData.join('').trim();
         const lastLine = output.split('\n').pop();
         if (!lastLine?.endsWith('.apkg')) {
+          if (output.includes(PYTHON_NO_CARDS_SENTINEL)) {
+            return reject(new PythonZeroCardsError(output));
+          }
           return reject(
             new Error(
               `Python script did not return a valid .apkg path. stdout: ${output || '(empty)'}`

--- a/src/lib/anki/PythonZeroCardsError.ts
+++ b/src/lib/anki/PythonZeroCardsError.ts
@@ -1,0 +1,10 @@
+export const PYTHON_NO_CARDS_SENTINEL = 'No cards generated';
+
+// The upload worker serialises errors as { message, name } and rebuilds a plain
+// Error, so the name is the only thing that survives to jobFailureReason.
+export class PythonZeroCardsError extends Error {
+  constructor(stdout: string) {
+    super(`Python built zero cards. stdout: ${stdout || '(empty)'}`);
+    this.name = 'PythonZeroCardsError';
+  }
+}

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -1053,6 +1053,7 @@ class UploadService {
           err instanceof ImageOnlyContentError ||
           (err instanceof Error && isExpectedClientFault(err)) ||
           (err instanceof Error && isPdfPasswordSentinel(err.message)) ||
+          (err instanceof Error && err.name === 'PythonZeroCardsError') ||
           (err instanceof Error && /^docx_parse_failed/.test(err.message));
         if (isExpectedState) {
           console.info('[UploadService] async job user-input state', {

--- a/src/usecases/jobs/jobFailureReason.test.ts
+++ b/src/usecases/jobs/jobFailureReason.test.ts
@@ -374,6 +374,12 @@ describe('jobFailureReasonFromError on worker-flattened errors', () => {
     return e;
   }
 
+  it('maps a flattened PythonZeroCardsError to the empty-deck reason', () => {
+    const flat = flatten('PythonZeroCardsError', 'Python built zero cards.');
+    expect(jobFailureReasonFromError(flat)).toBe(EMPTY_DECK_FAILURE_REASON);
+    expect(jobFailureReasonCode(flat)).toBe('empty_deck');
+  });
+
   it('keeps the large-section message when the class was flattened', () => {
     expect(
       jobFailureReasonFromError(

--- a/src/usecases/jobs/jobFailureReason.ts
+++ b/src/usecases/jobs/jobFailureReason.ts
@@ -98,6 +98,9 @@ export function jobFailureReasonCode(error: unknown): JobFailureReasonCode {
   if (error instanceof ClaudeLargeSectionError) {
     return 'claude_large_section';
   }
+  if (hasName(error, 'PythonZeroCardsError')) {
+    return 'empty_deck';
+  }
   if (error instanceof PythonExitError) {
     return 'python_crash';
   }
@@ -154,6 +157,9 @@ export function jobFailureReasonFromError(
     if (error.sourceFormat === 'markdown') {
       return MARKDOWN_LIKELY_LOSSY_REASON;
     }
+    return EMPTY_DECK_FAILURE_REASON;
+  }
+  if (hasName(error, 'PythonZeroCardsError')) {
     return EMPTY_DECK_FAILURE_REASON;
   }
   if (

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-13-zero-card-reason.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-13-zero-card-reason.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-13-zero-card-reason",
+  "date": "2026-08-13",
+  "type": "fix",
+  "title": "Uploads that produce no cards now say so, instead of reporting a converter error"
+}


### PR DESCRIPTION
Fixes https://github.com/2anki/server/issues/4078

## Why

Two async jobs on 2026-08-12 hit the chain the issue documents: Python finds zero notes, prints `No cards generated; exiting cleanly`, exits 0 → `CardGenerator.run()` rejects with a plain `Error` → the worker boundary flattens it to `{message, name: 'Error'}` → `jobFailureReasonFromError` falls through to the generic "something went wrong on our end… email support" message. The user's content produced zero cards — a user-input state — but we blamed ourselves, routed them to support instead of the fix, counted it as `unknown` in analytics, and logged it at `console.error`.

## What

- `PythonZeroCardsError` (name survives the worker's `{message, name}` flattening) thrown from `CardGenerator.run()` when exit-0 output carries the sentinel.
- `jobFailureReasonCode` → `empty_deck`; `jobFailureReasonFromError` → `EMPTY_DECK_FAILURE_REASON` — the same actionable copy real empty decks get.
- Async path logs it as the existing `async job user-input state` info line instead of `console.error`.

## Decisions made overnight (please review)

- `runBatch` deliberately untouched (the issue said "and runBatch"): it resolves an empty list rather than throwing, and the batch census/rescue path (#4030/#4065) already owns zero-card batches — making it throw would fight that machinery. If you want the sentinel typed there too, it's a follow-up.
- Sentinel matched with `includes('No cards generated')` against the locked Python output string — not extended.

## Verification

- New tests: `run()` rejects `PythonZeroCardsError` on the sentinel and keeps the generic error without it; flattened-name mapping asserted through `jobFailureReasonFromError`/`Code` (52 tests green across both suites). `UploadService.test.ts` 73 green. `tsc` clean, tree-wide format clean.
- Changelog entry included (user-visible downloads-page copy change).
- Sonar: not run locally; SonarCloud PR analysis is the gate.

Funnel/MRR impact: accurate `empty_deck` counts in failure analytics; fewer false "our end" failures on the downloads page (read at /api/ops/metrics failure breakdown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)