### PR TITLE
fix: salvage an event batch when one row hits a deleted user

### DIFF
--- a/src/services/events/EventsSink.test.ts
+++ b/src/services/events/EventsSink.test.ts
@@ -107,6 +107,44 @@ describe('EventsSink', () => {
     await expect(sink.waitForPendingFlush()).resolves.toBeUndefined();
   });
 
+  it('salvages the rest of a batch when one row violates the user foreign key', async () => {
+    const { repo, inserted } = makeFakeRepository();
+    const deletedUserId = 999;
+    (repo.insertEvents as jest.Mock).mockImplementation(
+      async (rows: EventRow[]) => {
+        if (rows.some((row) => row.user_id === deletedUserId)) {
+          const error = new Error(
+            'violates foreign key constraint "events_user_id_foreign"'
+          ) as Error & { code: string };
+          error.code = '23503';
+          throw error;
+        }
+        inserted.push([...rows]);
+      }
+    );
+    const sink = new EventsSink(repo, { flushThreshold: 2 });
+    sink.record(baseRow);
+    sink.record({ ...baseRow, user_id: deletedUserId, anonymous_id: 'anon-7' });
+    await sink.waitForPendingFlush();
+
+    const flat = inserted.flat();
+    expect(flat).toHaveLength(2);
+    expect(flat[0]).toMatchObject({ user_id: 1 });
+    expect(flat[1]).toMatchObject({ user_id: null, anonymous_id: 'anon-7' });
+  });
+
+  it('still drops the batch on non-foreign-key repository errors', async () => {
+    const { repo, inserted } = makeFakeRepository();
+    (repo.insertEvents as jest.Mock).mockRejectedValue(new Error('db down'));
+    const sink = new EventsSink(repo, { flushThreshold: 2 });
+    sink.record(baseRow);
+    sink.record({ ...baseRow, name: 'upload_started' });
+    await expect(sink.waitForPendingFlush()).resolves.toBeUndefined();
+
+    expect(inserted).toHaveLength(0);
+    expect(repo.insertEvents).toHaveBeenCalledTimes(1);
+  });
+
   it('start is idempotent — a second start adds no second timer', () => {
     // This test previously called start twice and stop once with no assertion,
     // so it passed no matter what start() did. A leaked second interval would

--- a/src/services/events/EventsSink.ts
+++ b/src/services/events/EventsSink.ts
@@ -12,6 +12,13 @@ export type SignupOriginResolver = (
   userIds: number[]
 ) => Promise<Map<number, string | null>>;
 
+function isForeignKeyViolation(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error as Error & { code?: string }).code === '23503'
+  );
+}
+
 export class EventsSink {
   private buffer: EventRow[] = [];
 
@@ -54,9 +61,34 @@ export class EventsSink {
     this.buffer = [];
     if (rows.length === 0) return;
     await this.enrichSignupOrigins(rows);
-    await this.repository.insertEvents(rows).catch((error) => {
+    await this.repository.insertEvents(rows).catch(async (error) => {
+      if (isForeignKeyViolation(error)) {
+        await this.salvageRows(rows);
+        return;
+      }
       console.error(`[events] dropping ${rows.length} event(s):`, error);
     });
+  }
+
+  // A row whose user was deleted between record() and flush() fails the whole
+  // batch insert; re-inserting it anonymously keeps the funnel count while the
+  // other rows land untouched.
+  private async salvageRows(rows: EventRow[]): Promise<void> {
+    for (const row of rows) {
+      try {
+        await this.repository.insertEvents([row]);
+      } catch (rowError) {
+        if (!isForeignKeyViolation(rowError)) {
+          console.error('[events] dropping 1 event:', rowError);
+          continue;
+        }
+        await this.repository
+          .insertEvents([{ ...row, user_id: null }])
+          .catch((anonError) => {
+            console.error('[events] dropping 1 event:', anonError);
+          });
+      }
+    }
   }
 
   private async enrichSignupOrigins(rows: EventRow[]): Promise<void> {


### PR DESCRIPTION
## What

The events sink no longer drops a whole flush batch when a single row references a deleted user. On a foreign-key violation (pg `23503`) it now re-inserts the batch row by row, and the offending row lands with `user_id: null` (keeping its `anonymous_id`) so the funnel count survives the user's deletion. Non-FK errors (db down) keep the existing drop-once behavior — no retry storms.

## Why

Last night's prod sweep caught `[events] dropping 1 event(s): … violates foreign key constraint "events_user_id_foreign"`. That batch happened to hold one row, but a flush carries up to 100 — one signup racing the inactive-user deletion job could silently discard 99 innocent funnel events. Metrics at `/api/ops/metrics` undercount with no signal, the same failure class as the KNOWN_EVENTS parity incidents.

## Testing

Two new EventsSink tests: mixed batch salvages (good row lands as-is, deleted-user row lands anonymously); non-FK error still drops the batch after exactly one insert attempt. Events suites 17/17, full server suite 6488 passed (documented `getPageCount` env pair only), format + tsc clean.

No changelog entry — internal analytics integrity, nothing user-visible.

Sonar: not run locally; PR decoration will report.

## Goal alignment

Funnel metrics accuracy — the instrument every acquisition read depends on. No user-facing metric moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbQZzLbjr2apKHQC7orhhw

