### PR TITLE
docs: refresh chat docs for file attachments and retention

### DIFF
--- a/web/src/pages/DocsPage/content/de/reference/chat.md
+++ b/web/src/pages/DocsPage/content/de/reference/chat.md
@@ -1,9 +1,9 @@
 ---
 title: Chat — Lernassistent
-description: Notizen einfügen, nach Karten fragen, ein Konzept durcharbeiten. Unterhaltungen werden gespeichert.
+description: Notizen einfügen oder eine Datei anhängen, nach Karten fragen, ein Konzept durcharbeiten. Unterhaltungen werden gespeichert.
 ---
 
-Chat ist ein Lernassistent, gebaut auf Claude. Füge deine Notizen ein und bitte ihn, Karten zu machen, bitte ihn, etwas zu erklären, oder arbeite ein Thema im Hin und Her durch. Öffne ihn unter [2anki.net/chat](https://2anki.net/chat). Anmeldung erforderlich.
+Chat ist ein Lernassistent, gebaut auf Claude. Füge deine Notizen ein oder häng eine Datei an, dann bitte ihn, Karten zu machen, etwas zu erklären, oder arbeite ein Thema im Hin und Her durch. Öffne ihn unter [2anki.net/chat](https://2anki.net/chat). Anmeldung erforderlich.
 
 **Plan:** Kostenlos für die ersten 20 Nachrichten pro Monat. Subscription und Lifetime sind unbegrenzt und nutzen ein stärkeres Modell.
 
@@ -14,7 +14,7 @@ Chat ist ein Lernassistent, gebaut auf Claude. Füge deine Notizen ein und bitte
 - Du willst ein Konzept durchdenken, bevor du Karten machst — Erklärung zuerst, Karten danach.
 - Du hängst an einem bestimmten Upload-Fehler fest und willst Hilfe, herauszufinden, warum eine Datei nicht konvertiert.
 
-Wenn deine Quelle schon sauber auf Karteikarten abbildet (Toggles, Aufzählungspaare, eine Tabelle), ist der Standard-[Upload-Ablauf](/documentation/start-here/upload-a-file) schneller. Chat ist für die Zwischenfälle.
+Chat verarbeitet Dateien jetzt direkt — häng ein PDF, ein Bild, einen Notion-Export oder ein Dokument an, und er arbeitet aus dem Inhalt. Für Massenkonvertierung oder eine Notion-Seite, deren Toggles schon sauber auf Karten abbilden, ist der Standard-[Upload-Ablauf](/documentation/start-here/upload-a-file) weiterhin schneller und deterministisch. Greif zu Chat, wenn du die Karten interaktiv formen willst.
 
 ## Eine Unterhaltung starten
 
@@ -24,6 +24,25 @@ Wenn deine Quelle schon sauber auf Karteikarten abbildet (Toggles, Aufzählungsp
 4. Wenn der Assistent Karten vorschlägt, siehst du sie inline als Vorder-/Rückseiten-Vorschauen. Du kannst weiter iterieren oder von dort eine `.apkg` herunterladen.
 
 Vergangene Unterhaltungen bleiben in der Seitenleiste links. Klick auf eine beliebige, um sie wieder zu öffnen. Du kannst eine Unterhaltung aus derselben Zeile umbenennen oder löschen.
+
+## Dateien anhängen
+
+Häng Lernmaterial direkt an eine Nachricht an — für eine einzelne Datei brauchst du die Upload-Seite nicht. Klick auf den Anhängen-Button, wähle deine Dateien und sende sie mit oder ohne Prompt. Ohne Prompt macht Chat Karten aus dem, was du angehängt hast.
+
+Was du anhängen kannst:
+
+- PDFs und Bilder (PNG, JPEG, GIF, WebP) gehen unverändert an das Modell — es liest die Seiten oder das Bild direkt.
+- Notion-Exporte (.zip), Word-Dokumente (.docx), Markdown (.md) und einfacher Text (.txt) werden in Text umgewandelt, bevor das Modell sie sieht.
+
+Grenzen pro Nachricht:
+
+- Bis zu 5 Dateien.
+- 10 MB pro Datei.
+- 25 MB über alle Dateien.
+
+Überschreitest du eine Grenze, wird die Nachricht abgelehnt, bevor sie sendet, mit einem Hinweis, welche Datei oder Summe du kürzen musst.
+
+**Einen Turn neu generieren.** Neugenerieren nutzt das PDF oder Bild wieder, das du an diesen Turn angehängt hast, sodass du für einen anderen Blickwinkel nichts erneut hochladen musst. Angehängte PDFs und Bilder werden 90 Tage aufbewahrt, dann gelöscht. Generierst du danach einen älteren Turn neu, bittet Chat dich, die Datei erneut anzuhängen.
 
 ## Nützliche Prompts schreiben
 
@@ -49,7 +68,8 @@ Die Zählung setzt sich am Ersten des Folgemonats zurück. Das genaue Rücksetzd
 
 ## Was wir speichern
 
-- Den Text jeder Nachricht in jeder Unterhaltung (damit du sie wieder öffnen kannst).
+- Den Text jeder Nachricht in jeder Unterhaltung (damit du sie wieder öffnen kannst). Ein Notion-Export, ein Dokument, Markdown oder eine Textdatei, die du anhängst, wird Teil dieses Nachrichtentexts.
+- Jedes PDF und Bild, das du anhängst, 90 Tage aufbewahrt, damit du den Turn neu generieren kannst, dann gelöscht.
 - Das Nutzerkonto, dem die Unterhaltung gehört.
 - Nichts sonst — wir betreiben keine Analytik darüber, was du fragst, und wir trainieren keine Modelle mit deinen Unterhaltungen.
 
@@ -58,7 +78,7 @@ Lösche eine Unterhaltung jederzeit über das Papierkorb-Symbol in der Seitenlei
 ## Häufige Fehler
 
 - **Mehr als das Nachrichtenlimit einfügen.** Jede Nachricht ist auf 100 000 Zeichen begrenzt. Teile eine längere Quelle über mehrere Nachrichten auf.
-- **Erwarten, dass Chat hochgeladene Dateien liest.** Chat liest Text. Um ein PDF oder einen Notion-Export zu konvertieren, nutze stattdessen die [Upload-Seite](/documentation/start-here/upload-a-file) — dieser Weg ist für Dateien gebaut. Chat kann dir helfen, einen festgefahrenen Upload zu debuggen, aber er verarbeitet die Datei nicht selbst.
+- **Einen Dateityp anhängen, den Chat nicht nimmt.** Chat akzeptiert PDF, Bilder, Notion-.zip-Exporte, .docx, .md und .txt. Exportiere oder konvertiere alles andere zuerst in eines davon.
 - **Chat als einzigen Weg behandeln.** Für Quellen, die schon Struktur haben, ist der Standard-Parser schneller, deterministisch und kostenlos.
 
 ## Verwandt

--- a/web/src/pages/DocsPage/content/reference/chat.md
+++ b/web/src/pages/DocsPage/content/reference/chat.md
@@ -1,9 +1,9 @@
 ---
 title: Chat — study assistant
-description: Paste notes, ask for cards, work through a concept. Conversations are saved.
+description: Paste notes or attach a file, ask for cards, work through a concept. Conversations are saved.
 ---
 
-Chat is a study assistant built on Claude. Paste your notes and ask it to make cards, ask it to explain something, or work through a topic by going back and forth. Open it at [2anki.net/chat](https://2anki.net/chat). Sign-in required.
+Chat is a study assistant built on Claude. Paste your notes or attach a file, then ask it to make cards, explain something, or work through a topic by going back and forth. Open it at [2anki.net/chat](https://2anki.net/chat). Sign-in required.
 
 **Plan:** Free for the first 20 messages a month. Subscription and Lifetime are unlimited and use a stronger model.
 
@@ -14,7 +14,7 @@ Chat is a study assistant built on Claude. Paste your notes and ask it to make c
 - You want to think through a concept before making cards — explanation first, cards second.
 - You're stuck on a specific upload error and want help working out why a file isn't converting.
 
-If your source already maps cleanly to flashcards (toggles, bullet pairs, a spreadsheet), the standard [upload flow](/documentation/start-here/upload-a-file) is faster. Chat is for the in-between cases.
+Chat handles files directly now — attach a PDF, an image, a Notion export, or a document and it works from the content. For bulk conversion, or a Notion page whose toggles already map cleanly to cards, the standard [upload flow](/documentation/start-here/upload-a-file) is still faster and deterministic. Reach for chat when you want to shape the cards interactively.
 
 ## Start a conversation
 
@@ -24,6 +24,25 @@ If your source already maps cleanly to flashcards (toggles, bullet pairs, a spre
 4. When the assistant proposes cards, you'll see them inline as front/back previews. You can keep iterating or download an `.apkg` from there.
 
 Past conversations stay in the sidebar on the left. Click any to reopen. You can rename a conversation or delete it from the same row.
+
+## Attach files
+
+Attach study material straight to a message — you don't need the upload page for a single file. Click the attach button, pick your files, and send with or without a prompt. With no prompt, chat makes cards from what you attached.
+
+What you can attach:
+
+- PDFs and images (PNG, JPEG, GIF, WebP) go to the model as-is — it reads the pages or the picture directly.
+- Notion exports (.zip), Word documents (.docx), Markdown (.md), and plain text (.txt) are read into text before the model sees them.
+
+Limits per message:
+
+- Up to 5 files.
+- 10 MB per file.
+- 25 MB across all files.
+
+Go over any limit and the message is rejected before it sends, with a note saying which file or total to trim.
+
+**Regenerating a turn.** Regenerate reuses the PDF or image you attached to that turn, so you don't re-upload to try a different angle. Attached PDFs and images are kept for 90 days, then deleted. Regenerate an older turn after that and chat asks you to attach the file again.
 
 ## Writing useful prompts
 
@@ -49,7 +68,8 @@ The count resets on the first of the following month. The exact reset date shows
 
 ## What we store
 
-- The text of every message in every conversation (so you can reopen them).
+- The text of every message in every conversation (so you can reopen them). A Notion export, document, Markdown, or plain-text file you attach becomes part of that message text.
+- Any PDF or image you attach, kept for 90 days so you can regenerate the turn, then deleted.
 - The user account that owns the conversation.
 - Nothing else — we don't run analytics on what you ask, and we don't train models on your conversations.
 
@@ -58,7 +78,7 @@ Delete a conversation any time using the trash icon in the sidebar. Deletion is 
 ## Common mistakes
 
 - **Pasting more than the message limit.** Each message caps at 100 000 characters. Split a longer source across multiple messages.
-- **Expecting Chat to read uploaded files.** Chat reads text. To convert a PDF or a Notion export, use the [upload page](/documentation/start-here/upload-a-file) instead — that path is built for files. Chat can help you debug a stuck upload, but it doesn't process the file itself.
+- **Attaching a file type chat can't take.** Chat accepts PDF, images, Notion .zip exports, .docx, .md, and .txt. Export or convert anything else to one of those first.
 - **Treating Chat as the only path.** For source that already has structure, the standard parser is faster, deterministic, and free.
 
 ## Related


### PR DESCRIPTION
## What
Refreshes the chat reference doc (English + German) so it describes chat file attachments and their 90-day retention. Removes the stale "chat reads text / use the upload page for files" framing, adds an "Attach files" section, and corrects the "what we store" and "common mistakes" sections.

## Why
Closes #4096. The page still told users chat could not process files and pointed them to the upload page for a PDF or Notion export — the opposite of what shipped. A user reading the docs would not discover a capability that exists, and the privacy section under-described what we retain.

## How
Content-only edits to two markdown files under `web/src/pages/DocsPage/content/`. No renderer, sidebar, or code changes — the page is already registered and rendered by the existing DocsPage loader. Every claim was verified against the source of truth before writing:

- 5 files / 10 MB per file / 25 MB total — `ChatController.ts` `MAX_FILE_COUNT`/`MAX_FILE_SIZE`/`MAX_TOTAL_SIZE`, and the multer + swagger limits in `ChatRouter.ts`.
- PDF + images native, .zip/.docx/.md/.txt parsed to text — `ChatController.ts` MIME sets and `buildAttachmentBlocks.ts`.
- Regenerate reuses attached PDF/image; 90-day retention then re-attach — `isReplayableAttachmentMime`, `loadReplayAttachments`, `CHAT_ATTACHMENT_RETENTION_DAYS = 90` (`chatAttachmentKeys.ts`), and the startup reaper in `server.ts`.

German mirror uses the app's own terminology ("Dateien anhängen", "Neugenerieren", "Anhänge werden 90 Tage aufbewahrt") pulled from `de/chat.json`; digits kept as digits, brand/format names verbatim.

## Measuring success
No new instrumentation — a docs content refresh. Signal it worked: fewer support threads asking "can chat read my PDF?" and time-on-page / scroll on `/documentation/reference/chat`. The behavior it documents already emits `attachmentRetention`/attach events in the chat surface.

## Testing
- Unit tests added: none — content-only markdown, no new source function.
- Existing suites run green: `content-parity`, `content-links`, `loader`, and the full DocsPage suite (65 tests) pass; `pnpm format:check` clean.

## Browser check
Browser check: not applicable — docs-only markdown content change rendered by the existing DocsPage loader (react-markdown + remark-gfm); only constructs already used in these files (headings, bold, lists, GFM tables, inline code, existing internal links). DocsPage render/link/parity suites green. Netlify previews redirect to prod (known); eyeball at `/documentation/reference/chat` via `pnpm dev` if desired.

## Changelog
No entry — docs content only, not a `fix:`/`feat:` behavior change. The attachments feature itself already shipped its changelog.

## Risks
Low. Markdown-only; worst case is a wording nit. Rollback is a revert of the single commit.

## Goal alignment
Acquisition/retention support surface. Accurate docs reduce a "does chat take files?" support load and let users self-discover a shipped capability, which lifts activation on the chat surface. No revenue metric moves directly; this is documentation hygiene keeping the product honest to its users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbQZzLbjr2apKHQC7orhhw

