### PR TITLE
fix: stop bundling media for nodes a mind map export excludes

### DIFF
--- a/src/usecases/mindmaps/ExportMindmapUseCase.test.ts
+++ b/src/usecases/mindmaps/ExportMindmapUseCase.test.ts
@@ -1,0 +1,89 @@
+process.env.SKIP_CREATE_DECK = '1';
+
+import { ExportMindmapUseCase, MindmapCardType } from './ExportMindmapUseCase';
+import { MindmapData } from './MindmapData';
+import { MindmapRepositoryInterface } from '../../data_layer/MindmapRepository';
+import StorageHandler from '../../lib/storage/StorageHandler';
+import { MindmapsId } from '../../data_layer/public/Mindmaps';
+import { UsersId } from '../../data_layer/public/Users';
+
+const mapWithIsolatedImageNode: MindmapData = {
+  nodes: [
+    {
+      id: 'a',
+      label: 'Heart',
+      image: { url: 'mindmaps/2/1/heart.png', width: 10, height: 10 },
+    },
+    {
+      id: 'b',
+      label: 'Aorta',
+      image: { url: 'mindmaps/2/1/aorta.png', width: 10, height: 10 },
+    },
+    {
+      id: 'floating',
+      label: 'Floating note',
+      image: { url: 'mindmaps/2/1/floating.png', width: 10, height: 10 },
+    },
+  ],
+  edges: [{ source: 'a', target: 'b' }],
+};
+
+function buildUseCase(data: MindmapData) {
+  const repo = {
+    findById: jest.fn().mockResolvedValue({ id: 1, title: 'Anatomy', data }),
+  };
+  const storage = {
+    getFileContents: jest
+      .fn()
+      .mockResolvedValue({ Body: Buffer.from('png-bytes') }),
+  };
+  const useCase = new ExportMindmapUseCase(
+    repo as unknown as MindmapRepositoryInterface,
+    storage as unknown as StorageHandler
+  );
+  return { useCase, storage };
+}
+
+function runExport(data: MindmapData, cardType: MindmapCardType) {
+  const { useCase, storage } = buildUseCase(data);
+  return useCase
+    .execute({ id: 'map-1' as MindmapsId, userId: 2 as UsersId, cardType })
+    .then((result) => ({ result, storage }));
+}
+
+describe('ExportMindmapUseCase media bundling', () => {
+  it('does not fetch or bundle an isolated node image on basic export', async () => {
+    const { result, storage } = await runExport(
+      mapWithIsolatedImageNode,
+      'basic'
+    );
+    const fetchedKeys = storage.getFileContents.mock.calls.map((c) => c[0]);
+    expect(fetchedKeys).toContain('mindmaps/2/1/heart.png');
+    expect(fetchedKeys).toContain('mindmaps/2/1/aorta.png');
+    expect(fetchedKeys).not.toContain('mindmaps/2/1/floating.png');
+    expect(result.buffer.toString()).not.toContain('floating.png');
+    expect(result.excludedNodeCount).toBe(1);
+  });
+
+  it('still fetches the isolated node image on cloze export, where it becomes a card', async () => {
+    const { result, storage } = await runExport(
+      mapWithIsolatedImageNode,
+      'cloze'
+    );
+    const fetchedKeys = storage.getFileContents.mock.calls.map((c) => c[0]);
+    expect(fetchedKeys).toContain('mindmaps/2/1/floating.png');
+    expect(result.buffer.toString()).toContain('floating.png');
+  });
+
+  it('fetches every node image on markmap export', async () => {
+    const { storage } = await runExport(mapWithIsolatedImageNode, 'markmap');
+    expect(storage.getFileContents).toHaveBeenCalledTimes(3);
+  });
+
+  it('keeps connected-node media intact on basic export', async () => {
+    const { result } = await runExport(mapWithIsolatedImageNode, 'basic');
+    const payload = result.buffer.toString();
+    expect(payload).toContain('heart.png');
+    expect(payload).toContain('aorta.png');
+  });
+});

--- a/src/usecases/mindmaps/ExportMindmapUseCase.ts
+++ b/src/usecases/mindmaps/ExportMindmapUseCase.ts
@@ -11,7 +11,10 @@ import { mindmapToNotes } from './mindmapToNotes';
 import { mindmapToClozeNotes } from './mindmapToClozeNotes';
 import { mindmapToMarkmapHtml } from './mindmapToMarkmapHtml';
 import { collectMindmapImages } from './collectMindmapImages';
-import { countExcludedMindmapNodes } from './mindmapExportCensus';
+import {
+  countExcludedMindmapNodes,
+  mediaEligibleNodeIds,
+} from './mindmapExportCensus';
 import { MindmapData } from './MindmapData';
 import { buildMindmapDeckInfo } from './buildMindmapDeckInfo';
 import CustomExporter from '../../lib/parser/exporters/CustomExporter';
@@ -73,7 +76,11 @@ export class ExportMindmapUseCase {
     const resolvedDeckName = deckName ?? map.title;
     const mapData = map.data as MindmapData;
     const excludedNodeCount = countExcludedMindmapNodes(mapData, cardType);
-    const collectedImages = await collectMindmapImages(mapData, this.storage);
+    const collectedImages = await collectMindmapImages(
+      mapData,
+      this.storage,
+      mediaEligibleNodeIds(mapData, cardType)
+    );
 
     const filenameMap: Record<string, string> = {};
     const allMediaFilenames: string[] = [];

--- a/src/usecases/mindmaps/collectMindmapImages.ts
+++ b/src/usecases/mindmaps/collectMindmapImages.ts
@@ -8,12 +8,14 @@ export interface CollectedImage {
 
 export async function collectMindmapImages(
   data: MindmapData,
-  storage: StorageHandler
+  storage: StorageHandler,
+  eligibleNodeIds: Set<string> | null = null
 ): Promise<CollectedImage[]> {
   const seen = new Set<string>();
   const result: CollectedImage[] = [];
 
   for (const node of data.nodes) {
+    if (eligibleNodeIds != null && !eligibleNodeIds.has(node.id)) continue;
     const { image } = node;
     if (image == null) continue;
     if (image.url == null || image.missing === true) continue;

--- a/src/usecases/mindmaps/mindmapExportCensus.ts
+++ b/src/usecases/mindmaps/mindmapExportCensus.ts
@@ -2,13 +2,31 @@ import { MindmapData } from './MindmapData';
 import type { MindmapCardType } from './ExportMindmapUseCase';
 import { reachableNodeIds } from './mindmapGraph';
 
-function countIsolatedNodes(data: MindmapData): number {
+function edgeIncidentNodeIds(data: MindmapData): Set<string> {
   const incident = new Set<string>();
   for (const edge of data.edges) {
     incident.add(edge.source);
     incident.add(edge.target);
   }
+  return incident;
+}
+
+function countIsolatedNodes(data: MindmapData): number {
+  const incident = edgeIncidentNodeIds(data);
   return data.nodes.filter((n) => !incident.has(n.id)).length;
+}
+
+export function mediaEligibleNodeIds(
+  data: MindmapData,
+  cardType: MindmapCardType
+): Set<string> | null {
+  if (cardType === 'basic') {
+    return edgeIncidentNodeIds(data);
+  }
+  if (cardType === 'cloze') {
+    return reachableNodeIds(data);
+  }
+  return null;
 }
 
 export function countExcludedMindmapNodes(


### PR DESCRIPTION
## What

Mind map exports no longer bundle image files for nodes the export excludes. Basic export skips edge-less nodes and cloze export skips root-unreachable ones, but image collection walked every node — each excluded node's image shipped as dead bytes in the .apkg (and cost a pointless Spaces fetch).

## Why

Issue #4092, split out from the #4081 mind map audit: orphan media was the confirmed defect left after #4093 closed the disconnected-export paths.

## How

`mediaEligibleNodeIds(data, cardType)` lives in `mindmapExportCensus.ts` next to the exclusion-count logic it mirrors — basic → edge-incident nodes, cloze → root-reachable nodes, markmap → all. `collectMindmapImages` takes that set and skips ineligible nodes before fetching. Note builders and the exporter are untouched; media files a note actually references are always collected.

## Decisions made overnight (please review)

The trio was convened on the issue's open product question — should basic export fabricate a card for a standalone node?

- **Decision: no fabricated card; the #4093 excluded-count notice stays the answer.** pm's call: a basic card is a Q→A pair, an unconnected node has neither side, and front=back is deck pollution — exclude-and-explain beats fabricate-and-guess. This also matches the issue's own "no user-facing regression" framing.
- **Designer disagreed** and proposed a mixed rule worth recording: export a card only when the isolated node has an image (front = label, back = image — genuine recall value), keep the notice for text-only nodes, with reworded notice copy. Not shipped overnight: it's new user-facing behavior plus a 10-locale copy change. If you want it, say so and it becomes a small follow-up.
- Cloze export's media set also narrows (cycle-only unreachable nodes' images no longer bundle) — consistent with what its excluded-count already reports.
- No changelog entry: the visible effect is a slightly smaller .apkg; nothing a user would look up.

## Testing

- New `ExportMindmapUseCase.test.ts` (the orchestration was previously untested): basic export neither fetches nor bundles the isolated node's image; cloze still includes it (single-node cloze card); markmap fetches all three; connected-node media intact.
- Mindmap suites 106/106, `MindmapRouter` integration 18/18, full server suite 6477 passed (remaining fails: documented `getPageCount` pdfinfo env ×2 + one parallel-run flake in `BlockHandler`, passes isolated). Format + tsc clean.

Sonar: local scanner not run overnight; PR decoration will report on this push.

## Goal alignment

Simpler/faster: smaller decks, fewer wasted storage reads. No funnel metric — internal cleanup of a paid surface.

Fixes #4092

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbQZzLbjr2apKHQC7orhhw
