### PR TITLE
feat: attribute the MCP channel in signups and AI cost

### DIFF
--- a/src/controllers/UsersControllers.test.ts
+++ b/src/controllers/UsersControllers.test.ts
@@ -631,7 +631,11 @@ describe('UsersController.requestMagicLink', () => {
 
     await controller.requestMagicLink(req, res, next);
 
-    expect(requestMagicLink).toHaveBeenCalledWith('al@example.com', 'login');
+    expect(requestMagicLink).toHaveBeenCalledWith(
+      'al@example.com',
+      'login',
+      null
+    );
   });
 
   it('returns 400 when email is missing', async () => {

--- a/src/controllers/UsersControllers.ts
+++ b/src/controllers/UsersControllers.ts
@@ -1388,7 +1388,11 @@ class UsersController {
     }
 
     try {
-      await this.userService.requestMagicLink(email.trim(), purpose);
+      await this.userService.requestMagicLink(
+        email.trim(),
+        purpose,
+        readFirstTouchCookie(req).signupOrigin
+      );
     } catch (error) {
       if (error instanceof MagicLinkRateLimitError) {
         return res.status(200).json({ message: 'ok' });

--- a/src/routes/mcp/createMcpRouter.ts
+++ b/src/routes/mcp/createMcpRouter.ts
@@ -16,6 +16,7 @@ import {
   RateLimiter,
 } from '../../lib/rateLimit/InMemoryRateLimiter';
 import { hashIp, resolveClientIp } from '../../lib/rateLimit/ipHelpers';
+import { mcpFirstTouchMiddleware } from './mcpFirstTouch';
 
 export const MCP_AUTHORIZE_PATH = '/mcp/authorize';
 export const MCP_TOKEN_PATH = '/mcp/token';
@@ -125,6 +126,7 @@ export function createMcpRouter(deps: McpRouterDeps): express.Router {
 
   router.use(
     MCP_AUTHORIZE_PATH,
+    mcpFirstTouchMiddleware,
     rateLimit(authorizeLimiter),
     authorizationHandler({ provider })
   );

--- a/src/routes/mcp/mcpFirstTouch.test.ts
+++ b/src/routes/mcp/mcpFirstTouch.test.ts
@@ -1,0 +1,33 @@
+import express from 'express';
+import { mcpFirstTouchMiddleware } from './mcpFirstTouch';
+
+function run(cookies: Record<string, unknown> | undefined) {
+  const req = { cookies } as unknown as express.Request;
+  const cookieMock = jest.fn();
+  const res = { cookie: cookieMock } as unknown as express.Response;
+  const next = jest.fn();
+  mcpFirstTouchMiddleware(req, res, next);
+  return { cookieMock, next };
+}
+
+describe('mcpFirstTouchMiddleware', () => {
+  it('sets a first-touch cookie with the /mcp landing path when absent', () => {
+    const { cookieMock, next } = run(undefined);
+
+    expect(cookieMock).toHaveBeenCalledWith(
+      'first_touch',
+      JSON.stringify({ landingPath: '/mcp', referrer: '' }),
+      { maxAge: 30 * 60 * 1000, path: '/', sameSite: 'lax' }
+    );
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('never overwrites an existing first touch', () => {
+    const { cookieMock, next } = run({
+      first_touch: JSON.stringify({ landingPath: '/pricing', referrer: '' }),
+    });
+
+    expect(cookieMock).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/src/routes/mcp/mcpFirstTouch.ts
+++ b/src/routes/mcp/mcpFirstTouch.ts
@@ -1,0 +1,25 @@
+import express from 'express';
+
+const FIRST_TOUCH_COOKIE = 'first_touch';
+const MAX_AGE_MS = 30 * 60 * 1000;
+
+// The MCP consent page is server-rendered, so the web client's first-touch
+// capture never runs for users who arrive from an AI assistant. Without this,
+// their eventual signup falls back to the mechanism name (magic_link, google,
+// ...) and the MCP channel is invisible in the funnel. Same payload shape and
+// lifetime as web/src/lib/firstTouch.ts; parseFirstTouch reads it back.
+export function mcpFirstTouchMiddleware(
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction
+): void {
+  const cookies = req.cookies as Record<string, unknown> | undefined;
+  if (cookies?.[FIRST_TOUCH_COOKIE] == null) {
+    res.cookie(
+      FIRST_TOUCH_COOKIE,
+      JSON.stringify({ landingPath: '/mcp', referrer: '' }),
+      { maxAge: MAX_AGE_MS, path: '/', sameSite: 'lax' }
+    );
+  }
+  next();
+}

--- a/src/services/UsersService.test.ts
+++ b/src/services/UsersService.test.ts
@@ -310,6 +310,35 @@ describe('UsersService.requestMagicLink', () => {
     );
   });
 
+  it('stamps the first-touch origin on a magic-link signup when provided', async () => {
+    const created = { id: 42, email: 'viambient@example.com' };
+    const getByEmail = jest
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue(created);
+    const createUserAndSeedFromTombstone = jest
+      .fn()
+      .mockResolvedValue([{ id: 42 }]);
+    const repository = {
+      getByEmail,
+      createUserAndSeedFromTombstone,
+    } as unknown as UsersRepository;
+    const service = new UsersService(
+      repository,
+      buildEmailService(),
+      new InMemoryMagicTokenRepository()
+    );
+
+    await service.requestMagicLink('viambient@example.com', 'login', '/mcp');
+
+    expect(createUserAndSeedFromTombstone).toHaveBeenCalledWith(
+      'viambient',
+      expect.any(String),
+      'viambient@example.com',
+      '/mcp'
+    );
+  });
+
   it('does not create an account for a password reset on an unknown email', async () => {
     const getByEmail = jest.fn().mockResolvedValue(null);
     const createUserAndSeedFromTombstone = jest.fn();

--- a/src/services/UsersService.ts
+++ b/src/services/UsersService.ts
@@ -176,7 +176,8 @@ class UsersService {
 
   async requestMagicLink(
     email: string,
-    purpose: 'login' | 'password_reset'
+    purpose: 'login' | 'password_reset',
+    signupOrigin?: string | null
   ): Promise<void> {
     if (this.magicTokenRepository == null) {
       return;
@@ -196,7 +197,12 @@ class UsersService {
         return;
       }
       const placeholderPassword = bcrypt.hashSync(crypto.randomUUID(), 12);
-      await this.register('', placeholderPassword, email, 'magic_link');
+      await this.register(
+        '',
+        placeholderPassword,
+        email,
+        signupOrigin ?? 'magic_link'
+      );
       user = await this.repository.getByEmail(email.toLowerCase());
       if (user?.id == null) {
         console.info('password_reset.magic_link', {

--- a/src/services/mcp/McpToolsService.ts
+++ b/src/services/mcp/McpToolsService.ts
@@ -310,6 +310,7 @@ export class McpToolsService {
       includeSourceImage: input.includeSourceImage,
       density: input.density,
       mode: input.mode,
+      usageSurface: 'photo_to_deck_mcp',
     });
 
     return {

--- a/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.ts
+++ b/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.ts
@@ -59,6 +59,7 @@ export interface PhotoToFlashcardsInput {
   mode?: PhotoMode;
   cardStyle?: PhotoCardStyle;
   mcqEnabled?: boolean;
+  usageSurface?: string;
 }
 
 export interface PhotoToFlashcardsResult {
@@ -613,7 +614,7 @@ export class PhotoToFlashcardsUseCase {
 
     let response = await createVisionMessage(VISION_MAX_TOKENS);
     recordClaudeUsage({
-      surface: 'photo_to_deck',
+      surface: input.usageSurface ?? 'photo_to_deck',
       model: response.model,
       usage: response.usage,
       userId,
@@ -629,7 +630,7 @@ export class PhotoToFlashcardsUseCase {
       );
       response = await createVisionMessage(VISION_RETRY_MAX_TOKENS);
       recordClaudeUsage({
-        surface: 'photo_to_deck',
+        surface: input.usageSurface ?? 'photo_to_deck',
         model: response.model,
         usage: response.usage,
         userId,


### PR DESCRIPTION
## Why

MCP is the best-performing acquisition channel measured so far — but it's invisible in the funnel. Only 3 of 67 MCP deck downloads carry a signup origin, because (a) the MCP consent page is server-rendered, so the web client's `first_touch` capture never runs for assistant-arriving users, and (b) the magic-link signup path hardcoded `'magic_link'` (the mechanism) as the origin, discarding any first touch. AI cost for MCP free users was also indistinguishable from web photo usage in the new /ops AI panel.

## What

- `/mcp/authorize` sets the `first_touch` cookie server-side (`landingPath: '/mcp'`, same shape/lifetime as `web/src/lib/firstTouch.ts`) — only when absent, never overwriting an earlier touch.
- `requestMagicLink` threads the first-touch origin through account creation (`?? 'magic_link'` fallback unchanged for direct visitors).
- MCP-originated photo conversions record AI cost under a distinct `photo_to_deck_mcp` surface via a `usageSurface` override on `PhotoToFlashcardsInput` — the ops AI panel now prices the channel's free-tier usage per surface, no schema change.

## Notes for review

- Auth-adjacent surface, so stating the security posture plainly: the middleware writes a static-literal analytics cookie (no user input, SameSite=Lax, no secrets) and origin values still pass `parseFirstTouch`'s allowlist sanitizer before storage via the existing parameterized repository call. No change to token issuance, consent, or session logic.
- Origin value is `'/mcp'` — consistent with the rows that already exist and with landing-page-yield grouping.
- No changelog entry — internal instrumentation, not user-visible.
- Browser check: not applicable — no `web/src` changes; server-set cookie + analytics props only.
- Sonar not run locally; SonarCloud PR analysis is the gate.

## Testing

- `mcpFirstTouch.test.ts`: sets the cookie when absent, never overwrites an existing touch.
- `UsersService.test.ts`: magic-link signup stamps a provided first-touch origin; existing fallback test still green.
- `UsersControllers.test.ts`: controller passes the cookie origin (one assertion extended).
- Suites green: UsersService + mcp routes + imageOcclusion (128) and UsersControllers + services/mcp (290). `tsc -p . --noEmit` clean, tree-wide `pnpm format:check` clean.

Funnel/MRR impact: `signup_origin='/mcp'` becomes readable in /api/ops/upload-funnel `by_origin` and landing-page yield; `photo_to_deck_mcp` appears in /ops → System → AI usage. Both feed the Plan-B decision rule directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)