### PR TITLE
fix: unblock notion landing pages and correct advertised prices

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -89,16 +89,37 @@
       {
         "@type": "Offer",
         "name": "Unlimited",
-        "price": "6",
+        "price": "7.99",
         "priceCurrency": "USD",
-        "description": "Unlimited flashcards, PDF support, concurrent conversions — billed monthly"
+        "description": "Unlimited flashcards, PDF support, AI conversion, concurrent conversions — billed monthly"
       },
       {
         "@type": "Offer",
-        "name": "Auto Sync",
-        "price": "30",
+        "name": "Unlimited (annual)",
+        "price": "64",
         "priceCurrency": "USD",
-        "description": "Automatic Notion to Anki sync every 5 minutes — billed monthly"
+        "description": "Everything in Unlimited, billed once a year"
+      },
+      {
+        "@type": "Offer",
+        "name": "Day Pass",
+        "price": "4",
+        "priceCurrency": "USD",
+        "description": "24 hours of Unlimited access, one-time payment"
+      },
+      {
+        "@type": "Offer",
+        "name": "Week Pass",
+        "price": "9",
+        "priceCurrency": "USD",
+        "description": "7 days of Unlimited access, one-time payment"
+      },
+      {
+        "@type": "Offer",
+        "name": "Lifetime",
+        "price": "345",
+        "priceCurrency": "USD",
+        "description": "Unlimited plus Auto Sync, forever — one-time payment"
       }
     ],
     "description": "Convert Notion pages, PDF, Markdown, HTML, CSV, Word, and Quizlet exports into Anki flashcard decks. Free up to 100 cards per month. Open source.",

--- a/web/public/robots.txt
+++ b/web/public/robots.txt
@@ -2,7 +2,7 @@
 User-agent: *
 Disallow: /api/
 Disallow: /rules/
-Disallow: /notion
+Disallow: /notion$
 Disallow: /favorites
 Disallow: /downloads
 Disallow: /chat

--- a/web/scripts/prerenderLandingPages.test.ts
+++ b/web/scripts/prerenderLandingPages.test.ts
@@ -225,7 +225,7 @@ describe('emitMetaOnlyPages', () => {
       '<title>Upload notes and get an Anki deck — 2anki</title>'
     );
     expect(pricing).toContain(
-      '<title>Pricing — Free, Day Pass, Unlimited, Auto Sync | 2anki</title>'
+      '<title>Pricing — Free, Day Pass, Unlimited, Lifetime | 2anki</title>'
     );
     expect(about).toContain(
       '<title>About 2anki — open-source Notion to Anki converter</title>'

--- a/web/scripts/prerenderLandingPages.ts
+++ b/web/scripts/prerenderLandingPages.ts
@@ -133,7 +133,7 @@ const NOTION_MARKETPLACE_META = {
   pathname: '/notion-marketplace',
   title: 'Notion to Anki — automatic sync | 2anki',
   description:
-    'Connect your Notion workspace and your notes become Anki flashcards automatically. No exports, no zips. Auto Sync $30/mo, Unlimited $6/mo.',
+    'Connect your Notion workspace and your notes become Anki flashcards automatically. No exports, no zips. Included with Unlimited at $7.99/mo.',
   h1: 'Your Notion notes become Anki cards — automatically',
   subhead:
     'Connect your workspace in 5 minutes. No exports, no zips, no manual steps.',
@@ -249,9 +249,9 @@ const META_ONLY_PAGES: MetaOnlyPageMeta[] = [
   },
   {
     pathname: '/pricing',
-    title: 'Pricing — Free, Day Pass, Unlimited, Auto Sync | 2anki',
+    title: 'Pricing — Free, Day Pass, Unlimited, Lifetime | 2anki',
     description:
-      'Compare 2anki plans. Free converts 100 cards a month. Unlimited at $6/mo. Auto Sync at $30/mo polls your Notion workspace and keeps your decks current.',
+      'Compare 2anki plans. Free converts 100 cards a month. Unlimited at $7.99/mo or $64/yr. Day and Week Passes from $4. Lifetime with Auto Sync included.',
   },
   {
     pathname: '/about',

--- a/web/src/pricingSchema.test.ts
+++ b/web/src/pricingSchema.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { LEGACY_UNLIMITED_PRICING } from './pages/PricingPage/pricing.constants';
+
+const indexHtml = readFileSync(resolve(__dirname, '../index.html'), 'utf-8');
+
+function extractSoftwareApplicationSchema(): {
+  offers: Array<{ name: string; price: string }>;
+} {
+  const blocks = [
+    ...indexHtml.matchAll(
+      /<script type="application\/ld\+json">([\s\S]*?)<\/script>/g
+    ),
+  ].map((m) => JSON.parse(m[1]));
+  const app = blocks.find((b) => b['@type'] === 'SoftwareApplication');
+  if (app == null) throw new Error('SoftwareApplication schema missing');
+  return app;
+}
+
+describe('index.html SoftwareApplication schema', () => {
+  it('advertises the live Unlimited prices, not a stale ramp', () => {
+    const { offers } = extractSoftwareApplicationSchema();
+    const monthly = offers.find((o) => o.name === 'Unlimited');
+    expect(monthly?.price).toBe(
+      (LEGACY_UNLIMITED_PRICING.monthlyCents / 100).toFixed(2)
+    );
+    const annual = offers.find((o) => o.name === 'Unlimited (annual)');
+    expect(annual?.price).toBe(
+      String(LEGACY_UNLIMITED_PRICING.annualCents / 100)
+    );
+  });
+
+  it('does not offer plans that cannot be purchased', () => {
+    const { offers } = extractSoftwareApplicationSchema();
+    expect(offers.map((o) => o.name)).not.toContain('Auto Sync');
+  });
+
+  it('lists the pass and lifetime offers at their card prices', () => {
+    const { offers } = extractSoftwareApplicationSchema();
+    expect(offers.find((o) => o.name === 'Day Pass')?.price).toBe('4');
+    expect(offers.find((o) => o.name === 'Week Pass')?.price).toBe('9');
+    expect(offers.find((o) => o.name === 'Lifetime')?.price).toBe('345');
+  });
+});

--- a/web/src/robots.test.ts
+++ b/web/src/robots.test.ts
@@ -23,3 +23,10 @@ describe('robots.txt', () => {
     expect(robotsTxt).toContain('Disallow: /card-options');
   });
 });
+
+describe('robots.txt landing-page safety', () => {
+  it('anchors the /notion disallow so /notion-to-anki stays crawlable', () => {
+    expect(robotsTxt).toContain('Disallow: /notion$');
+    expect(robotsTxt).not.toMatch(/Disallow: \/notion\n/);
+  });
+});


### PR DESCRIPTION
## What

Audit P0s #1 and #2, one surface:

- `robots.txt`: `Disallow: /notion` → `Disallow: /notion$`. The unanchored prefix blocked `/notion-to-anki/` (sitemap priority 0.9 — the single highest-value acquisition page) and `/notion-marketplace/`, confirmed live in production. The `$` anchor keeps the auth-gated `/notion` app route disallowed (Google/Bing honor it; crawlers that don't just get the SPA shell — the route is auth-gated server-side).
- `web/index.html` SoftwareApplication schema: replaces the stale $6 Unlimited offer and the un-purchasable $30 standalone Auto Sync offer with the live catalog — Unlimited $7.99/mo + $64/yr, Day Pass $4, Week Pass $9, Lifetime $345.
- Prerendered meta for `/pricing/` (title + description) and `/notion-marketplace/` (description) stop quoting "$6/mo … $30/mo" into SERP snippets.

## Why

The audit's only CRITICAL SEO finding plus a structured-data policy risk: the sitemap says "crawl this," robots said "don't," and every searcher who saw the pricing snippet was quoted a price that undercuts the real one.

## Durable sensor

New `web/src/pricingSchema.test.ts` parses the JSON-LD out of `index.html` and pins the Unlimited offers to `pricing.constants.ts` — the next reprice fails the suite instead of silently drifting the SERP. `robots.test.ts` now asserts the anchored form and rejects the unanchored one.

## Testing

Full web suite 2866/2866 (4 new tests), format clean. No changelog entry — crawl metadata, nothing a user would look up in the app.

## Browser check

Browser check: not applicable — robots.txt, JSON-LD, and prerendered meta only; no rendered UI change (the web/src diff is two test files).

Sonar: not run locally; PR decoration will report.

## Goal alignment

Acquisition lane: unblocks ranking of the primary money page (recrawl begins at deploy; Search Console read in 1–3 weeks) and corrects the advertised price to every searcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbQZzLbjr2apKHQC7orhhw

