### PR TITLE
fix: read comma-separated Quizlet exports line by line

### DIFF
--- a/src/lib/parser/experimental/FallbackParser.test.ts
+++ b/src/lib/parser/experimental/FallbackParser.test.ts
@@ -83,6 +83,70 @@ describe('FallbackParser tab-separated text', () => {
   });
 });
 
+describe('FallbackParser comma-separated text (Quizlet comma export)', () => {
+  it('creates one card per line from a comma-separated .txt export', () => {
+    const content =
+      'mitochondria,powerhouse of the cell\nosmosis,diffusion of water across a membrane\nATP,energy currency of the cell';
+    const parser = new FallbackParser([
+      { name: 'quizlet_export.txt', contents: Buffer.from(content) },
+    ]);
+    const decks = parser.run({} as any);
+    expect(decks).toHaveLength(1);
+    expect(decks[0].cards).toHaveLength(3);
+    expect(decks[0].cards[0].name).toBe('mitochondria');
+    expect(decks[0].cards[0].back).toBe('powerhouse of the cell');
+    expect(decks[0].cards[2].name).toBe('ATP');
+    expect(decks[0].cards[2].back).toBe('energy currency of the cell');
+  });
+
+  it('splits on the first comma when a definition itself contains commas', () => {
+    const content =
+      'CNS,brain and spinal cord\nPNS,nerves outside the CNS\nneuron,nerve cell\nsynapse,junction between neurons\nglia,support cells\naxon,long projection\ndendrite,branched projection\nsoma,cell body\nmyelin,insulating sheath\nmeninges,dura, arachnoid, and pia mater';
+    const parser = new FallbackParser([
+      { name: 'anatomy.txt', contents: Buffer.from(content) },
+    ]);
+    const decks = parser.run({} as any);
+    expect(decks).toHaveLength(1);
+    expect(decks[0].cards).toHaveLength(10);
+    expect(decks[0].cards[9].name).toBe('meninges');
+    expect(decks[0].cards[9].back).toBe('dura, arachnoid, and pia mater');
+  });
+
+  it('leaves " - " pair files to pair parsing even when lines contain commas', () => {
+    const content =
+      'What is DNA? - deoxyribonucleic acid, the genetic code\nWhat is RNA? - ribonucleic acid, the messenger\nWhat is a gene? - a unit of heredity, made of DNA';
+    const parser = new FallbackParser([
+      { name: 'bio.txt', contents: Buffer.from(content) },
+    ]);
+    const decks = parser.run({} as any);
+    expect(decks).toHaveLength(1);
+    expect(decks[0].cards).toHaveLength(3);
+    expect(decks[0].cards[0].name).toBe('What is DNA?');
+    expect(decks[0].cards[0].back).toBe(
+      'deoxyribonucleic acid, the genetic code'
+    );
+  });
+
+  it('keeps prose with varying comma counts an empty deck', () => {
+    const content =
+      'The cell membrane regulates transport, signaling, and adhesion.\nRibosomes synthesize proteins.\nThe nucleus, dense and central, stores DNA.\nEnzymes lower activation energy.';
+    const parser = new FallbackParser([
+      { name: 'lecture_notes.txt', contents: Buffer.from(content) },
+    ]);
+    const decks = parser.run({} as any);
+    expect(decks).toHaveLength(0);
+  });
+
+  it('needs at least three lines before treating commas as separators', () => {
+    const content = 'First point, made in passing.\nSecond point, also brief.';
+    const parser = new FallbackParser([
+      { name: 'two_lines.txt', contents: Buffer.from(content) },
+    ]);
+    const decks = parser.run({} as any);
+    expect(decks).toHaveLength(0);
+  });
+});
+
 describe('FallbackParser CSV column mapping', () => {
   it('maps front and back by column name when the header order is reversed', () => {
     const csv = 'back,front\nHello,Bonjour';

--- a/src/lib/parser/experimental/FallbackParser.ts
+++ b/src/lib/parser/experimental/FallbackParser.ts
@@ -161,6 +161,46 @@ class FallbackParser {
       .filter((note) => note.name.length > 0 && note.back.length > 0);
   }
 
+  isCommaSeparated(contents: string): boolean {
+    const lines = contents
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+    if (lines.length < 3) return false;
+    if (
+      lines.some(
+        (line) =>
+          line.includes('\t') || line.includes(' - ') || line.includes(' = ')
+      )
+    ) {
+      return false;
+    }
+    const pairLines = lines.filter((line) => {
+      const commaIndex = line.indexOf(',');
+      return (
+        line.split(',').length === 2 &&
+        line.slice(0, commaIndex).trim().length > 0 &&
+        line.slice(commaIndex + 1).trim().length > 0
+      );
+    });
+    return pairLines.length >= lines.length * 0.9;
+  }
+
+  parseCommaSeparated(contents: string): Note[] {
+    return contents
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.includes(','))
+      .map((line, index) => {
+        const commaIndex = line.indexOf(',');
+        const note = new Note(line.slice(0, commaIndex).trim(), '');
+        note.back = line.slice(commaIndex + 1).trim();
+        note.number = index;
+        return note;
+      })
+      .filter((note) => note.name.length > 0 && note.back.length > 0);
+  }
+
   private parseHTMLFile(
     contents: string,
     fileName: string
@@ -191,6 +231,12 @@ class FallbackParser {
       return {
         cards: this.mapCardsToNotes(found),
         deckName: this.getTitleMarkdown(contents),
+      };
+    }
+    if (this.isCommaSeparated(contents)) {
+      return {
+        cards: this.parseCommaSeparated(contents),
+        deckName: fileName.replace(/\.[^/.]+$/, ''),
       };
     }
     return this.parseUnstructuredText(contents, fileName);

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-15-quizlet-comma-export.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-15-quizlet-comma-export.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-15-quizlet-comma-export",
+  "date": "2026-08-15",
+  "type": "fix",
+  "title": "Quizlet exports with comma-separated terms now convert line by line"
+}


### PR DESCRIPTION
## What

Teaches the upload fallback parser to read comma-separated Quizlet exports (`term,definition`, one card per line). Tab-separated exports already worked; comma was the dead path — every line lost its definition and the upload ended as an empty-deck error.

## Why

A rating-1 feedback this week: a Quizlet export converted to an unusable deck (#4106). The Quizlet→Anki landing page, the convert hub, and an /answers page all advertise exactly this conversion. Quizlet's built-in text export offers two term/definition separators — tab and comma; we only parsed one of them.

## How

`FallbackParser.isCommaSeparated` gates a new line-by-line comma split, deliberately narrow so prose can never mis-split:

- at least 3 non-empty lines,
- no tabs and no ` - `/` = ` pair separators anywhere in the file (existing formats always win),
- ≥90% of lines contain exactly one comma with non-empty text on both sides.

Qualifying files split each line at its **first** comma, so definitions containing commas stay intact. The check runs after tab and markdown-bullet handling — every currently-working format keeps its exact behavior. Verified `.csv` uploads were already fine: SheetJS sniffs tab/comma delimiters in `rowsFromBuffer`.

## Decisions made overnight (please review)

- Threshold: 90% exactly-one-comma over ≥3 lines — chose strict-gate-with-fallback over looser detection. Assumption: a file of short one-comma lines is a term/definition list, not prose (prose varies 0–2+ commas per line and lives in paragraphs). If wrong, tune the constants in `isCommaSeparated`.
- Scope: did NOT add semicolon row-separator support (Quizlet's "between rows: semicolon" option produces one giant line) and did NOT touch the landing pages — the advertised default (tab) and the comma alternative both convert now. The reporter's exact file shape is unknowable from the feedback text; this closes the one reproducible dead path.
- Kept the fix in `FallbackParser` beside the existing tab support rather than inside `PlainTextParser` — same layer, same detection style, no change to `PlainTextParser`'s contract.

## Measuring success

Near-empty-deck rate for plain-text input on the input-format-segmented upload funnel (`/api/ops/metrics`, shipped in c47f390f); day-7 read after deploy.

## Testing

- 5 new Jest cases: comma export → one card per line; first-comma split with comma-bearing definitions; ` - ` files with commas untouched; prose with varying commas stays empty; two-line files don't trigger.
- Full server suite: 6478 passed; only the documented environmental failures (`getPageCount` pdfinfo ×2) plus one parallel-run timing flake (`scheduleAnkifyPolling`, passes isolated, diff-independent). Full web suite: 2858 passed. `pnpm format:check` clean, server tsc clean.

## Browser check

Not applicable — changelog-JSON-only web diff; no component or style changes.

Sonar: local scanner not run overnight; PR decoration will report on this push.

## Goal alignment

Acquisition lane: first-conversion success on an actively marketed acquisition surface.

Fixes #4106

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbQZzLbjr2apKHQC7orhhw
