### PR TITLE
fix: announce chat errors and raise helper-text contrast to AA

### DIFF
--- a/web/src/components/ChatPanel/ChatPanel.module.css
+++ b/web/src/components/ChatPanel/ChatPanel.module.css
@@ -156,7 +156,7 @@
 
 .makingCards {
   font-size: var(--text-xs);
-  color: var(--color-text-tertiary);
+  color: var(--color-text-tertiary-accessible);
   font-style: italic;
 }
 
@@ -242,7 +242,7 @@
 
 .usageLine {
   font-size: var(--text-xs);
-  color: var(--color-text-tertiary);
+  color: var(--color-text-tertiary-accessible);
   font-variant-numeric: tabular-nums;
 }
 
@@ -346,7 +346,7 @@
 .retentionHint {
   flex-basis: 100%;
   font-size: 0.75rem;
-  color: var(--color-text-tertiary);
+  color: var(--color-text-tertiary-accessible);
   padding: 0 0.25rem;
 }
 
@@ -388,7 +388,7 @@
 
 .chipSize {
   font-variant-numeric: tabular-nums;
-  color: var(--color-text-tertiary);
+  color: var(--color-text-tertiary-accessible);
   flex-shrink: 0;
   white-space: nowrap;
 }

--- a/web/src/components/ChatPanel/ChatPanel.test.tsx
+++ b/web/src/components/ChatPanel/ChatPanel.test.tsx
@@ -499,6 +499,46 @@ describe('ChatPanel — aria-live', () => {
   });
 });
 
+describe('ChatPanel — error announcements', () => {
+  beforeEach(() => {
+    mockPost.mockReset();
+    mockGet.mockResolvedValue({ used: 0, limit: 20 });
+  });
+
+  it('announces a send failure to screen readers via role="alert"', async () => {
+    mockPost.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({}),
+    } as Response);
+    renderChatPanel();
+    fireEvent.change(screen.getByRole('textbox', { name: 'Message input' }), {
+      target: { value: 'What went wrong?' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        "Couldn't send this message. Try again."
+      );
+    });
+  });
+
+  it('announces an attachment-type rejection via role="alert"', async () => {
+    renderChatPanel();
+    const input = document.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement;
+    const badFile = new File(['x'], 'clip.mp4', { type: 'video/mp4' });
+    Object.defineProperty(input, 'files', { value: [badFile] });
+    fireEvent.change(input);
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'Only PDF and image files work here.'
+      );
+    });
+  });
+});
+
 describe('ChatPanel', () => {
   beforeEach(() => {
     mockPost.mockReset();

--- a/web/src/components/ChatPanel/ChatPanel.tsx
+++ b/web/src/components/ChatPanel/ChatPanel.tsx
@@ -1212,7 +1212,9 @@ export default function ChatPanel({
               </div>
               <ComposerPill {...composerProps} />
               {networkError != null && (
-                <p className={styles.networkError}>{networkError}</p>
+                <p className={styles.networkError} role="alert">
+                  {networkError}
+                </p>
               )}
               {monthlyLimit != null &&
                 !limitReached &&
@@ -1358,7 +1360,9 @@ export default function ChatPanel({
                   </p>
                 )}
               {networkError != null && (
-                <p className={styles.networkError}>{networkError}</p>
+                <p className={styles.networkError} role="alert">
+                  {networkError}
+                </p>
               )}
               {successMessage != null && (
                 <p className={styles.successMessage} role="status">

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-14-chat-a11y.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-14-chat-a11y.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-14-chat-a11y",
+  "date": "2026-08-14",
+  "type": "fix",
+  "title": "Chat errors are announced to screen readers, and its small helper text is easier to read"
+}

--- a/web/src/styles/base.css
+++ b/web/src/styles/base.css
@@ -2,6 +2,7 @@
   --color-text-primary: #1f2937;
   --color-text-secondary: #6b7280;
   --color-text-tertiary: #838b99;
+  --color-text-tertiary-accessible: #6a717c;
   --color-text-danger: #dc2626;
   --color-text-success: #059669;
   --color-text-link: #2563eb;
@@ -129,6 +130,7 @@
   --color-text-primary: #f9fafb;
   --color-text-secondary: #9ca3af;
   --color-text-tertiary: #7b8494;
+  --color-text-tertiary-accessible: #8a92a0;
   --color-text-danger: #f87171;
   --color-text-success: #34d399;
   --color-text-link: #60a5fa;
@@ -193,6 +195,7 @@
   --color-text-primary: #3a2e15;
   --color-text-secondary: #7a5b22;
   --color-text-tertiary: #9a7a3a;
+  --color-text-tertiary-accessible: #846932;
   --color-text-danger: #b91c1c;
   --color-text-success: #047857;
   --color-text-link: #7a5b22;
@@ -258,6 +261,7 @@
   --color-text-primary: #1e1b2e;
   --color-text-secondary: #5b5675;
   --color-text-tertiary: #8a84a0;
+  --color-text-tertiary-accessible: #6e697f;
   --color-text-danger: #dc2626;
   --color-text-success: #059669;
   --color-text-link: #6b59b3;
@@ -325,6 +329,7 @@
   --color-text-primary: #1a0a10;
   --color-text-secondary: #831843;
   --color-text-tertiary: #bd4f7c;
+  --color-text-tertiary-accessible: #b14a74;
   --color-text-danger: #dc2626;
   --color-text-success: #059669;
   --color-text-link: #be185d;


### PR DESCRIPTION
## What
Two pre-existing chat a11y gaps, both surfaced by the designer review on #4075 and shared across the chat surface (not specific to that PR):
1. The shared chat error paragraph now carries `role="alert"`, so every chat error — send failure, regenerate refusal, attachment rejection, deck-download failure — is announced to screen readers.
2. A dedicated `--color-text-tertiary-accessible` token replaces `--color-text-tertiary` on the four small helper-text chat classes (`.chipSize`, `.usageLine`, `.makingCards`, `.retentionHint`), lifting them to WCAG AA (≥4.5:1) on every theme.

## Why
Closes #4095. `--color-text-tertiary` at 0.75rem computed below the 4.5:1 AA minimum for normal text (light ~3.3:1, sepia/gold ~3.6:1, purple ~3.2:1). And the error paragraph had no `role`/`aria-live`, so refusals and failures were silent for screen-reader users — they'd act on a chat that had quietly errored.

## How
- `role="alert"` on both render sites of `<p className={styles.networkError}>` (empty-state and input-area branches; they're mutually exclusive, so only one is ever in the DOM). `alert` implies `aria-live="assertive"`, correct for an action-failed message.
- New `--color-text-tertiary-accessible` defined in all 5 theme blocks in `base.css`. Each value darkens (or, for dark theme, lightens) the theme's own tertiary along its existing hue — the neutral/tinted character is preserved, so the change is visually near-invisible, just enough to pass. Verified against both surfaces a class can sit on (`--color-bg-primary` and `--color-bg-secondary`); the reported ratio is the worse of the two.
- `--color-text-tertiary` itself is untouched — no global reskin. Only the four named chat classes switch to the new token.

Per-theme contrast (WCAG relative luminance; new value vs bg-primary / bg-secondary → worst case):

| Theme | tertiary → accessible | bg-primary | bg-secondary | worst |
| --- | --- | --- | --- | --- |
| light (`:root`) | `#838b99` → `#6a717c` | 4.92 | 4.71 | **4.71** |
| dark | `#7b8494` → `#8a92a0` | 5.66 | 4.68 | **4.68** |
| gold | `#9a7a3a` → `#846932` | 5.06 | 4.69 | **4.69** |
| purple | `#8a84a0` → `#6e697f` | 5.02 | 4.70 | **4.70** |
| hotpink | `#bd4f7c` → `#b14a74` | 4.86 | 4.69 | **4.69** |

All ≥ 4.5:1. For reference the old tertiary worst-cases were light 3.28, dark 3.89, gold 3.64, purple 3.19, hotpink 4.21.

## Measuring success
A11y fix — no funnel metric. In-product verification: with VoiceOver/NVDA, trigger a chat send failure and confirm the error is spoken without moving focus (the `role="alert"` live region). Contrast is verifiable statically — the ratios above are arithmetic from the committed hex values and any WCAG checker reproduces them.

## Testing
- Unit tests added: two `it` blocks in `ChatPanel.test.tsx` under a new `error announcements` describe — one asserts a send failure (500) renders through `role="alert"` with the right text; one asserts a client-side attachment-type rejection reaches the same alerted element. Both failed for the right reason before the `role` was added (no `alert` role in the DOM), pass after.
- Full web suite: **363 files, 2858 passed, 0 failed**. Web typecheck clean. `pnpm format:check` (tree-wide, the exact CI command) clean. `pnpm lint` — 0 errors (pre-existing warnings only, none in touched files).

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px

Notes: `pnpm --filter 2anki-web test:golden-path` run as the attestation evidence — **2/2 passed (6.0s)**, landing + signed-in dashboard driven at a 375px viewport with the backend mocked at the edge, failing on any console error. My change touches a global token (`base.css`) loaded on every page and the ChatPanel (not on the golden path itself); the spec confirms no console regressions from the token addition. Chat-surface visual review of the darker helper text is worth a human glance under `pnpm dev` since Playwright can't judge "near-invisible"; the ratios above bound the change.

## Changelog
`Chat errors are announced to screen readers, and its small helper text is easier to read` (`web/src/pages/WhatsNewPage/changelog/2026-08-14-chat-a11y.json`)

## Risks
Low. The token is additive (no existing value changed), scoped to four chat classes; a wrong hex would only mean a slightly-off helper-text shade, caught visually. `role="alert"` is a standard ARIA live region; the two render sites are mutually exclusive so there's never a duplicate alert. Rollback: revert the single commit. Sonar note: change carries no new logic (one attribute + CSS-variable swaps + two tests, no functions/branching/complexity) — the PR-side SonarCloud decoration bot evaluates it; no local `sonar-scanner` run.

## Goal alignment
Makes the chat surface more accessible (WCAG AA), removing a barrier for screen-reader and low-vision learners — simpler/more usable for everyone, and it widens who can complete a chat-to-deck conversion. No direct funnel metric — internal quality/accessibility bar, not an acquisition lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbQZzLbjr2apKHQC7orhhw
