### PR TITLE
test: deflake the polling suite and drop BlockHandler fossils

### DIFF
--- a/src/lib/ankify/jobs/scheduleAnkifyPolling.test.ts
+++ b/src/lib/ankify/jobs/scheduleAnkifyPolling.test.ts
@@ -45,9 +45,17 @@ const makeUseCase = (): jest.Mocked<
     execute: jest.fn(async () => undefined),
   }) as unknown as jest.Mocked<Pick<SyncNotionPageToRacUseCase, 'execute'>>;
 
-const waitForTick = () => new Promise((resolve) => setTimeout(resolve, 30));
+const waitForTick = () => jest.advanceTimersByTimeAsync(16);
 
 describe('scheduleAnkifyPolling', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   test('skips a subscription deleted after the enabled snapshot was taken', async () => {
     const subscriptions = makeSubscriptions();
     const useCase = makeUseCase();

--- a/src/services/NotionService/BlockHandler/BlockHandler.test.ts
+++ b/src/services/NotionService/BlockHandler/BlockHandler.test.ts
@@ -266,12 +266,6 @@ jest.mock('get-notion-object-title', () => ({
 }));
 
 describe('BlockHandler', () => {
-  test.skip('Get Notion Page', async () => {
-    const page = await api.getPage('446d09aa05d041058c16e56232188e2b');
-    const title = await api.getPageTitle(page, new CardOption({}));
-    expect(title).toBe('Testing');
-  });
-
   test('Get Blocks', async () => {
     // This should be mocked
     const blocks = await api.getBlocks({
@@ -283,55 +277,6 @@ describe('BlockHandler', () => {
     });
     const topLevelToggles = getToggleBlocks(blocks.results);
     expect(topLevelToggles.length).toEqual(14);
-  });
-
-  test.skip('Toggle Headings in HTML export', async () => {
-    const r = new ParserRules();
-    r.setFlashcardTypes(['heading']);
-    const cards = await loadCards(
-      {},
-      '25226df63b4d4895a71f3bba01d8a8f3',
-      new Workspace(true, 'fs'),
-      r
-    );
-    console.log('cards', JSON.stringify(cards, null, 4));
-    expect(cards.length).toBe(1);
-  });
-
-  test.skip('Subpages', async () => {
-    const settings = new CardOption({ all: 'true' });
-    const rules = new ParserRules();
-    const exporter = new CustomExporter('', new Workspace(true, 'fs').location);
-    const bl = new BlockHandler(exporter, api, settings);
-    const decks = await bl.findFlashcards({
-      parentType: 'page',
-      topLevelId: examplId,
-      rules,
-      decks: [],
-      parentName: '',
-    });
-
-    expect(decks.length > 1).toBe(true);
-    expect(decks[1].name.includes('::')).toBe(true);
-  });
-
-  test.skip('Toggle Mode', async () => {
-    const flashcards = await loadCards(
-      {},
-      examplId,
-      new Workspace(true, 'fs'),
-      new ParserRules()
-    );
-    const nestedOnes = flashcards.find((c) => c.name.match(/Nested/i));
-    expect(nestedOnes?.back).toBe(true);
-  });
-
-  test.skip('Strikethrough Local Tags', async () => {
-    const card = await findCardByName('This card has three tags', {
-      tags: 'true',
-    });
-    const expected = ['global tag', 'tag a', 'tag b'];
-    expect(card?.tags).toBe(expected);
   });
 
   test('Basic Cards from Blocks', async () => {
@@ -880,25 +825,27 @@ describe('BlockHandler', () => {
 
     const getBlocksSpy = jest.spyOn(api, 'getBlocks');
 
-    const flashcards = await loadCards(
-      {},
-      tablePageId,
-      new Workspace(true, 'fs'),
-      rules
-    );
+    try {
+      const flashcards = await loadCards(
+        {},
+        tablePageId,
+        new Workspace(true, 'fs'),
+        rules
+      );
 
-    expect(flashcards).toHaveLength(2);
-    expect(flashcards[0].name).toContain('hello');
-    expect(flashcards[0].back).toContain('world');
-    expect(flashcards[1].name).toContain('goodbye');
-    expect(flashcards[1].back).toContain('moon');
+      expect(flashcards).toHaveLength(2);
+      expect(flashcards[0].name).toContain('hello');
+      expect(flashcards[0].back).toContain('world');
+      expect(flashcards[1].name).toContain('goodbye');
+      expect(flashcards[1].back).toContain('moon');
 
-    const tableBlockCalls = getBlocksSpy.mock.calls.filter(
-      (call) => call[0].id === tableBlockId
-    );
-    expect(tableBlockCalls).toHaveLength(1);
-
-    getBlocksSpy.mockRestore();
+      const tableBlockCalls = getBlocksSpy.mock.calls.filter(
+        (call) => call[0].id === tableBlockId
+      );
+      expect(tableBlockCalls).toHaveLength(1);
+    } finally {
+      getBlocksSpy.mockRestore();
+    }
   });
 
   test('Code-wrapped text in a table cell produces a cloze note', async () => {


### PR DESCRIPTION
## What

Audit test-health lane, the two weekly parallel-run flakes fixed at root:

- `scheduleAnkifyPolling.test.ts` raced a real 30ms sleep against a real 5ms interval — under a saturated worker pool the window fit zero fires and assertions read 0 calls. Now drives jest fake timers (`advanceTimersByTimeAsync`), fully deterministic; 3 consecutive runs green.
- `BlockHandler.test.ts`: the `getBlocks` spy restore moves into a `finally` (one assertion failure used to leak the spy onto the shared api object for every later test — the flake-cascade amplifier), and the five committed `test.skip` fossils from the pre-fixture network era are deleted. Two were broken as written (`toBe` on an array, `toBe(true)` on a string back); modern fixture suites (DeckParser nested-toggle, subpage, tag coverage) own those behaviors. Deleting rather than resurrecting per testing.md — a skip the suite can't see is drift, not coverage.

## Testing

Polling suite 6/6 ×3 runs; BlockHandler 28 passed / 6 todo / 0 skipped; full server suite 6497 passed (documented `getPageCount` env pair only), tsc + format clean. No changelog entry — test-only.

Sonar: not run locally; PR decoration will report.

## Goal alignment

None — CI trust. Every green claim on future PRs stops being haunted by these two suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbQZzLbjr2apKHQC7orhhw