### PR TITLE
feat: reject duplicate uploads while the same file is converting

### DIFF
--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -2974,3 +2974,156 @@ describe('UploadService.handleUpload — signup_origin attribution', () => {
     );
   });
 });
+
+describe('UploadService.handleUpload — in-flight duplicate guard', () => {
+  const originalWorkspaceBase = process.env.WORKSPACE_BASE;
+
+  beforeAll(() => {
+    process.env.WORKSPACE_BASE = path.join(os.tmpdir(), 'upload-service-test');
+  });
+
+  afterAll(() => {
+    process.env.WORKSPACE_BASE = originalWorkspaceBase;
+  });
+
+  beforeEach(() => {
+    MockGeneratePackagesUseCase.mockClear();
+    trackMock.mockClear();
+    mockWorkspaceId = 'guard-ws-id';
+  });
+
+  function buildJobRepo(): JobRepository {
+    return {
+      create: jest.fn().mockResolvedValue(undefined),
+      updateJobStatus: jest.fn().mockResolvedValue(undefined),
+    } as unknown as JobRepository;
+  }
+
+  function buildService() {
+    return new UploadService(
+      buildRepository(),
+      buildJobRepo(),
+      buildUsersRepo()
+    );
+  }
+
+  function buildAiRequest(contents: string, name = 'chapter.pdf') {
+    return buildRequest({
+      files: [
+        {
+          originalname: name,
+          mimetype: 'application/pdf',
+          size: contents.length,
+          buffer: Buffer.from(contents),
+        },
+      ],
+      body: { 'claude-ai-flashcards': 'true' },
+    } as unknown as Partial<express.Request>);
+  }
+
+  function buildPayingResponse() {
+    const built = buildResponse();
+    (built.res.locals as Record<string, unknown>).owner = 42;
+    (built.res.locals as Record<string, unknown>).patreon = true;
+    return built;
+  }
+
+  it('rejects a second identical upload while the first is still converting', async () => {
+    let finishFirst: (() => void) | undefined;
+    MockGeneratePackagesUseCase.mockImplementation(
+      () =>
+        ({
+          execute: jest.fn(
+            () =>
+              new Promise((resolve) => {
+                finishFirst = () => resolve({ packages: [] });
+              })
+          ),
+        }) as unknown as InstanceType<typeof GeneratePackagesUseCase>
+    );
+
+    const service = buildService();
+    const firstRes = buildPayingResponse();
+    await service.handleUpload(buildAiRequest('same bytes'), firstRes.res);
+    expect(firstRes.capturedStatus()).toBe(202);
+
+    const secondRes = buildPayingResponse();
+    await service.handleUpload(buildAiRequest('same bytes'), secondRes.res);
+
+    expect(secondRes.capturedStatus()).toBe(409);
+    expect(secondRes.capturedJson()).toMatchObject({
+      code: 'conversion_in_flight',
+    });
+    expect(MockGeneratePackagesUseCase).toHaveBeenCalledTimes(1);
+
+    finishFirst?.();
+  });
+
+  it('allows different content to convert concurrently', async () => {
+    MockGeneratePackagesUseCase.mockImplementation(
+      () =>
+        ({
+          execute: jest.fn(() => new Promise(() => {})),
+        }) as unknown as InstanceType<typeof GeneratePackagesUseCase>
+    );
+
+    const service = buildService();
+    const firstRes = buildPayingResponse();
+    await service.handleUpload(buildAiRequest('doc one'), firstRes.res);
+    const secondRes = buildPayingResponse();
+    await service.handleUpload(buildAiRequest('doc two'), secondRes.res);
+
+    expect(firstRes.capturedStatus()).toBe(202);
+    expect(secondRes.capturedStatus()).toBe(202);
+  });
+
+  it('releases the guard when the conversion finishes, allowing a re-upload', async () => {
+    let finishFirst: (() => void) | undefined;
+    MockGeneratePackagesUseCase.mockImplementationOnce(
+      () =>
+        ({
+          execute: jest.fn(
+            () =>
+              new Promise((_, reject) => {
+                finishFirst = () => reject(new EmptyDeckError());
+              })
+          ),
+        }) as unknown as InstanceType<typeof GeneratePackagesUseCase>
+    ).mockImplementation(
+      () =>
+        ({
+          execute: jest.fn(() => new Promise(() => {})),
+        }) as unknown as InstanceType<typeof GeneratePackagesUseCase>
+    );
+
+    const service = buildService();
+    const firstRes = buildPayingResponse();
+    await service.handleUpload(buildAiRequest('retry bytes'), firstRes.res);
+
+    finishFirst?.();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const retryRes = buildPayingResponse();
+    await service.handleUpload(buildAiRequest('retry bytes'), retryRes.res);
+    expect(retryRes.capturedStatus()).toBe(202);
+  });
+
+  it('never blocks two different users uploading the same content', async () => {
+    MockGeneratePackagesUseCase.mockImplementation(
+      () =>
+        ({
+          execute: jest.fn(() => new Promise(() => {})),
+        }) as unknown as InstanceType<typeof GeneratePackagesUseCase>
+    );
+
+    const service = buildService();
+    const firstRes = buildPayingResponse();
+    await service.handleUpload(buildAiRequest('shared bytes'), firstRes.res);
+
+    const otherUser = buildPayingResponse();
+    (otherUser.res.locals as Record<string, unknown>).owner = 43;
+    await service.handleUpload(buildAiRequest('shared bytes'), otherUser.res);
+
+    expect(otherUser.capturedStatus()).toBe(202);
+  });
+});

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import fs from 'node:fs';
 import path from 'node:path';
+import { createHash } from 'node:crypto';
 
 import { IUploadRepository } from '../data_layer/UploadRespository';
 import JobRepository from '../data_layer/JobRepository';
@@ -337,6 +338,8 @@ function logNoPackageDiagnostics(uploadedFiles: UploadedFile[]) {
 }
 
 class UploadService {
+  private readonly inFlightConversions = new Set<string>();
+
   getUploadsByOwner(owner: number) {
     return this.uploadRepository.getUploadsByOwner(owner);
   }
@@ -923,6 +926,26 @@ class UploadService {
     }
   }
 
+  private static conversionFingerprint(
+    owner: string,
+    files: UploadedFile[]
+  ): string {
+    const hash = createHash('sha256');
+    hash.update(owner);
+    const sorted = [...files].sort((a, b) =>
+      a.originalname.localeCompare(b.originalname)
+    );
+    for (const file of sorted) {
+      hash.update('\0');
+      hash.update(file.originalname);
+      hash.update(String(file.size ?? ''));
+      if (file.buffer != null) {
+        hash.update(file.buffer);
+      }
+    }
+    return hash.digest('hex');
+  }
+
   private async handleAsyncUpload(
     req: express.Request,
     res: express.Response,
@@ -932,9 +955,23 @@ class UploadService {
     paying: boolean
   ) {
     const files = req.files as UploadedFile[];
+    const fingerprint = UploadService.conversionFingerprint(owner, files);
+    if (this.inFlightConversions.has(fingerprint)) {
+      return res.status(409).json({
+        code: 'conversion_in_flight',
+        message:
+          "We're already converting this file. It'll land in My Decks in a few minutes — no need to upload again.",
+      });
+    }
+    this.inFlightConversions.add(fingerprint);
     const title =
       files.length === 1 ? files[0].originalname : `${files.length} files`;
-    await this.jobRepository.create(ws.id, owner, title, 'claude');
+    try {
+      await this.jobRepository.create(ws.id, owner, title, 'claude');
+    } catch (err) {
+      this.inFlightConversions.delete(fingerprint);
+      throw err;
+    }
     persistConversionSettings(ws.location, req.body);
 
     const ownerForEvent = Number(owner);
@@ -1055,6 +1092,9 @@ class UploadService {
           'failed',
           reason
         );
+      })
+      .finally(() => {
+        this.inFlightConversions.delete(fingerprint);
       });
 
     return res.status(202).json({ jobId: ws.id });

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-16-duplicate-conversion-guard.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-16-duplicate-conversion-guard.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-16-duplicate-conversion-guard",
+  "date": "2026-08-16",
+  "type": "fix",
+  "title": "Uploading the same file twice mid-conversion now tells you it's already in progress"
+}


### PR DESCRIPTION
## What

A second upload of the same file by the same user, while its AI conversion is still running, now gets a 409 with "We're already converting this file. It'll land in My Decks in a few minutes — no need to upload again." — instead of a second full Anthropic bill.

## Why

Yesterday's spend spike: a paying user (24679) re-uploaded one ~480KB document five times over 2.5 hours — each conversion was still grinding (the #4114 truncation cascade) when the next upload went in, so nothing ever appeared in My Decks and they kept retrying. ~$70 of the $74 day. Also the "make conversion idempotent" half of #4099's ask, at the upload layer.

## How

`handleAsyncUpload` fingerprints owner + sorted file names/sizes/bytes (sha256) into an in-process `Set`; a duplicate while in flight gets the 409, and `.finally` on the conversion chain releases the key on every terminal state (success, empty deck, thrown limits, failures — plus a catch around job creation). In-process is sound: pm2 runs `fork` with `instances: 1`, one color live at a time, and conversions are worker threads of the same process (engineer-verified against `ecosystem.blue-green.config.js`).

## Decisions (trio)

- **In-flight dedupe only, not a time-window block** (pm): re-converting with changed Card Options is legitimate and must never bounce; a sequential retry after completion always goes through. A time-window would trade a rare double-bill for common false rejects.
- Different users with identical content are never linked; the fingerprint includes the owner.
- Copy is server-side EN, rendered by the existing generic upload-error surface (`{code, message}` body) — no client or i18n changes.

## Testing

Four new outside-in tests on `handleUpload`: duplicate-while-converting → 409 + only one conversion dispatched; different content concurrent → both 202; guard releases after failure so a retry converts; different users same content → never blocked. Upload suite 77/77, full server suite 6495 passed (documented `getPageCount` env pair only), tsc + format clean.

## Browser check

Not applicable — changelog-JSON-only web diff; the message renders through the existing error surface.

Sonar: not run locally; PR decoration will report.

## Goal alignment

Per-user value: caps the worst-case AI cost per document at one conversion, and tells the user where their deck is instead of letting them spin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbQZzLbjr2apKHQC7orhhw
