### PR TITLE
fix: report pool-drain terminations as interrupted, protect done jobs

### DIFF
--- a/src/data_layer/JobRepository.test.ts
+++ b/src/data_layer/JobRepository.test.ts
@@ -358,3 +358,56 @@ describe('JobRepository — generated SQL shape', () => {
     pgKnex.destroy();
   });
 });
+
+describe('JobRepository.updateJobStatus — terminal transitions', () => {
+  let db: Knex;
+  let repo: JobRepository;
+
+  beforeEach(async () => {
+    db = await makeDb();
+    repo = new JobRepository(db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it('failed does not overwrite done', async () => {
+    await insertJob(db, { owner: '1', object_id: 'job-1', status: 'done' });
+
+    await repo.updateJobStatus('job-1', '1', 'failed', 'late race loser');
+
+    const row = await db('jobs').where({ object_id: 'job-1' }).first();
+    expect(row.status).toBe('done');
+    expect(row.job_reason_failure).toBeNull();
+  });
+
+  it('interrupted does not overwrite done', async () => {
+    await insertJob(db, { owner: '1', object_id: 'job-1', status: 'done' });
+
+    await repo.updateJobStatus('job-1', '1', 'interrupted', 'pool drain');
+
+    const row = await db('jobs').where({ object_id: 'job-1' }).first();
+    expect(row.status).toBe('done');
+  });
+
+  it('done overwrites failed so a successful restart recovers the job', async () => {
+    await insertJob(db, { owner: '1', object_id: 'job-1', status: 'failed' });
+
+    await repo.updateJobStatus('job-1', '1', 'done', undefined, 12);
+
+    const row = await db('jobs').where({ object_id: 'job-1' }).first();
+    expect(row.status).toBe('done');
+    expect(row.card_count).toBe(12);
+  });
+
+  it('failed still lands on a running job', async () => {
+    await insertJob(db, { owner: '1', object_id: 'job-1', status: 'started' });
+
+    await repo.updateJobStatus('job-1', '1', 'failed', 'real failure');
+
+    const row = await db('jobs').where({ object_id: 'job-1' }).first();
+    expect(row.status).toBe('failed');
+    expect(row.job_reason_failure).toBe('real failure');
+  });
+});

--- a/src/data_layer/JobRepository.ts
+++ b/src/data_layer/JobRepository.ts
@@ -149,6 +149,13 @@ class JobRepository {
     if (!isTerminal) {
       query.whereNotIn('status', JobRepository.TERMINAL_STATUSES);
     }
+    // A finished deck must never present as failed: a racing writer (pool
+    // shutdown, duplicate dispatch) marking failure after the success writer
+    // marked done is the bug, not a state to record. done may still overwrite
+    // failed — that is the restart path succeeding.
+    if (isTerminal && status !== 'done') {
+      query.whereNot('status', 'done');
+    }
     const update: Record<string, unknown> = {
       status,
       job_reason_failure: description,

--- a/src/lib/storage/jobs/helpers/performConversion.ts
+++ b/src/lib/storage/jobs/helpers/performConversion.ts
@@ -413,6 +413,8 @@ export default async function performConversion(
         code: error.code,
         rawOutput: error.rawOutput,
       });
+    } else {
+      console.error('[conversion] failed', { jobId: id, error });
     }
     if (isNotionUnauthorizedError(error)) {
       const ownerNum = Number(owner);

--- a/src/lib/workerTermination.test.ts
+++ b/src/lib/workerTermination.test.ts
@@ -1,0 +1,15 @@
+import { isWorkerTerminationError } from './workerTermination';
+
+describe('isWorkerTerminationError', () => {
+  it('matches the piscina pool-destroy rejection', () => {
+    expect(
+      isWorkerTerminationError(new Error('Terminating worker thread'))
+    ).toBe(true);
+  });
+
+  it('does not match other errors or non-errors', () => {
+    expect(isWorkerTerminationError(new Error('ECONNRESET'))).toBe(false);
+    expect(isWorkerTerminationError('Terminating worker thread')).toBe(false);
+    expect(isWorkerTerminationError(undefined)).toBe(false);
+  });
+});

--- a/src/lib/workerTermination.ts
+++ b/src/lib/workerTermination.ts
@@ -1,0 +1,10 @@
+// Piscina rejects in-flight tasks with `Error('Terminating worker thread')`
+// when a pool is destroyed (recycle drain timeout, graceful shutdown). The
+// class behind it is created by a factory and not exported at runtime, so the
+// message is the stable marker across piscina versions (piscina/src/errors.ts).
+export function isWorkerTerminationError(err: unknown): boolean {
+  return err instanceof Error && err.message === 'Terminating worker thread';
+}
+
+export const WORKER_INTERRUPTED_REASON =
+  'The server restarted while converting this file. Upload it again to retry.';

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -83,6 +83,10 @@ import CustomExporter from '../lib/parser/exporters/CustomExporter';
 import Deck from '../lib/parser/Deck';
 import { isHTMLFile, isMarkdownFile } from '../lib/storage/checks';
 import { FileSizeInMegaBytes } from '../lib/misc/file';
+import {
+  isWorkerTerminationError,
+  WORKER_INTERRUPTED_REASON,
+} from '../lib/workerTermination';
 import { track } from './events/track';
 import { parseFirstTouch } from '../controllers/helpers/parseFirstTouch';
 import { classifyDevice } from '../lib/analytics/classifyDevice';
@@ -567,6 +571,18 @@ class UploadService {
         await this.jobRepository.updateJobStatus(job.object_id, owner, step);
       }
     ).catch(async (err: Error) => {
+      if (isWorkerTerminationError(err)) {
+        console.info('[UploadService] restart interrupted by pool drain', {
+          jobId: job.object_id,
+        });
+        await this.jobRepository.updateJobStatus(
+          job.object_id,
+          owner,
+          'interrupted',
+          WORKER_INTERRUPTED_REASON
+        );
+        return;
+      }
       await this.jobRepository.updateJobStatus(
         job.object_id,
         owner,
@@ -996,6 +1012,18 @@ class UploadService {
         }
       })
       .catch(async (err: unknown) => {
+        if (isWorkerTerminationError(err)) {
+          console.info('[UploadService] async job interrupted by pool drain', {
+            jobId: ws.id,
+          });
+          await this.jobRepository.updateJobStatus(
+            ws.id,
+            owner,
+            'interrupted',
+            WORKER_INTERRUPTED_REASON
+          );
+          return;
+        }
         const message = err instanceof Error ? err.message : String(err);
         const isExpectedState =
           err instanceof EmptyDeckError ||

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-14-interrupted-not-failed.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-14-interrupted-not-failed.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-14-interrupted-not-failed",
+  "date": "2026-08-14",
+  "type": "fix",
+  "title": "Conversions interrupted by a server update now say so and ask you to retry"
+}


### PR DESCRIPTION
## What
Pool-drain worker terminations stop presenting as user-facing conversion failures: they mark the job `interrupted` with an honest retry message, a `done` job can no longer be overwritten by a late failure writer, and `performConversion` logs the errors it previously swallowed.

## Why
Addresses parts 2 and 3 of #4099 (part 1, the double-dispatch trace, stays open there). Prod case 2026-08-13: a free user's 156-page scanned PDF generated ~1,750 cards, then a routine Piscina pool recycle destroyed the worker whose task had hung post-generation; the `ThreadTermination` rejection was recorded as `failed` with the generic "something went wrong on our end" message. An infrastructure lifecycle event presented to the user as a conversion failure.

## How
- `src/lib/workerTermination.ts`: `isWorkerTerminationError` (piscina's marker message; the class isn't exported at runtime) + the retry-facing reason string.
- `UploadService`: both async catch sites map termination → `updateJobStatus('interrupted', …)` + `console.info`, everything else unchanged.
- `JobRepository.updateJobStatus`: failure-terminal statuses (`failed`/`cancelled`/`interrupted`) get `whereNot('status','done')` — a finished deck can't be re-marked failed by a racing writer. `done` still overwrites `failed` so the restart path recovers jobs.
- `performConversion` catch: non-`PythonExitError` errors now log `[conversion] failed { jobId, error }` before reaching `SetJobFailed` — previously zero server-side trace.

## Measuring success
Prod logs: `[UploadService] async job interrupted by pool drain` lines replace generic failures at recycle time; `grep 'async job failed'` count should drop. The next #4099-class incident carries a `[conversion] failed` line with the real error.

## Testing
- New: 4 `updateJobStatus` transition tests (failed/interrupted can't clobber done; done recovers failed; failed lands on running) + `isWorkerTerminationError` unit tests.
- Full server suite: 6,445 passed; only failure is the documented environmental `getPageCount` (pdfinfo). `tsc -p . --noEmit` clean, `pnpm format:check` clean.

## Browser check
Browser check: not applicable — server-side only plus a changelog JSON; the `interrupted` status and its reason string already render via the existing DownloadsPage `StatusTag`.

## Changelog
"Conversions interrupted by a server update now say so and ask you to retry" (`2026-08-14-interrupted-not-failed.json`).

## Risks
Low. The status guard is scoped to failure-terminal writes; the termination mapping is scoped to one exact error marker. If piscina ever changes the message, behavior degrades to today's (generic failure), not worse.

## Goal alignment
Retention/trust on the conversion funnel: heavy AI users (the exact cohort the survey targets) stop seeing "our end failed" for decks that generated. Metric: `async job failed` rate in prod logs and `conversion_failed` reason mix at `/api/ops/metrics`.
