### PR TITLE
fix: stop the zip recovery path from following symlinks

### DIFF
--- a/src/lib/zip/fallback/listFiles.test.ts
+++ b/src/lib/zip/fallback/listFiles.test.ts
@@ -1,0 +1,62 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { listFiles } from './listFiles';
+
+describe('listFiles', () => {
+  let workspace: string;
+  let outside: string;
+
+  beforeEach(async () => {
+    workspace = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), 'unpack-test-')
+    );
+    outside = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'secret-'));
+    await fs.promises.writeFile(path.join(outside, 'secret.txt'), 'top secret');
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(workspace, { recursive: true, force: true });
+    await fs.promises.rm(outside, { recursive: true, force: true });
+  });
+
+  it('collects regular files, including nested ones', async () => {
+    await fs.promises.writeFile(path.join(workspace, 'a.md'), 'alpha');
+    await fs.promises.mkdir(path.join(workspace, 'sub'));
+    await fs.promises.writeFile(path.join(workspace, 'sub', 'b.md'), 'beta');
+
+    const files = await listFiles(workspace);
+
+    expect(files.map((f) => path.basename(f.name)).sort()).toEqual([
+      'a.md',
+      'b.md',
+    ]);
+  });
+
+  it('never follows a symlink out of the workspace', async () => {
+    await fs.promises.writeFile(path.join(workspace, 'a.md'), 'alpha');
+    await fs.promises.symlink(
+      path.join(outside, 'secret.txt'),
+      path.join(workspace, 'link.md')
+    );
+
+    const files = await listFiles(workspace);
+
+    expect(files.map((f) => path.basename(f.name))).toEqual(['a.md']);
+    const contents = files.map((f) => Buffer.from(f.contents ?? []).toString());
+    expect(contents.join('')).not.toContain('top secret');
+  });
+
+  it('never follows a symlinked directory out of the workspace', async () => {
+    await fs.promises.symlink(
+      outside,
+      path.join(workspace, 'linked-dir'),
+      'dir'
+    );
+
+    const files = await listFiles(workspace);
+
+    expect(files).toEqual([]);
+  });
+});

--- a/src/lib/zip/fallback/listFiles.ts
+++ b/src/lib/zip/fallback/listFiles.ts
@@ -8,8 +8,11 @@ export async function listFiles(workspace: string) {
     const dir = await fs.promises.readdir(currentPath);
     for (const fileName of dir) {
       const filePath = `${currentPath}/${fileName}`;
-      const stats = await fs.promises.stat(filePath);
+      const stats = await fs.promises.lstat(filePath);
 
+      if (stats.isSymbolicLink()) {
+        continue;
+      }
       if (stats.isFile()) {
         const buffer = await fs.promises.readFile(filePath);
         files.push({


### PR DESCRIPTION
## What

Audit P0 #4 — the security sweep's one substantive finding. The bsdtar fallback for truncated archives (`src/lib/zip/fallback/listFiles.ts`) read extracted entries back with `stat`/`readFile` and no symlink guard: a crafted archive containing a symlink to an absolute path (e.g. a server config file) would embed that file's contents into the user's returned deck. The main zip path already rejects unsafe entry names and contains writes; only this recovery path lacked the guard.

## How

`lstat` instead of `stat`; symbolic links (file or directory) are skipped entirely.

## Testing

Three new tests: nested regular files still collected; a symlinked file pointing outside the workspace is excluded and its contents never appear; a symlinked directory is not descended into. Zip suites 41/41, full server suite 6500 passed (documented `getPageCount` env pair only), tsc + format clean.

No changelog entry — security hardening, no visible behavior change for legitimate archives.

Sonar: not run locally; PR decoration will report.

## Goal alignment

None — security hardening on the upload path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbQZzLbjr2apKHQC7orhhw