### PR TITLE
fix: verify origin and cap height on review card frame messages

### DIFF
--- a/web/src/pages/AnkifyPage/components/ReviewPanel.test.tsx
+++ b/web/src/pages/AnkifyPage/components/ReviewPanel.test.tsx
@@ -1,9 +1,15 @@
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import {
+  act,
+  render,
+  screen,
+  waitFor,
+  fireEvent,
+} from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
-import ReviewPanel, { DeckPicker } from './ReviewPanel';
+import ReviewPanel, { CardFrame, DeckPicker } from './ReviewPanel';
 import { Backend, ReviewQueueCard } from '../../../lib/backend/Backend';
 import { AnkifyStats, AnkifyStatsDeck } from '../stats/types';
 
@@ -611,5 +617,55 @@ describe('DeckPicker collapse persistence', () => {
     expect(
       screen.getByRole('button', { name: 'Expand MS3' })
     ).toBeInTheDocument();
+  });
+});
+
+describe('CardFrame message handling', () => {
+  function frameHeight(container: HTMLElement): string {
+    const iframe = container.querySelector('iframe');
+    if (iframe == null) throw new Error('iframe missing');
+    return iframe.style.height;
+  }
+
+  function sendHeight(
+    container: HTMLElement,
+    height: number,
+    overrides: Partial<MessageEventInit> = {}
+  ) {
+    const iframe = container.querySelector('iframe');
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: { type: 'n2a-review-height', height },
+          origin: 'null',
+          source: iframe?.contentWindow ?? null,
+          ...overrides,
+        })
+      );
+    });
+  }
+
+  it('resizes to a height reported by its own sandboxed frame', () => {
+    const { container } = render(<CardFrame srcDoc="<p>card</p>" />);
+    sendHeight(container, 480);
+    expect(frameHeight(container)).toBe('480px');
+  });
+
+  it('ignores a height message from a foreign origin', () => {
+    const { container } = render(<CardFrame srcDoc="<p>card</p>" />);
+    sendHeight(container, 480, { origin: 'https://evil.example' });
+    expect(frameHeight(container)).toBe('128px');
+  });
+
+  it('ignores a height message whose source is not the frame', () => {
+    const { container } = render(<CardFrame srcDoc="<p>card</p>" />);
+    sendHeight(container, 480, { source: null });
+    expect(frameHeight(container)).toBe('128px');
+  });
+
+  it('caps a hostile height so card content cannot blow up the layout', () => {
+    const { container } = render(<CardFrame srcDoc="<p>card</p>" />);
+    sendHeight(container, 10_000_000);
+    expect(frameHeight(container)).toBe('4096px');
   });
 });

--- a/web/src/pages/AnkifyPage/components/ReviewPanel.tsx
+++ b/web/src/pages/AnkifyPage/components/ReviewPanel.tsx
@@ -174,6 +174,10 @@ export function DeckPicker({
 }
 
 const MIN_CARD_FRAME_HEIGHT = 128;
+// A sandboxed srcDoc frame (no allow-same-origin) always posts with the
+// literal origin "null"; anything else is another window impersonating the
+// card. The cap bounds what hostile card content can do to the page layout.
+const MAX_CARD_FRAME_HEIGHT = 4096;
 
 function buildSrcDoc(css: string, body: string): string {
   const sizingScript = `<script>(function(){function post(){parent.postMessage({type:'n2a-review-height',height:document.documentElement.scrollHeight},'*');}window.addEventListener('load',post);document.querySelectorAll('img').forEach(function(img){img.addEventListener('load',post);img.addEventListener('error',post);});if(window.ResizeObserver){new ResizeObserver(post).observe(document.documentElement);}post();var __a=document.querySelector('audio');if(__a){__a.play().catch(function(){});}})();</script>`;
@@ -194,6 +198,9 @@ export function CardFrame({ srcDoc }: { readonly srcDoc: string }) {
       if (event.source !== iframeRef.current?.contentWindow) {
         return;
       }
+      if (event.origin !== 'null') {
+        return;
+      }
       const data = event.data as { type?: string; height?: number };
       if (
         data?.type !== 'n2a-review-height' ||
@@ -202,7 +209,12 @@ export function CardFrame({ srcDoc }: { readonly srcDoc: string }) {
       ) {
         return;
       }
-      setHeight(Math.max(MIN_CARD_FRAME_HEIGHT, data.height));
+      setHeight(
+        Math.min(
+          MAX_CARD_FRAME_HEIGHT,
+          Math.max(MIN_CARD_FRAME_HEIGHT, data.height)
+        )
+      );
     };
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);


### PR DESCRIPTION
## What

Audit P0 #3. The Ankify review card renders in a sandboxed `srcDoc` iframe that posts its content height to the parent. The listener checked the message's `source` and shape but not its origin (Sonar S2819 — the only open CRITICAL security finding on main), and applied any finite height unbounded.

## How

A sandboxed frame without `allow-same-origin` always posts with the literal origin `"null"` — anything else is another window impersonating the card, and is now dropped. Heights clamp to a 4096px ceiling so hostile card content can't blow up the page layout.

## Testing

Four new CardFrame tests: legit frame message resizes; foreign origin ignored; foreign source ignored; hostile height capped. Full web suite 2866/2866, typecheck + format clean.

No changelog entry — security hardening with no visible behavior change for legitimate cards.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: machine-backed — `pnpm --filter 2anki-web test:golden-path` 2/2 on this diff.

Sonar: not run locally; PR decoration will report (and should close the S2819 on its next main scan).

## Goal alignment

None — security hardening on the paid Ankify surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbQZzLbjr2apKHQC7orhhw