### PR TITLE
test: add i18n and ops route-button parity sensors + winback button

### DIFF
--- a/web/src/lib/i18n/locales/parity.test.ts
+++ b/web/src/lib/i18n/locales/parity.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const NON_EN_LOCALES = [
+  'de',
+  'es',
+  'fr',
+  'it',
+  'ja',
+  'nl',
+  'pl',
+  'pt',
+  'ru',
+] as const;
+
+const PLURAL_SUFFIX = /_(zero|one|two|few|many|other)$/;
+const PLACEHOLDER = /{{\s*([^}]+?)\s*}}/g;
+
+function localePath(locale: string, file?: string): string {
+  return file ? join(__dirname, locale, file) : join(__dirname, locale);
+}
+
+function namespaceFiles(locale: string): string[] {
+  return readdirSync(localePath(locale))
+    .filter((name) => name.endsWith('.json'))
+    .sort();
+}
+
+function readNamespace(locale: string, file: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(localePath(locale, file), 'utf8')) as Record<
+    string,
+    unknown
+  >;
+}
+
+function flatten(
+  value: Record<string, unknown>,
+  prefix = ''
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, child] of Object.entries(value)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (child != null && typeof child === 'object' && !Array.isArray(child)) {
+      Object.assign(out, flatten(child as Record<string, unknown>, path));
+    } else if (typeof child === 'string') {
+      out[path] = child;
+    }
+  }
+  return out;
+}
+
+function baseKey(key: string): string {
+  return key.replace(PLURAL_SUFFIX, '');
+}
+
+function baseKeySet(flat: Record<string, string>): Set<string> {
+  return new Set(Object.keys(flat).map(baseKey));
+}
+
+function placeholders(value: string): Set<string> {
+  return new Set(Array.from(value.matchAll(PLACEHOLDER), (match) => match[1]));
+}
+
+const EN_FILES = namespaceFiles('en');
+
+describe('i18n locale parity with en', () => {
+  it('en ships at least one namespace file', () => {
+    expect(EN_FILES.length).toBeGreaterThan(0);
+  });
+
+  describe.each(NON_EN_LOCALES)('%s', (locale) => {
+    it.each(EN_FILES)('has the %s namespace file', (file) => {
+      expect(existsSync(localePath(locale, file))).toBe(true);
+    });
+
+    it.each(EN_FILES)(
+      'shares the same key set as en/%s (plural suffixes exempt)',
+      (file) => {
+        if (!existsSync(localePath(locale, file))) {
+          return;
+        }
+        const enBase = baseKeySet(flatten(readNamespace('en', file)));
+        const localeBase = baseKeySet(flatten(readNamespace(locale, file)));
+
+        const missing = [...enBase].filter((key) => !localeBase.has(key));
+        const extra = [...localeBase].filter((key) => !enBase.has(key));
+
+        expect({ missing, extra }).toEqual({ missing: [], extra: [] });
+      }
+    );
+
+    it.each(EN_FILES)(
+      'preserves the exact placeholder set of en/%s',
+      (file) => {
+        if (!existsSync(localePath(locale, file))) {
+          return;
+        }
+        const enFlat = flatten(readNamespace('en', file));
+        const localeFlat = flatten(readNamespace(locale, file));
+
+        const mismatches: Array<{
+          key: string;
+          en: string[];
+          locale: string[];
+        }> = [];
+
+        for (const [key, value] of Object.entries(enFlat)) {
+          const enPlaceholders = placeholders(value);
+          if (enPlaceholders.size === 0) {
+            continue;
+          }
+          const localeValue = localeFlat[key];
+          if (localeValue == null) {
+            continue;
+          }
+          const localePlaceholders = placeholders(localeValue);
+          const same =
+            enPlaceholders.size === localePlaceholders.size &&
+            [...enPlaceholders].every((name) => localePlaceholders.has(name));
+          if (!same) {
+            mismatches.push({
+              key,
+              en: [...enPlaceholders].sort(),
+              locale: [...localePlaceholders].sort(),
+            });
+          }
+        }
+
+        expect(mismatches).toEqual([]);
+      }
+    );
+  });
+});

--- a/web/src/pages/OpsPage/CommandsTab.tsx
+++ b/web/src/pages/OpsPage/CommandsTab.tsx
@@ -5,6 +5,7 @@ import styles from './OpsPage.module.css';
 import { syncStripeSubscriptions } from './syncStripeSubscriptions';
 import { grantDeveloperAccess } from './grantDeveloperAccess';
 import { setChatAttachmentsLifecycle } from './setChatAttachmentsLifecycle';
+import { sendPassWinback } from './sendPassWinback';
 import {
   deleteInactiveUsers,
   DeleteInactiveUsersResponse,
@@ -66,6 +67,35 @@ export default function CommandsTab() {
   const [devMessage, setDevMessage] = useState('');
   const [lifecycleStatus, setLifecycleStatus] = useState<Status>('idle');
   const [lifecycleMessage, setLifecycleMessage] = useState('');
+  const [winbackCampaign, setWinbackCampaign] = useState('');
+  const [winbackStatus, setWinbackStatus] = useState<Status>('idle');
+  const [winbackMessage, setWinbackMessage] = useState('');
+
+  const runWinback = async (dryRun: boolean) => {
+    const campaign = winbackCampaign.trim();
+    if (campaign.length === 0) {
+      setWinbackStatus('error');
+      setWinbackMessage('Enter a campaign id first.');
+      return;
+    }
+    setWinbackStatus('loading');
+    setWinbackMessage('');
+    try {
+      const result = await sendPassWinback(campaign, dryRun);
+      const buyers = `lapsed pass buyer${result.count === 1 ? '' : 's'}`;
+      setWinbackStatus('success');
+      setWinbackMessage(
+        result.dryRun
+          ? `${result.count} ${buyers} would receive the ${result.campaign} win-back email.`
+          : `Win-back email sent to ${result.count} ${buyers} for ${result.campaign}.`
+      );
+    } catch (error) {
+      setWinbackStatus('error');
+      setWinbackMessage(
+        error instanceof Error ? error.message : 'Unknown error'
+      );
+    }
+  };
 
   const runDeveloperAccess = async (grant: boolean) => {
     const email = devEmail.trim();
@@ -271,6 +301,54 @@ export default function CommandsTab() {
       {status === 'error' && message && (
         <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>
           {message}
+        </div>
+      )}
+
+      <section className={`${sharedStyles.surface} ${styles.card}`}>
+        <h2 className={styles.cardTitle}>Pass win-back</h2>
+        <p className={styles.panelSubtitle}>
+          Emails lapsed Day/Week pass buyers whose pass expired with no active
+          pass or subscription a seasonal nudge to come back. Excludes opted-out
+          and hard-suppressed addresses and dedupes per campaign. Enter a
+          campaign id (e.g. winback-2026-fall), dry-run to check counts, then
+          send. Capped at 500 per run.
+        </p>
+        <div className={styles.controls}>
+          <input
+            type="text"
+            aria-label="Campaign id"
+            placeholder="winback-2026-fall"
+            className={styles.textInput}
+            value={winbackCampaign}
+            onChange={(e) => setWinbackCampaign(e.target.value)}
+          />
+          <button
+            type="button"
+            className={sharedStyles.btnSmall}
+            onClick={() => runWinback(true)}
+            disabled={winbackStatus === 'loading'}
+          >
+            {winbackStatus === 'loading' ? 'Working…' : 'Dry run'}
+          </button>
+          <button
+            type="button"
+            className={sharedStyles.btnSmall}
+            onClick={() => runWinback(false)}
+            disabled={winbackStatus === 'loading'}
+          >
+            Send win-back
+          </button>
+        </div>
+      </section>
+
+      {winbackStatus === 'success' && winbackMessage && (
+        <div className={`${sharedStyles.alertSuccess} ${styles.banner}`}>
+          {winbackMessage}
+        </div>
+      )}
+      {winbackStatus === 'error' && winbackMessage && (
+        <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>
+          {winbackMessage}
         </div>
       )}
 

--- a/web/src/pages/OpsPage/opsRouteButtonParity.test.ts
+++ b/web/src/pages/OpsPage/opsRouteButtonParity.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const OPS_ROUTER = join(__dirname, '../../../../src/routes/OpsRouter.ts');
+
+const POST_OPS_ROUTE = /router\.post\(\s*['"]([^'"]+)['"]/g;
+
+function postOpsRoutes(): string[] {
+  const source = readFileSync(OPS_ROUTER, 'utf8');
+  const paths = Array.from(
+    source.matchAll(POST_OPS_ROUTE),
+    (match) => match[1]
+  );
+  return paths.filter((path) => path.startsWith('/api/ops/'));
+}
+
+function opsClientSource(): string {
+  const entries = readdirSync(__dirname, { recursive: true }) as string[];
+  return entries
+    .filter((name) => /\.tsx?$/.test(name) && !/\.test\.tsx?$/.test(name))
+    .map((name) => readFileSync(join(__dirname, name), 'utf8'))
+    .join('\n');
+}
+
+describe('every POST /api/ops route in OpsRouter has an OpsPage client trigger', () => {
+  const routes = postOpsRoutes();
+  const clientSource = opsClientSource();
+
+  it('extraction reads router.post("/api/ops/…") paths from OpsRouter source text', () => {
+    expect(routes).toContain('/api/ops/send-pass-winback');
+    expect(routes).toContain('/api/ops/delete-inactive-users');
+    expect(routes.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it.each(routes)(
+    'POST %s appears as a fetch URL in a non-test web/src/pages/OpsPage module',
+    (route) => {
+      expect(clientSource).toContain(route);
+    }
+  );
+});

--- a/web/src/pages/OpsPage/sendPassWinback.test.ts
+++ b/web/src/pages/OpsPage/sendPassWinback.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { sendPassWinback } from './sendPassWinback';
+
+describe('sendPassWinback', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  test('POSTs the campaign and dryRun true and returns the candidate count', async () => {
+    const payload = { campaign: 'winback-2026-fall', count: 12, dryRun: true };
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: () => Promise.resolve(payload),
+    });
+
+    const result = await sendPassWinback('winback-2026-fall', true);
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      '/api/ops/send-pass-winback?campaign=winback-2026-fall&dryRun=true',
+      { method: 'POST', credentials: 'include' }
+    );
+    expect(result).toEqual(payload);
+  });
+
+  test('POSTs dryRun false for a real send and returns the sent count', async () => {
+    const payload = { campaign: 'winback-2026-fall', count: 12, dryRun: false };
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: () => Promise.resolve(payload),
+    });
+
+    const result = await sendPassWinback('winback-2026-fall', false);
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      '/api/ops/send-pass-winback?campaign=winback-2026-fall&dryRun=false',
+      { method: 'POST', credentials: 'include' }
+    );
+    expect(result).toEqual(payload);
+  });
+
+  test('encodes campaign identifiers that contain URL-reserved characters', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: () =>
+        Promise.resolve({ campaign: 'a b&c', count: 0, dryRun: true }),
+    });
+
+    await sendPassWinback('a b&c', true);
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      '/api/ops/send-pass-winback?campaign=a%20b%26c&dryRun=true',
+      { method: 'POST', credentials: 'include' }
+    );
+  });
+
+  test('throws the server message on a non-ok response', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      json: () => Promise.resolve({ message: 'campaign is required' }),
+    });
+
+    await expect(sendPassWinback('', true)).rejects.toThrow(
+      'campaign is required'
+    );
+  });
+
+  test('falls back to status text when the error body has no message', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      json: () => Promise.reject(new Error('no body')),
+    });
+
+    await expect(sendPassWinback('winback-2026-fall', false)).rejects.toThrow(
+      '404 Not Found'
+    );
+  });
+});

--- a/web/src/pages/OpsPage/sendPassWinback.ts
+++ b/web/src/pages/OpsPage/sendPassWinback.ts
@@ -1,0 +1,22 @@
+export interface SendPassWinbackResponse {
+  campaign: string;
+  count: number;
+  dryRun: boolean;
+}
+
+export async function sendPassWinback(
+  campaign: string,
+  dryRun: boolean
+): Promise<SendPassWinbackResponse> {
+  const response = await fetch(
+    `/api/ops/send-pass-winback?campaign=${encodeURIComponent(campaign)}&dryRun=${dryRun}`,
+    { method: 'POST', credentials: 'include' }
+  );
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(
+      data.message ?? `${response.status} ${response.statusText}`
+    );
+  }
+  return response.json();
+}


### PR DESCRIPTION
## What
Adds two audit-identified parity sensors and fixes the one gap the ops sensor detects:
- `web/src/lib/i18n/locales/parity.test.ts` — asserts the 9 non-en locales stay in lockstep with `en` across every namespace (file presence, flattened base-key set, and per-key `{{placeholder}}` set).
- `web/src/pages/OpsPage/opsRouteButtonParity.test.ts` — asserts every `POST /api/ops/*` route in `OpsRouter.ts` is triggered by a non-test module under `web/src/pages/OpsPage/`.
- `web/src/pages/OpsPage/sendPassWinback.ts` + a **Pass win-back** button in `CommandsTab.tsx` — `/api/ops/send-pass-winback` shipped buttonless; this gives it a campaign input, dry-run, and send, mirroring the delete-inactive-users wrapper and inactivity-warnings button.

## Why
Codebase audit 2026-08-17: harness finding 15 (i18n parity sensor) + finding 9 (ops button parity, send-pass-winback shipped buttonless). No existing check guarded either: an en-only key/placeholder change renders stale in the other 9 locales silently, and a POST ops route with no button is the backend-only-ops-command failure mode `code-quality.md` bans (reachable only by hand-crafting an authed curl).

## How
- i18n sensor reads namespace JSON with `fs`, flattens nested keys, and exempts CLDR plural suffix variants (`_one/_other/_few/_many/_zero/_two`) by comparing base keys — ru carries `_few/_many` that en does not, so requiring identical plural-suffix sets would false-fail. Placeholder equality is checked per exact key (plural variants naturally skip where the suffix is absent in a locale). Parity is currently clean, so it lands green.
- ops sensor extracts `router.post('/api/ops/…')` paths from `OpsRouter.ts` source text (same read-as-text approach as `events.parity.test.ts`) and requires each to appear in a non-test OpsPage client module. Scope is the whole OpsPage client dir, not just CommandsTab: `showcase/populate` is a POST route whose button legitimately lives in `ShowcaseTab.tsx`, so a CommandsTab-only scope would false-fail. Test files are excluded from the corpus so a URL that appears only in a test can't satisfy parity.
- Both sensors were verified to fail for the right reason: mutating a `de` placeholder reddens the i18n sensor on that key; removing `sendPassWinback.ts` (keeping its test) reddens the ops sensor on `/api/ops/send-pass-winback`.

## Measuring success
CI signal, not a prod metric. The i18n sensor goes red in `pnpm --filter 2anki-web test` the moment a locale drifts from `en`; the ops sensor goes red the moment a new `POST /api/ops/*` route lands without a UI trigger. Both run in the normal web vitest pass.

## Testing
- Unit tests added: `parity.test.ts` (i18n, 379 assertions), `sendPassWinback.test.ts` (5), `opsRouteButtonParity.test.ts` (9). Full web suite green: 367 files, 3259 tests. Web typecheck + lint clean; `pnpm format:check` clean tree-wide.

## Browser check
- [x] Golden path on localhost:3000 — `pnpm --filter 2anki-web test:golden-path` passed (2/2, landing + signed-in dashboard).
- [x] No console errors at 375px — golden-path asserts zero console errors at 375px on both routes.
Notes: The new **Pass win-back** button lives in the ops-owner-only `/ops` Commands tab (not reachable by a normal user), so the golden-path suite is the attestation form here per the task brief.

## Changelog
No entry — internal ops tooling and test sensors, no user-visible change.

## Risks
Low. The button is an exact mirror of existing ops-command wrappers; the sensors are additive tests. If a future locale legitimately diverges or a POST ops route is intentionally UI-less, the sensor would need updating — but that is the intended signal.

## Goal alignment
None — internal. Ops tooling and CI drift-guards. The i18n sensor protects the 10-locale acquisition surface from silent stale-copy regressions, and the ops sensor keeps future ops commands from shipping unreachable, but neither moves a funnel metric directly.

## Sonar
Not run locally; PR decoration will report.
