### PR TITLE
fix: stop long PDF filenames from hanging page counting

### DIFF
--- a/src/lib/pdf/getPageCount.test.ts
+++ b/src/lib/pdf/getPageCount.test.ts
@@ -99,6 +99,15 @@ describe('getPageCount', () => {
     }
   );
 
+  it('still resolves when the pdf filename is too long for a diagnostic log name', async () => {
+    const longBase = 'a'.repeat(250);
+    const longPath = path.join(tmpDir, `${longBase}.pdf`);
+    await fs.writeFile(longPath, '%PDF-1.4 placeholder');
+    fakePdfinfo({ stdout: 'Pages: 3\n', code: 0 });
+
+    await expect(getPageCount(longPath)).resolves.toBe(3);
+  }, 10000);
+
   it('rejects encrypted PDFs with a message the failure classifier reads as pdf_password', async () => {
     fakePdfinfo({
       stderr: 'Command Line Error: Incorrect password\nEncrypted',

--- a/src/lib/pdf/getPageCount.ts
+++ b/src/lib/pdf/getPageCount.ts
@@ -2,6 +2,19 @@ import { spawn } from 'child_process';
 import path from 'path';
 import fs from 'fs/promises';
 
+const DIAGNOSTIC_LOG_BASENAME_MAX = 80;
+
+async function writeDiagnosticLog(
+  filePath: string,
+  contents: string
+): Promise<void> {
+  try {
+    await fs.writeFile(filePath, contents);
+  } catch (error) {
+    console.warn('[pdfinfo] diagnostic log write failed:', error);
+  }
+}
+
 export function getPageCount(
   pdfPath: string,
   credential?: string
@@ -36,13 +49,14 @@ export function getPageCount(
       const pdfDir = path.dirname(pdfPath);
       const pdfBaseName = path.basename(pdfPath, path.extname(pdfPath));
       const basename = path.basename(pdfPath);
+      const logBase = pdfBaseName.slice(0, DIAGNOSTIC_LOG_BASENAME_MAX);
 
-      await fs.writeFile(
-        path.join(pdfDir, `${pdfBaseName}_stdout.log`),
+      await writeDiagnosticLog(
+        path.join(pdfDir, `${logBase}_stdout.log`),
         stdout
       );
-      await fs.writeFile(
-        path.join(pdfDir, `${pdfBaseName}_stderr.log`),
+      await writeDiagnosticLog(
+        path.join(pdfDir, `${logBase}_stderr.log`),
         stderr
       );
 

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-16-long-filename-stall.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-16-long-filename-stall.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-16-long-filename-stall",
+  "date": "2026-08-16",
+  "type": "fix",
+  "title": "PDFs with very long filenames no longer stall the conversion"
+}


### PR DESCRIPTION
## What

A PDF whose filename is too long for the filesystem no longer stalls its conversion. `getPageCount` wrote pdfinfo's stdout/stderr diagnostics to `<basename>_stdout.log` inside the workspace; a ~250-character basename (Google-Drive-export shaped) made that path exceed the 255-byte filename limit, and the `ENAMETOOLONG` throw inside the close handler left the promise **unsettled forever** — the conversion hung with no error reaching the user or the job row.

Found in last night's prod error sweep (one occurrence, blue slot error log).

## How

Diagnostic log basenames cap at 80 characters, and the writes go through a helper that warns instead of throwing — page counting must never fail or hang over its own debug artifacts.

## Testing

New deterministic test (fake pdfinfo spawn): a 250-char filename now resolves the page count; previously it timed out. Full server suite 6487 passed — remaining 2 fails are the documented `getPageCount` pdfinfo env pair (hardcoded `/usr/local/bin/pdfinfo` vs brew ARM's `/opt/homebrew`, unrelated). Format + tsc clean.

## Browser check

Not applicable — changelog-JSON-only web diff.

Sonar: not run locally; PR decoration will report.

## Goal alignment

Simpler/faster: an upload class that silently hung now completes. No metric — reliability fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbQZzLbjr2apKHQC7orhhw
