### PR TITLE
fix: improve keyboard and screen-reader access across key surfaces

### DIFF
--- a/web/src/components/CardOptionsForm/CardOptionsForm.module.css
+++ b/web/src/components/CardOptionsForm/CardOptionsForm.module.css
@@ -49,7 +49,7 @@
 .deckInput:focus {
   outline: none;
   border-color: var(--color-primary);
-  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.15);
+  box-shadow: 0 0 0 2px var(--color-focus-ring);
 }
 
 .detailsSummary {
@@ -327,7 +327,7 @@
   left: 2px;
   width: 1.125rem;
   height: 1.125rem;
-  background: #fff;
+  background: var(--color-bg-primary);
   border-radius: 50%;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
   transition: transform var(--transition-fast, 150ms);

--- a/web/src/components/CardOptionsForm/CardOptionsForm.module.css
+++ b/web/src/components/CardOptionsForm/CardOptionsForm.module.css
@@ -340,3 +340,16 @@
 .toggleSwitch input:checked + .toggleSwitchTrack::after {
   transform: translateX(1.125rem);
 }
+
+.fieldsetReset {
+  border: 0;
+  padding: 0;
+  margin: 0;
+  min-width: 0;
+}
+
+.legendReset {
+  display: block;
+  width: 100%;
+  padding: 0;
+}

--- a/web/src/components/CardOptionsForm/CardOptionsForm.tsx
+++ b/web/src/components/CardOptionsForm/CardOptionsForm.tsx
@@ -847,18 +847,18 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
             />
           </div>
 
-          <div className={fieldStyles.section}>
-            <div className={fieldStyles.labelRow}>
-              <span id="deck-icon-label" className={fieldStyles.sectionLabel}>
-                {t('cardOptions.deck.iconLabel')}
+          <fieldset
+            className={`${fieldStyles.section} ${fieldStyles.fieldsetReset}`}
+          >
+            <legend className={fieldStyles.legendReset}>
+              <span className={fieldStyles.labelRow}>
+                <span className={fieldStyles.sectionLabel}>
+                  {t('cardOptions.deck.iconLabel')}
+                </span>
+                <FieldHint text={t('cardOptions.deck.iconHint')} />
               </span>
-              <FieldHint text={t('cardOptions.deck.iconHint')} />
-            </div>
-            <div
-              className={fieldStyles.segmented}
-              role="group"
-              aria-labelledby="deck-icon-label"
-            >
+            </legend>
+            <div className={fieldStyles.segmented}>
               {(
                 [
                   {
@@ -888,23 +888,20 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
                 </button>
               ))}
             </div>
-          </div>
+          </fieldset>
 
-          <div className={fieldStyles.section}>
-            <div className={fieldStyles.labelRow}>
-              <span
-                id="deck-toggle-mode-label"
-                className={fieldStyles.sectionLabel}
-              >
-                {t('cardOptions.deck.toggleModeLabel')}
+          <fieldset
+            className={`${fieldStyles.section} ${fieldStyles.fieldsetReset}`}
+          >
+            <legend className={fieldStyles.legendReset}>
+              <span className={fieldStyles.labelRow}>
+                <span className={fieldStyles.sectionLabel}>
+                  {t('cardOptions.deck.toggleModeLabel')}
+                </span>
+                <FieldHint text={t('cardOptions.deck.toggleModeHint')} />
               </span>
-              <FieldHint text={t('cardOptions.deck.toggleModeHint')} />
-            </div>
-            <div
-              className={fieldStyles.segmented}
-              role="group"
-              aria-labelledby="deck-toggle-mode-label"
-            >
+            </legend>
+            <div className={fieldStyles.segmented}>
               {(
                 [
                   {
@@ -930,7 +927,7 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
                 </button>
               ))}
             </div>
-          </div>
+          </fieldset>
         </div>
 
         {generalOptions.length > 0 && (

--- a/web/src/components/CardOptionsForm/CardOptionsForm.tsx
+++ b/web/src/components/CardOptionsForm/CardOptionsForm.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/label-has-associated-control */
 import React, {
   forwardRef,
   SyntheticEvent,
@@ -850,12 +849,16 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
 
           <div className={fieldStyles.section}>
             <div className={fieldStyles.labelRow}>
-              <label className={fieldStyles.sectionLabel}>
+              <span id="deck-icon-label" className={fieldStyles.sectionLabel}>
                 {t('cardOptions.deck.iconLabel')}
-              </label>
+              </span>
               <FieldHint text={t('cardOptions.deck.iconHint')} />
             </div>
-            <div className={fieldStyles.segmented}>
+            <div
+              className={fieldStyles.segmented}
+              role="group"
+              aria-labelledby="deck-icon-label"
+            >
               {(
                 [
                   {
@@ -889,12 +892,19 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
 
           <div className={fieldStyles.section}>
             <div className={fieldStyles.labelRow}>
-              <label className={fieldStyles.sectionLabel}>
+              <span
+                id="deck-toggle-mode-label"
+                className={fieldStyles.sectionLabel}
+              >
                 {t('cardOptions.deck.toggleModeLabel')}
-              </label>
+              </span>
               <FieldHint text={t('cardOptions.deck.toggleModeHint')} />
             </div>
-            <div className={fieldStyles.segmented}>
+            <div
+              className={fieldStyles.segmented}
+              role="group"
+              aria-labelledby="deck-toggle-mode-label"
+            >
               {(
                 [
                   {

--- a/web/src/components/ChatPanel/ChatPanel.module.css
+++ b/web/src/components/ChatPanel/ChatPanel.module.css
@@ -508,6 +508,12 @@
   box-shadow: none;
 }
 
+.textarea:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 0;
+  border-radius: var(--radius-sm);
+}
+
 .textarea:disabled {
   opacity: 0.5;
   cursor: not-allowed;

--- a/web/src/components/ChatPanel/ChatPanel.tsx
+++ b/web/src/components/ChatPanel/ChatPanel.tsx
@@ -1199,9 +1199,9 @@ export default function ChatPanel({
       <div className={styles.container} data-hj-suppress>
         {showEmptyState ? (
           <div className={styles.emptyState}>
-            <h1 className={styles.emptyHeading}>
+            <h2 className={styles.emptyHeading}>
               {cameFromUpload ? t('heading.withFile') : t('heading.studying')}
-            </h1>
+            </h2>
             <div className={styles.emptyComposer}>
               <div className={styles.composerTemplateRow}>
                 <TemplateSelector

--- a/web/src/lib/hooks/useDialogFocus.test.tsx
+++ b/web/src/lib/hooks/useDialogFocus.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { useRef } from 'react';
+import { useDialogFocus } from './useDialogFocus';
+
+function Harness({
+  onClose,
+  active = true,
+}: Readonly<{ onClose: () => void; active?: boolean }>) {
+  const ref = useRef<HTMLDivElement>(null);
+  useDialogFocus(ref, onClose, active);
+  return (
+    <div ref={ref} role="dialog">
+      <button type="button">first</button>
+      <button type="button">middle</button>
+      <button type="button">last</button>
+    </div>
+  );
+}
+
+describe('useDialogFocus', () => {
+  it('moves focus to the first focusable element on open', () => {
+    render(<Harness onClose={vi.fn()} />);
+    expect(screen.getByText('first')).toHaveFocus();
+  });
+
+  it('calls onClose when Escape is pressed', () => {
+    const onClose = vi.fn();
+    render(<Harness onClose={onClose} />);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('wraps focus from the last element to the first on Tab', () => {
+    render(<Harness onClose={vi.fn()} />);
+    screen.getByText('last').focus();
+    fireEvent.keyDown(document, { key: 'Tab' });
+    expect(screen.getByText('first')).toHaveFocus();
+  });
+
+  it('wraps focus from the first element to the last on Shift+Tab', () => {
+    render(<Harness onClose={vi.fn()} />);
+    screen.getByText('first').focus();
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
+    expect(screen.getByText('last')).toHaveFocus();
+  });
+
+  it('restores focus to the previously focused element on unmount', () => {
+    const outside = document.createElement('button');
+    outside.textContent = 'outside';
+    document.body.appendChild(outside);
+    outside.focus();
+
+    const { unmount } = render(<Harness onClose={vi.fn()} />);
+    expect(screen.getByText('first')).toHaveFocus();
+
+    unmount();
+    expect(outside).toHaveFocus();
+    outside.remove();
+  });
+
+  it('does nothing while inactive', () => {
+    const onClose = vi.fn();
+    render(<Harness onClose={onClose} active={false} />);
+    expect(screen.getByText('first')).not.toHaveFocus();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/lib/hooks/useDialogFocus.ts
+++ b/web/src/lib/hooks/useDialogFocus.ts
@@ -47,7 +47,7 @@ export function useDialogFocus<T extends HTMLElement>(
         return;
       }
       const first = items[0];
-      const last = items[items.length - 1];
+      const last = items.at(-1) ?? first;
       const activeElement = document.activeElement;
       if (event.shiftKey && activeElement === first) {
         event.preventDefault();

--- a/web/src/lib/hooks/useDialogFocus.ts
+++ b/web/src/lib/hooks/useDialogFocus.ts
@@ -1,0 +1,67 @@
+import { useEffect, useRef, type RefObject } from 'react';
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'textarea:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+export function useDialogFocus<T extends HTMLElement>(
+  containerRef: RefObject<T | null>,
+  onClose: () => void,
+  active = true
+): void {
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  useEffect(() => {
+    if (!active) return;
+    const container = containerRef.current;
+    if (container == null) return;
+
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+
+    const focusables = (): HTMLElement[] =>
+      Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+
+    const initial = focusables();
+    if (initial.length > 0) {
+      initial[0].focus();
+    } else {
+      container.focus();
+    }
+
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onCloseRef.current();
+        return;
+      }
+      if (event.key !== 'Tab') return;
+      const items = focusables();
+      if (items.length === 0) {
+        event.preventDefault();
+        return;
+      }
+      const first = items[0];
+      const last = items[items.length - 1];
+      const activeElement = document.activeElement;
+      if (event.shiftKey && activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      previouslyFocused?.focus?.();
+    };
+  }, [active, containerRef]);
+}

--- a/web/src/lib/i18n/a11yUploadKeys.parity.test.ts
+++ b/web/src/lib/i18n/a11yUploadKeys.parity.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+const modules = import.meta.glob('./locales/*/common.json', {
+  eager: true,
+}) as Record<string, { default: Record<string, unknown> }>;
+
+const LANGS = ['en', 'de', 'es', 'fr', 'it', 'ja', 'nl', 'pl', 'pt', 'ru'];
+
+const FORM_KEYS = [
+  'liveConverting',
+  'liveDeckReady',
+  'liveEmptyDeck',
+  'liveImageOnly',
+  'liveError',
+  'liveLimitReached',
+  'liveLockedPdf',
+  'pdfPasswordAria',
+  'changeSourceAria',
+  'uploadFileAria',
+];
+
+const PLURAL_FORMS: Record<string, string[]> = {
+  en: ['one', 'other'],
+  de: ['one', 'other'],
+  es: ['one', 'other'],
+  fr: ['one', 'other'],
+  it: ['one', 'other'],
+  nl: ['one', 'other'],
+  pt: ['one', 'other'],
+  ja: ['other'],
+  pl: ['one', 'few', 'many', 'other'],
+  ru: ['one', 'few', 'many', 'other'],
+};
+
+function record(value: unknown): Record<string, unknown> {
+  return value as Record<string, unknown>;
+}
+
+function uploadForm(lang: string): Record<string, unknown> {
+  const common = modules[`./locales/${lang}/common.json`].default;
+  return record(record(common.upload).form);
+}
+
+function walkthroughs(lang: string): Record<string, unknown> {
+  const common = modules[`./locales/${lang}/common.json`].default;
+  return record(record(common.home).walkthroughs);
+}
+
+describe('a11y upload/home i18n key parity', () => {
+  it.each(LANGS)('%s defines every non-plural upload.form key', (lang) => {
+    const form = uploadForm(lang);
+    for (const key of FORM_KEYS) {
+      expect(typeof form[key]).toBe('string');
+      expect((form[key] as string).length).toBeGreaterThan(0);
+    }
+  });
+
+  it.each(LANGS)(
+    '%s defines the liveDeckReadyCount plural forms with {{count}}',
+    (lang) => {
+      const form = uploadForm(lang);
+      for (const suffix of PLURAL_FORMS[lang]) {
+        const value = form[`liveDeckReadyCount_${suffix}`];
+        expect(typeof value).toBe('string');
+        expect(value).toContain('{{count}}');
+      }
+    }
+  );
+
+  it.each(LANGS)(
+    '%s defines home.walkthroughs.playVideo with {{title}}',
+    (lang) => {
+      const value = walkthroughs(lang).playVideo;
+      expect(typeof value).toBe('string');
+      expect(value).toContain('{{title}}');
+    }
+  );
+});

--- a/web/src/lib/i18n/locales/de/common.json
+++ b/web/src/lib/i18n/locales/de/common.json
@@ -102,7 +102,8 @@
       "cardTitle": "Video einreichen",
       "showFewer": "▴ Weniger anzeigen",
       "showAll_one": "▾ {{count}} Video anzeigen",
-      "showAll_other": "▾ Alle {{count}} Videos anzeigen"
+      "showAll_other": "▾ Alle {{count}} Videos anzeigen",
+      "playVideo": "Abspielen: {{title}}"
     }
   },
   "upload": {
@@ -153,7 +154,19 @@
       "packingFolder": "Dein Ordner wird in eine Zip-Datei gepackt.",
       "folderTooBig": "Dieser Ordner ist größer als 500 MB — packe ihn selbst als Zip und lade die Zip-Datei hoch.",
       "folderEmpty": "Dieser Ordner ist leer — zieh den Ordner mit deinen Export-Dateien hierher.",
-      "folderFailed": "Dieser Ordner konnte nicht gepackt werden — packe ihn selbst als Zip und lade die Zip-Datei hoch, oder schreib an support@2anki.net."
+      "folderFailed": "Dieser Ordner konnte nicht gepackt werden — packe ihn selbst als Zip und lade die Zip-Datei hoch, oder schreib an support@2anki.net.",
+      "liveConverting": "Deine Datei wird konvertiert.",
+      "liveDeckReady": "Dein Stapel ist fertig.",
+      "liveDeckReadyCount_one": "Dein Stapel ist fertig — {{count}} Karte.",
+      "liveDeckReadyCount_other": "Dein Stapel ist fertig — {{count}} Karten.",
+      "liveEmptyDeck": "Konvertierung abgeschlossen, aber es wurden keine Karten gefunden.",
+      "liveImageOnly": "Das sehen nach Bildern aus. Probiere Foto zu Stapel, um daraus Karten zu machen.",
+      "liveError": "Konvertierung fehlgeschlagen.",
+      "liveLimitReached": "Du hast dein monatliches Limit erreicht.",
+      "liveLockedPdf": "Dieses PDF ist passwortgeschützt. Gib das Passwort ein, um fortzufahren.",
+      "pdfPasswordAria": "PDF-Passwort",
+      "changeSourceAria": "Upload-Quelle ändern",
+      "uploadFileAria": "Datei hochladen"
     },
     "page": {
       "title": "Konvertiere deine Notizen",

--- a/web/src/lib/i18n/locales/en/common.json
+++ b/web/src/lib/i18n/locales/en/common.json
@@ -102,7 +102,8 @@
       "cardTitle": "Submit your video",
       "showFewer": "▴ Show fewer",
       "showAll_one": "▾ Show {{count}} video",
-      "showAll_other": "▾ Show all {{count}} videos"
+      "showAll_other": "▾ Show all {{count}} videos",
+      "playVideo": "Play: {{title}}"
     }
   },
   "upload": {
@@ -153,7 +154,19 @@
       "packingFolder": "Packing your folder into a zip.",
       "folderTooBig": "This folder is over 500 MB — zip it yourself and upload the zip file.",
       "folderEmpty": "This folder is empty — drop the folder that contains your export files.",
-      "folderFailed": "Couldn't package this folder — zip it yourself and upload the zip, or email support@2anki.net."
+      "folderFailed": "Couldn't package this folder — zip it yourself and upload the zip, or email support@2anki.net.",
+      "liveConverting": "Converting your file.",
+      "liveDeckReady": "Your deck is ready.",
+      "liveDeckReadyCount_one": "Your deck is ready — {{count}} card.",
+      "liveDeckReadyCount_other": "Your deck is ready — {{count}} cards.",
+      "liveEmptyDeck": "Conversion finished, but no cards were found.",
+      "liveImageOnly": "These look like images. Try Photo to Deck to turn them into cards.",
+      "liveError": "Conversion failed.",
+      "liveLimitReached": "You've reached your monthly limit.",
+      "liveLockedPdf": "This PDF is password-protected. Enter the password to continue.",
+      "pdfPasswordAria": "PDF password",
+      "changeSourceAria": "Change upload source",
+      "uploadFileAria": "Upload file"
     },
     "page": {
       "title": "Convert your notes",

--- a/web/src/lib/i18n/locales/es/common.json
+++ b/web/src/lib/i18n/locales/es/common.json
@@ -102,7 +102,8 @@
       "cardTitle": "Envía tu vídeo",
       "showFewer": "▴ Mostrar menos",
       "showAll_one": "▾ Mostrar {{count}} vídeo",
-      "showAll_other": "▾ Mostrar los {{count}} vídeos"
+      "showAll_other": "▾ Mostrar los {{count}} vídeos",
+      "playVideo": "Reproducir: {{title}}"
     }
   },
   "upload": {
@@ -153,7 +154,19 @@
       "packingFolder": "Empaquetando tu carpeta en un zip.",
       "folderTooBig": "Esta carpeta supera los 500 MB — comprímela tú mismo y sube el archivo zip.",
       "folderEmpty": "Esta carpeta está vacía — suelta la carpeta que contiene tus archivos exportados.",
-      "folderFailed": "No se pudo empaquetar esta carpeta — comprímela tú mismo y sube el zip, o escribe a support@2anki.net."
+      "folderFailed": "No se pudo empaquetar esta carpeta — comprímela tú mismo y sube el zip, o escribe a support@2anki.net.",
+      "liveConverting": "Convirtiendo tu archivo.",
+      "liveDeckReady": "Tu mazo está listo.",
+      "liveDeckReadyCount_one": "Tu mazo está listo — {{count}} tarjeta.",
+      "liveDeckReadyCount_other": "Tu mazo está listo — {{count}} tarjetas.",
+      "liveEmptyDeck": "La conversión terminó, pero no se encontraron tarjetas.",
+      "liveImageOnly": "Esto parecen imágenes. Prueba Foto a mazo para convertirlas en tarjetas.",
+      "liveError": "La conversión falló.",
+      "liveLimitReached": "Has alcanzado tu límite mensual.",
+      "liveLockedPdf": "Este PDF está protegido con contraseña. Introduce la contraseña para continuar.",
+      "pdfPasswordAria": "Contraseña del PDF",
+      "changeSourceAria": "Cambiar origen de subida",
+      "uploadFileAria": "Subir archivo"
     },
     "page": {
       "title": "Convierte tus notas",

--- a/web/src/lib/i18n/locales/fr/common.json
+++ b/web/src/lib/i18n/locales/fr/common.json
@@ -102,7 +102,8 @@
       "cardTitle": "Propose ta vidéo",
       "showFewer": "▴ Afficher moins",
       "showAll_one": "▾ Afficher {{count}} vidéo",
-      "showAll_other": "▾ Afficher les {{count}} vidéos"
+      "showAll_other": "▾ Afficher les {{count}} vidéos",
+      "playVideo": "Lire : {{title}}"
     }
   },
   "upload": {
@@ -153,7 +154,19 @@
       "packingFolder": "Ton dossier est en cours d'empaquetage en zip.",
       "folderTooBig": "Ce dossier dépasse 500 Mo — compresse-le toi-même et téléverse le fichier zip.",
       "folderEmpty": "Ce dossier est vide — dépose le dossier qui contient tes fichiers exportés.",
-      "folderFailed": "Impossible d'empaqueter ce dossier — compresse-le toi-même et téléverse le zip, ou écris à support@2anki.net."
+      "folderFailed": "Impossible d'empaqueter ce dossier — compresse-le toi-même et téléverse le zip, ou écris à support@2anki.net.",
+      "liveConverting": "Conversion de ton fichier en cours.",
+      "liveDeckReady": "Ton paquet est prêt.",
+      "liveDeckReadyCount_one": "Ton paquet est prêt — {{count}} carte.",
+      "liveDeckReadyCount_other": "Ton paquet est prêt — {{count}} cartes.",
+      "liveEmptyDeck": "Conversion terminée, mais aucune carte n'a été trouvée.",
+      "liveImageOnly": "On dirait des images. Essaie Photo vers paquet pour en faire des cartes.",
+      "liveError": "La conversion a échoué.",
+      "liveLimitReached": "Tu as atteint ta limite mensuelle.",
+      "liveLockedPdf": "Ce PDF est protégé par mot de passe. Saisis le mot de passe pour continuer.",
+      "pdfPasswordAria": "Mot de passe du PDF",
+      "changeSourceAria": "Changer la source d'envoi",
+      "uploadFileAria": "Envoyer le fichier"
     },
     "page": {
       "title": "Convertis tes notes",

--- a/web/src/lib/i18n/locales/it/common.json
+++ b/web/src/lib/i18n/locales/it/common.json
@@ -102,7 +102,8 @@
       "cardTitle": "Invia il tuo video",
       "showFewer": "▴ Mostra meno",
       "showAll_one": "▾ Mostra {{count}} video",
-      "showAll_other": "▾ Mostra tutti i {{count}} video"
+      "showAll_other": "▾ Mostra tutti i {{count}} video",
+      "playVideo": "Riproduci: {{title}}"
     }
   },
   "upload": {
@@ -153,7 +154,19 @@
       "packingFolder": "Sto impacchettando la tua cartella in uno zip.",
       "folderTooBig": "Questa cartella supera i 500 MB — comprimila tu stesso e carica il file zip.",
       "folderEmpty": "Questa cartella è vuota — trascina la cartella che contiene i file esportati.",
-      "folderFailed": "Impossibile impacchettare questa cartella — comprimila tu stesso e carica lo zip, oppure scrivi a support@2anki.net."
+      "folderFailed": "Impossibile impacchettare questa cartella — comprimila tu stesso e carica lo zip, oppure scrivi a support@2anki.net.",
+      "liveConverting": "Sto convertendo il tuo file.",
+      "liveDeckReady": "Il tuo mazzo è pronto.",
+      "liveDeckReadyCount_one": "Il tuo mazzo è pronto — {{count}} carta.",
+      "liveDeckReadyCount_other": "Il tuo mazzo è pronto — {{count}} carte.",
+      "liveEmptyDeck": "Conversione completata, ma non è stata trovata nessuna carta.",
+      "liveImageOnly": "Sembrano immagini. Prova Da foto a mazzo per trasformarle in carte.",
+      "liveError": "Conversione non riuscita.",
+      "liveLimitReached": "Hai raggiunto il limite mensile.",
+      "liveLockedPdf": "Questo PDF è protetto da password. Inserisci la password per continuare.",
+      "pdfPasswordAria": "Password del PDF",
+      "changeSourceAria": "Cambia sorgente di caricamento",
+      "uploadFileAria": "Carica file"
     },
     "page": {
       "title": "Converti i tuoi appunti",

--- a/web/src/lib/i18n/locales/ja/common.json
+++ b/web/src/lib/i18n/locales/ja/common.json
@@ -101,7 +101,8 @@
       "ctaBody": "2anki の動画を作りましたか？ ご連絡いただければ、ここで無料で紹介します。",
       "cardTitle": "動画を投稿する",
       "showFewer": "▴ 表示を減らす",
-      "showAll_other": "▾ {{count}} 本の動画をすべて表示"
+      "showAll_other": "▾ {{count}} 本の動画をすべて表示",
+      "playVideo": "再生: {{title}}"
     }
   },
   "upload": {
@@ -151,7 +152,18 @@
       "packingFolder": "フォルダをzipにまとめています。",
       "folderTooBig": "このフォルダは500 MBを超えています — ご自身でzipに圧縮してからアップロードしてください。",
       "folderEmpty": "このフォルダは空です — エクスポートしたファイルが入っているフォルダをドロップしてください。",
-      "folderFailed": "このフォルダをまとめられませんでした — ご自身でzipに圧縮してアップロードするか、support@2anki.net までご連絡ください。"
+      "folderFailed": "このフォルダをまとめられませんでした — ご自身でzipに圧縮してアップロードするか、support@2anki.net までご連絡ください。",
+      "liveConverting": "ファイルを変換しています。",
+      "liveDeckReady": "デッキの準備ができました。",
+      "liveDeckReadyCount_other": "デッキの準備ができました — {{count}} 枚",
+      "liveEmptyDeck": "変換は完了しましたが、カードは見つかりませんでした。",
+      "liveImageOnly": "これらは画像のようです。写真からデッキでカードに変換してみてください。",
+      "liveError": "変換に失敗しました。",
+      "liveLimitReached": "今月の上限に達しました。",
+      "liveLockedPdf": "この PDF はパスワードで保護されています。続けるにはパスワードを入力してください。",
+      "pdfPasswordAria": "PDF のパスワード",
+      "changeSourceAria": "アップロード元を変更",
+      "uploadFileAria": "ファイルをアップロード"
     },
     "page": {
       "title": "ノートを変換",

--- a/web/src/lib/i18n/locales/nl/common.json
+++ b/web/src/lib/i18n/locales/nl/common.json
@@ -102,7 +102,8 @@
       "cardTitle": "Dien je video in",
       "showFewer": "▴ Minder tonen",
       "showAll_one": "▾ {{count}} video tonen",
-      "showAll_other": "▾ Alle {{count}} video's tonen"
+      "showAll_other": "▾ Alle {{count}} video's tonen",
+      "playVideo": "Afspelen: {{title}}"
     }
   },
   "upload": {
@@ -153,7 +154,19 @@
       "packingFolder": "Je map wordt ingepakt als zip.",
       "folderTooBig": "Deze map is groter dan 500 MB — zip hem zelf en upload het zip-bestand.",
       "folderEmpty": "Deze map is leeg — sleep de map met je exportbestanden hierheen.",
-      "folderFailed": "Deze map kon niet worden ingepakt — zip hem zelf en upload de zip, of mail naar support@2anki.net."
+      "folderFailed": "Deze map kon niet worden ingepakt — zip hem zelf en upload de zip, of mail naar support@2anki.net.",
+      "liveConverting": "Je bestand wordt geconverteerd.",
+      "liveDeckReady": "Je deck is klaar.",
+      "liveDeckReadyCount_one": "Je deck is klaar — {{count}} kaart.",
+      "liveDeckReadyCount_other": "Je deck is klaar — {{count}} kaarten.",
+      "liveEmptyDeck": "Conversie voltooid, maar er zijn geen kaarten gevonden.",
+      "liveImageOnly": "Dit lijken afbeeldingen. Probeer Foto naar deck om er kaarten van te maken.",
+      "liveError": "Conversie mislukt.",
+      "liveLimitReached": "Je hebt je maandlimiet bereikt.",
+      "liveLockedPdf": "Deze PDF is met een wachtwoord beveiligd. Voer het wachtwoord in om door te gaan.",
+      "pdfPasswordAria": "PDF-wachtwoord",
+      "changeSourceAria": "Uploadbron wijzigen",
+      "uploadFileAria": "Bestand uploaden"
     },
     "page": {
       "title": "Zet je notities om",

--- a/web/src/lib/i18n/locales/pl/common.json
+++ b/web/src/lib/i18n/locales/pl/common.json
@@ -104,7 +104,8 @@
       "showAll_one": "▾ Pokaż {{count}} film",
       "showAll_few": "▾ Pokaż wszystkie {{count}} filmy",
       "showAll_many": "▾ Pokaż wszystkie {{count}} filmów",
-      "showAll_other": "▾ Pokaż wszystkie {{count}} filmu"
+      "showAll_other": "▾ Pokaż wszystkie {{count}} filmu",
+      "playVideo": "Odtwórz: {{title}}"
     }
   },
   "upload": {
@@ -157,7 +158,21 @@
       "packingFolder": "Pakowanie folderu do pliku zip.",
       "folderTooBig": "Ten folder przekracza 500 MB — spakuj go samodzielnie i prześlij plik zip.",
       "folderEmpty": "Ten folder jest pusty — upuść folder z wyeksportowanymi plikami.",
-      "folderFailed": "Nie udało się spakować tego folderu — spakuj go samodzielnie i prześlij zip albo napisz na support@2anki.net."
+      "folderFailed": "Nie udało się spakować tego folderu — spakuj go samodzielnie i prześlij zip albo napisz na support@2anki.net.",
+      "liveConverting": "Konwertowanie pliku.",
+      "liveDeckReady": "Twoja talia jest gotowa.",
+      "liveDeckReadyCount_one": "Twoja talia jest gotowa — {{count}} karta.",
+      "liveDeckReadyCount_few": "Twoja talia jest gotowa — {{count}} karty.",
+      "liveDeckReadyCount_many": "Twoja talia jest gotowa — {{count}} kart.",
+      "liveDeckReadyCount_other": "Twoja talia jest gotowa — {{count}} karty.",
+      "liveEmptyDeck": "Konwersja zakończona, ale nie znaleziono kart.",
+      "liveImageOnly": "To wygląda na obrazy. Wypróbuj Zdjęcie na talię, aby zmienić je w karty.",
+      "liveError": "Konwersja nie powiodła się.",
+      "liveLimitReached": "Osiągnąłeś miesięczny limit.",
+      "liveLockedPdf": "Ten PDF jest chroniony hasłem. Wprowadź hasło, aby kontynuować.",
+      "pdfPasswordAria": "Hasło do PDF",
+      "changeSourceAria": "Zmień źródło przesyłania",
+      "uploadFileAria": "Prześlij plik"
     },
     "page": {
       "title": "Przekształć swoje notatki",

--- a/web/src/lib/i18n/locales/pt/common.json
+++ b/web/src/lib/i18n/locales/pt/common.json
@@ -102,7 +102,8 @@
       "cardTitle": "Envie seu vídeo",
       "showFewer": "▴ Mostrar menos",
       "showAll_one": "▾ Mostrar {{count}} vídeo",
-      "showAll_other": "▾ Mostrar todos os {{count}} vídeos"
+      "showAll_other": "▾ Mostrar todos os {{count}} vídeos",
+      "playVideo": "Reproduzir: {{title}}"
     }
   },
   "upload": {
@@ -153,7 +154,19 @@
       "packingFolder": "Empacotando sua pasta em um zip.",
       "folderTooBig": "Esta pasta passa de 500 MB — compacte você mesmo e envie o arquivo zip.",
       "folderEmpty": "Esta pasta está vazia — solte a pasta que contém seus arquivos exportados.",
-      "folderFailed": "Não foi possível empacotar esta pasta — compacte você mesmo e envie o zip, ou escreva para support@2anki.net."
+      "folderFailed": "Não foi possível empacotar esta pasta — compacte você mesmo e envie o zip, ou escreva para support@2anki.net.",
+      "liveConverting": "Convertendo seu arquivo.",
+      "liveDeckReady": "Seu baralho está pronto.",
+      "liveDeckReadyCount_one": "Seu baralho está pronto — {{count}} cartão.",
+      "liveDeckReadyCount_other": "Seu baralho está pronto — {{count}} cartões.",
+      "liveEmptyDeck": "Conversão concluída, mas nenhum cartão foi encontrado.",
+      "liveImageOnly": "Isto parece ser imagens. Use Foto para baralho para transformá-las em cartões.",
+      "liveError": "A conversão falhou.",
+      "liveLimitReached": "Você atingiu seu limite mensal.",
+      "liveLockedPdf": "Este PDF está protegido por senha. Digite a senha para continuar.",
+      "pdfPasswordAria": "Senha do PDF",
+      "changeSourceAria": "Trocar fonte de upload",
+      "uploadFileAria": "Enviar arquivo"
     },
     "page": {
       "title": "Converta suas anotações",

--- a/web/src/lib/i18n/locales/ru/common.json
+++ b/web/src/lib/i18n/locales/ru/common.json
@@ -104,7 +104,8 @@
       "showAll_one": "▾ Показать {{count}} видео",
       "showAll_few": "▾ Показать все {{count}} видео",
       "showAll_many": "▾ Показать все {{count}} видео",
-      "showAll_other": "▾ Показать все {{count}} видео"
+      "showAll_other": "▾ Показать все {{count}} видео",
+      "playVideo": "Воспроизвести: {{title}}"
     }
   },
   "upload": {
@@ -157,7 +158,21 @@
       "packingFolder": "Упаковываем папку в zip.",
       "folderTooBig": "Эта папка больше 500 МБ — заархивируй её и загрузи zip-файл.",
       "folderEmpty": "Эта папка пуста — перетащи папку с экспортированными файлами.",
-      "folderFailed": "Не удалось упаковать эту папку — заархивируй её и загрузи zip или напиши на support@2anki.net."
+      "folderFailed": "Не удалось упаковать эту папку — заархивируй её и загрузи zip или напиши на support@2anki.net.",
+      "liveConverting": "Конвертируем твой файл.",
+      "liveDeckReady": "Твоя колода готова.",
+      "liveDeckReadyCount_one": "Твоя колода готова — {{count}} карта.",
+      "liveDeckReadyCount_few": "Твоя колода готова — {{count}} карты.",
+      "liveDeckReadyCount_many": "Твоя колода готова — {{count}} карт.",
+      "liveDeckReadyCount_other": "Твоя колода готова — {{count}} карты.",
+      "liveEmptyDeck": "Конвертация завершена, но карты не найдены.",
+      "liveImageOnly": "Это похоже на изображения. Попробуй «Фото в колоду», чтобы превратить их в карты.",
+      "liveError": "Конвертация не удалась.",
+      "liveLimitReached": "Ты достиг месячного лимита.",
+      "liveLockedPdf": "Этот PDF защищён паролем. Введи пароль, чтобы продолжить.",
+      "pdfPasswordAria": "Пароль PDF",
+      "changeSourceAria": "Сменить источник загрузки",
+      "uploadFileAria": "Загрузить файл"
     },
     "page": {
       "title": "Преобразуй свои заметки",

--- a/web/src/pages/HomePage/HomePage.tsx
+++ b/web/src/pages/HomePage/HomePage.tsx
@@ -94,6 +94,7 @@ function VideoCard({
   embedId,
   title,
 }: Readonly<{ embedId: string; title: string }>) {
+  const { t } = useTranslation();
   const [playing, setPlaying] = useState(false);
 
   if (playing) {
@@ -117,7 +118,7 @@ function VideoCard({
       type="button"
       className={styles.walkCard}
       onClick={() => setPlaying(true)}
-      aria-label={`Play: ${title}`}
+      aria-label={t('home.walkthroughs.playVideo', { title })}
     >
       <div className={styles.walkThumb}>
         <img

--- a/web/src/pages/MindmapsPage/MindmapEditor.module.css
+++ b/web/src/pages/MindmapsPage/MindmapEditor.module.css
@@ -104,6 +104,11 @@
   min-width: 0;
 }
 
+.sidebarTitle:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
 .renameTrigger {
   background: transparent;
   border: none;

--- a/web/src/pages/MindmapsPage/MindmapEditor.test.tsx
+++ b/web/src/pages/MindmapsPage/MindmapEditor.test.tsx
@@ -247,6 +247,24 @@ describe('MindmapEditor', () => {
     expect(await screen.findByText(/card type/i)).toBeDefined();
   });
 
+  it('the export modal has dialog semantics and Escape closes it', async () => {
+    setInnerWidth(375);
+    const { MindmapEditor } = await import('./MindmapEditor');
+    render(createElement(MindmapEditor), { wrapper });
+
+    const bar = await screen.findByTestId('editor-mobile-bar');
+    fireEvent.click(
+      within(bar).getByRole('button', { name: /download deck/i })
+    );
+
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog.getAttribute('aria-modal')).toBe('true');
+    expect(dialog.getAttribute('aria-labelledby')).toBe('mindmap-export-title');
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+  });
+
   it('paste image event triggers upload and node creation', async () => {
     const imageResult = {
       url: '/api/mindmaps/images/42/map-1/abc.png',

--- a/web/src/pages/MindmapsPage/MindmapEditor.tsx
+++ b/web/src/pages/MindmapsPage/MindmapEditor.tsx
@@ -18,6 +18,7 @@ import type { TFunction } from 'i18next';
 import { Link, useParams } from 'react-router-dom';
 import PencilIcon from '../../components/icons/PencilIcon';
 import { track } from '../../lib/analytics/track';
+import { useDialogFocus } from '../../lib/hooks/useDialogFocus';
 import shared from '../../styles/shared.module.css';
 import { layoutGraph, NODE_HEIGHT } from './layoutGraph';
 import styles from './MindmapEditor.module.css';
@@ -167,6 +168,8 @@ function ExportModal({
   const { t } = useTranslation('tools');
   const [deckName, setDeckName] = useState(defaultName);
   const [cardType, setCardType] = useState<MindmapCardType>('basic');
+  const dialogRef = useRef<HTMLDivElement>(null);
+  useDialogFocus(dialogRef, onClose);
 
   function cardCountLabel(): string {
     let count = clozeCardCount;
@@ -177,8 +180,16 @@ function ExportModal({
 
   return (
     <div className={styles.exportModal}>
-      <div className={styles.exportCard}>
-        <h2 className={styles.exportTitle}>{t('mindmaps.downloadDeck')}</h2>
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="mindmap-export-title"
+        className={styles.exportCard}
+      >
+        <h2 id="mindmap-export-title" className={styles.exportTitle}>
+          {t('mindmaps.downloadDeck')}
+        </h2>
         <label className={styles.exportLabel}>{t('mindmaps.deckName')}</label>
         <input
           type="text"
@@ -881,8 +892,15 @@ export function MindmapEditor() {
       );
     }
 
+    function isInsideDialog(target: EventTarget | null): boolean {
+      return (
+        target instanceof HTMLElement &&
+        target.closest('[role="dialog"]') != null
+      );
+    }
+
     function handleKeyDown(e: KeyboardEvent) {
-      if (isEditableTarget(e.target)) return;
+      if (isEditableTarget(e.target) || isInsideDialog(e.target)) return;
 
       if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'l') {
         e.preventDefault();

--- a/web/src/pages/MindmapsPage/MindmapList.module.css
+++ b/web/src/pages/MindmapsPage/MindmapList.module.css
@@ -1,15 +1,10 @@
 .mapRow {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.75rem 1rem;
   border-radius: var(--radius-md);
   background: var(--color-bg-primary);
   border: 1px solid var(--color-border);
   margin-bottom: 0.5rem;
-  cursor: pointer;
-  width: 100%;
-  text-align: left;
   transition:
     background var(--transition-fast),
     box-shadow var(--transition-fast);
@@ -19,6 +14,27 @@
 .mapRow:focus-within {
   background: var(--color-bg-secondary);
   box-shadow: inset 2px 0 0 var(--color-primary);
+}
+
+.mapOpen {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+  border-radius: var(--radius-md);
+}
+
+.mapOpen:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px var(--color-focus-ring);
 }
 
 .mapTitle {
@@ -32,47 +48,44 @@
   min-width: 0;
 }
 
-.mapActions {
-  display: inline-flex;
-  align-items: center;
-  flex-shrink: 0;
-  opacity: 0.55;
-  transition: opacity var(--transition-fast);
-}
-
-@media (hover: hover) {
-  .mapRow:hover .mapActions,
-  .mapRow:focus-within .mapActions {
-    opacity: 1;
-  }
-}
-
-@media (hover: none) {
-  .mapActions {
-    opacity: 1;
-  }
-}
-
 .deleteBtn {
   background: transparent;
   border: none;
   padding: 0.375rem;
+  margin-right: 0.625rem;
   cursor: pointer;
   color: var(--color-text-tertiary);
   display: inline-flex;
   align-items: center;
   justify-content: center;
   border-radius: var(--radius-sm);
+  flex-shrink: 0;
+  opacity: 0.55;
   transition:
     color var(--transition-fast),
-    background var(--transition-fast);
+    background var(--transition-fast),
+    opacity var(--transition-fast);
   font-size: var(--text-sm);
+}
+
+@media (hover: hover) {
+  .mapRow:hover .deleteBtn,
+  .mapRow:focus-within .deleteBtn {
+    opacity: 1;
+  }
+}
+
+@media (hover: none) {
+  .deleteBtn {
+    opacity: 1;
+  }
 }
 
 .deleteBtn:hover,
 .deleteBtn:focus-visible {
   color: var(--color-danger);
   background: var(--color-danger-light);
+  opacity: 1;
 }
 
 .deleteBtn:focus-visible {

--- a/web/src/pages/MindmapsPage/MindmapList.test.tsx
+++ b/web/src/pages/MindmapsPage/MindmapList.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockNavigate, mockDelete, mockUseMindmapList } = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+  mockDelete: vi.fn(),
+  mockUseMindmapList: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>(
+      'react-router-dom'
+    );
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock('./useMindmap', () => ({
+  useMindmapList: () => mockUseMindmapList(),
+  useCreateMindmap: () => ({ mutateAsync: vi.fn() }),
+  useDeleteMindmap: () => ({ mutate: mockDelete }),
+}));
+
+import { MindmapList } from './MindmapList';
+
+const access = {
+  hasUnlimited: true,
+  currentCount: 1,
+  freeMapLimit: 3,
+  maxNodesPerMap: 50,
+};
+
+describe('MindmapList', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockDelete.mockClear();
+    mockUseMindmapList.mockReturnValue({
+      data: { maps: [{ id: 'm1', title: 'Cardiology' }], access },
+      isLoading: false,
+    });
+  });
+
+  it('renders the open and delete controls as separate, non-nested buttons', () => {
+    render(<MindmapList />);
+    const openBtn = screen.getByRole('button', { name: 'Cardiology' });
+    const deleteBtn = screen.getByRole('button', { name: 'Delete Cardiology' });
+    expect(deleteBtn.tagName).toBe('BUTTON');
+    expect(openBtn).not.toContainElement(deleteBtn);
+  });
+
+  it('opens the map when the open button is clicked', () => {
+    render(<MindmapList />);
+    fireEvent.click(screen.getByRole('button', { name: 'Cardiology' }));
+    expect(mockNavigate).toHaveBeenCalledWith('/mindmaps/m1');
+  });
+
+  it('deletes the map without navigating when the delete button is activated', () => {
+    render(<MindmapList />);
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Cardiology' }));
+    expect(mockDelete).toHaveBeenCalledWith('m1');
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/pages/MindmapsPage/MindmapList.tsx
+++ b/web/src/pages/MindmapsPage/MindmapList.tsx
@@ -121,42 +121,31 @@ export function MindmapList() {
         </div>
       )}
 
-      {(data?.maps ?? []).map((map) => (
-        <button
-          key={map.id}
-          type="button"
-          onClick={() => navigate(`/mindmaps/${map.id}`)}
-          className={styles.mapRow}
-        >
-          <span className={styles.mapTitle} title={map.title}>
-            {map.title.length === 0 ? t('mindmaps.untitled') : map.title}
-          </span>
-          <span className={styles.mapActions}>
-            <span
-              role="button"
-              tabIndex={0}
-              aria-label={t('mindmaps.deleteAria', {
-                title:
-                  map.title.length === 0 ? t('mindmaps.untitled') : map.title,
-              })}
-              onClick={(e) => {
-                e.stopPropagation();
-                deleteMindmap.mutate(map.id);
-              }}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  deleteMindmap.mutate(map.id);
-                }
-              }}
+      {(data?.maps ?? []).map((map) => {
+        const displayTitle =
+          map.title.length === 0 ? t('mindmaps.untitled') : map.title;
+        return (
+          <div key={map.id} className={styles.mapRow}>
+            <button
+              type="button"
+              onClick={() => navigate(`/mindmaps/${map.id}`)}
+              className={styles.mapOpen}
+            >
+              <span className={styles.mapTitle} title={map.title}>
+                {displayTitle}
+              </span>
+            </button>
+            <button
+              type="button"
+              aria-label={t('mindmaps.deleteAria', { title: displayTitle })}
+              onClick={() => deleteMindmap.mutate(map.id)}
               className={styles.deleteBtn}
             >
               <TrashIcon width={16} height={16} />
-            </span>
-          </span>
-        </button>
-      ))}
+            </button>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/web/src/pages/PricingPage/components/PricingCard.tsx
+++ b/web/src/pages/PricingPage/components/PricingCard.tsx
@@ -101,7 +101,7 @@ export function PricingCard({
     <div className={cardClass}>
       {badge != null && <span className={badgeClass}>{badge}</span>}
       <div className={styles.cardHeader}>
-        <p className={styles.cardTitle}>{title}</p>
+        <h3 className={styles.cardTitle}>{title}</h3>
         {priceNode}
       </div>
       <div className={styles.cardBody}>

--- a/web/src/pages/PricingPage/components/UnlimitedCard.tsx
+++ b/web/src/pages/PricingPage/components/UnlimitedCard.tsx
@@ -86,7 +86,7 @@ export function UnlimitedCard({
         {t('pricing.unlimited.mostPopular')}
       </span>
       <div className={styles.cardHeader}>
-        <p className={styles.cardTitle}>Unlimited</p>
+        <h3 className={styles.cardTitle}>Unlimited</h3>
         <span className={styles.cardPriceLine}>
           <span className={styles.cardPrice}>{heroPrice}</span>
           <span className={styles.cardPriceSuffix}>

--- a/web/src/pages/UploadPage/components/OnboardingTour/OnboardingTour.test.tsx
+++ b/web/src/pages/UploadPage/components/OnboardingTour/OnboardingTour.test.tsx
@@ -225,6 +225,36 @@ describe('OnboardingTour', () => {
     expect(trackMock).not.toHaveBeenCalledWith('onboarding_completed');
   });
 
+  it('exposes a dialog and moves focus into it when it opens', () => {
+    render(
+      <OnboardingTour
+        createdAt={AFTER_MIGRATION}
+        onboardedAt={null}
+        migrationDate={MIGRATION_DATE}
+      />
+    );
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Next' })).toHaveFocus();
+  });
+
+  it('dismisses the tour on Escape and calls markOnboarded', async () => {
+    render(
+      <OnboardingTour
+        createdAt={AFTER_MIGRATION}
+        onboardedAt={null}
+        migrationDate={MIGRATION_DATE}
+      />
+    );
+    fireEvent.keyDown(document, { key: 'Escape' });
+    await waitFor(() =>
+      expect(
+        screen.queryByText('Drop a file, or pick a Notion page.')
+      ).not.toBeInTheDocument()
+    );
+    expect(markOnboardedMock).toHaveBeenCalledTimes(1);
+    expect(trackMock).toHaveBeenCalledWith('onboarding_skipped');
+  });
+
   it('tracks onboarding_completed when Skip is pressed on the last step', () => {
     render(
       <OnboardingTour

--- a/web/src/pages/UploadPage/components/OnboardingTour/OnboardingTour.tsx
+++ b/web/src/pages/UploadPage/components/OnboardingTour/OnboardingTour.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { track } from '../../../../lib/analytics/track';
 import { markOnboarded } from '../../../../lib/backend/markOnboarded';
+import { useDialogFocus } from '../../../../lib/hooks/useDialogFocus';
 import styles from './OnboardingTour.module.css';
 
 const STEP_KEYS: ReadonlyArray<{ title: string; hint: string }> = [
@@ -50,9 +51,11 @@ export function OnboardingTour({
   const [step, setStep] = useState(0);
   const [dismissed, setDismissed] = useState(false);
   const shownTracked = useRef(false);
+  const dialogRef = useRef<HTMLDivElement>(null);
 
   const visible =
     !dismissed && shouldShowTour(createdAt, onboardedAt, migrationDate);
+  const isLast = step === STEP_KEYS.length - 1;
 
   useEffect(() => {
     if (visible && !shownTracked.current) {
@@ -61,20 +64,22 @@ export function OnboardingTour({
     }
   }, [visible]);
 
+  const handleClose = useCallback(() => {
+    track(isLast ? 'onboarding_completed' : 'onboarding_skipped');
+    setDismissed(true);
+    void markOnboarded();
+  }, [isLast]);
+
+  useDialogFocus(dialogRef, handleClose, visible);
+
   if (!visible) return null;
 
   const current = STEP_KEYS[step];
   const isFirst = step === 0;
-  const isLast = step === STEP_KEYS.length - 1;
-
-  const handleSkip = () => {
-    track(isLast ? 'onboarding_completed' : 'onboarding_skipped');
-    setDismissed(true);
-    void markOnboarded();
-  };
 
   return (
     <div
+      ref={dialogRef}
       className={styles.tour}
       role="dialog"
       aria-label={t('upload.onboarding.aria')}
@@ -110,7 +115,7 @@ export function OnboardingTour({
             {t('upload.onboarding.next')}
           </button>
         )}
-        <button type="button" className={styles.btnSkip} onClick={handleSkip}>
+        <button type="button" className={styles.btnSkip} onClick={handleClose}>
           {t('upload.onboarding.skip')}
         </button>
       </div>

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
@@ -4,6 +4,7 @@ import {
   waitFor,
   fireEvent,
   screen,
+  within,
 } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest';
@@ -89,8 +90,9 @@ describe('UploadForm', () => {
       const { container } = renderUploadForm(
         <UploadForm setErrorMessage={vi.fn()} />
       );
-      const chip = container.querySelector('button[aria-label="Google Drive"]');
-      expect(chip).not.toBeNull();
+      const chip = within(container).getByRole('button', {
+        name: 'Google Drive',
+      });
       expect(chip?.hasAttribute('disabled')).toBe(false);
     } finally {
       process.env.REACT_APP_GOOGLE_CLIENT_ID = previousClient;
@@ -128,8 +130,9 @@ describe('UploadForm', () => {
       const { container } = renderUploadForm(
         <UploadForm setErrorMessage={vi.fn()} />
       );
-      const chip = container.querySelector('button[aria-label="Google Drive"]');
-      expect(chip).not.toBeNull();
+      const chip = within(container).getByRole('button', {
+        name: 'Google Drive',
+      });
       expect(chip?.hasAttribute('disabled')).toBe(true);
     } finally {
       process.env.REACT_APP_GOOGLE_CLIENT_ID = previousClient;
@@ -211,7 +214,7 @@ describe('UploadForm Google Drive picker interaction', () => {
     );
 
     fireEvent.click(
-      container.querySelector('button[aria-label="Google Drive"]')!
+      within(container).getByRole('button', { name: 'Google Drive' })
     );
     const driveButton = await screen.findByRole('button', {
       name: 'Choose from Google Drive',
@@ -584,9 +587,9 @@ describe('UploadForm analytics events', () => {
     const { container } = renderUploadForm(
       <UploadForm setErrorMessage={vi.fn()} />
     );
-    const dropboxChip = container.querySelector(
-      'button[aria-label="Dropbox"]'
-    ) as HTMLButtonElement;
+    const dropboxChip = within(container).getByRole('button', {
+      name: 'Dropbox',
+    });
     expect(dropboxChip).toBeTruthy();
     await act(async () => {
       dropboxChip.click();
@@ -605,9 +608,9 @@ describe('UploadForm analytics events', () => {
       <UploadForm setErrorMessage={vi.fn()} />
     );
     const before = container.querySelector('input#pakker');
-    const dropboxChip = container.querySelector(
-      'button[aria-label="Dropbox"]'
-    ) as HTMLButtonElement;
+    const dropboxChip = within(container).getByRole('button', {
+      name: 'Dropbox',
+    });
     await act(async () => {
       dropboxChip.click();
     });
@@ -625,9 +628,9 @@ describe('UploadForm analytics events', () => {
     const { container } = renderUploadForm(
       <UploadForm setErrorMessage={vi.fn()} />
     );
-    const dropboxChip = container.querySelector(
-      'button[aria-label="Dropbox"]'
-    ) as HTMLButtonElement;
+    const dropboxChip = within(container).getByRole('button', {
+      name: 'Dropbox',
+    });
     await act(async () => {
       dropboxChip.click();
     });
@@ -644,9 +647,9 @@ describe('UploadForm analytics events', () => {
     const { container } = renderUploadForm(
       <UploadForm setErrorMessage={vi.fn()} />
     );
-    const dropboxChip = container.querySelector(
-      'button[aria-label="Dropbox"]'
-    ) as HTMLButtonElement;
+    const dropboxChip = within(container).getByRole('button', {
+      name: 'Dropbox',
+    });
     await act(async () => {
       dropboxChip.click();
     });
@@ -1537,7 +1540,7 @@ describe('UploadForm multi-deck batch', () => {
       );
     });
 
-    await screen.findByText('2 decks ready');
+    await screen.findAllByText('2 decks ready');
     expect(locationStub.href).toBe('');
 
     const biology = screen.getByLabelText(

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -1573,7 +1573,7 @@ function UploadForm({
           onKeyDown={(e) => {
             if (e.key === 'Enter') handleUnlock();
           }}
-          aria-label="PDF password"
+          aria-label={t('upload.form.pdfPasswordAria')}
         />
         <button
           type="button"
@@ -1713,28 +1713,27 @@ function UploadForm({
 
   const renderLiveStatus = (): string => {
     if (zoneState === 'packaging') return t('upload.form.packingFolder');
-    if (zoneState === 'converting') return 'Converting your file.';
+    if (zoneState === 'converting') return t('upload.form.liveConverting');
     if (zoneState === 'success') {
-      if (cardCount == null) return 'Your deck is ready.';
-      const noun = cardCount === 1 ? 'card' : 'cards';
-      return `Your deck is ready — ${cardCount} ${noun}.`;
+      if (cardCount == null) return t('upload.form.liveDeckReady');
+      return t('upload.form.liveDeckReadyCount', { count: cardCount });
     }
     if (zoneState === 'multiDeck') {
       const n = batchResult?.deckCount ?? 0;
-      return `${n} ${n === 1 ? 'deck' : 'decks'} ready.`;
+      return t('upload.form.decksReady', { count: n });
     }
     if (zoneState === 'emptyDeck') {
-      return 'Conversion finished, but no cards were found.';
+      return t('upload.form.liveEmptyDeck');
     }
     if (zoneState === 'imageOnly') {
-      return 'These look like images. Try Photo to Deck to turn them into cards.';
+      return t('upload.form.liveImageOnly');
     }
-    if (zoneState === 'error') return 'Conversion failed.';
+    if (zoneState === 'error') return t('upload.form.liveError');
     if (zoneState === 'limitReached') {
-      return "You've reached your monthly limit.";
+      return t('upload.form.liveLimitReached');
     }
     if (zoneState === 'lockedPdf') {
-      return 'This PDF is password-protected. Enter the password to continue.';
+      return t('upload.form.liveLockedPdf');
     }
     return '';
   };
@@ -1875,7 +1874,7 @@ function UploadForm({
             <button
               type="button"
               className={formStyles.changeSourceLink}
-              aria-label="Change upload source"
+              aria-label={t('upload.form.changeSourceAria')}
               onClick={() => handleSourceChange('local')}
             >
               {t('upload.form.changeSource')}
@@ -1889,7 +1888,7 @@ function UploadForm({
               className={formStyles.chooseButton}
               onClick={handleDropboxClick}
               disabled={dropboxPending}
-              aria-label="Choose from Dropbox"
+              aria-label={t('upload.form.chooseFromDropbox')}
             >
               {dropboxPending
                 ? t('upload.form.openingDropbox')
@@ -1920,7 +1919,7 @@ function UploadForm({
             <button
               type="button"
               className={formStyles.changeSourceLink}
-              aria-label="Change upload source"
+              aria-label={t('upload.form.changeSourceAria')}
               onClick={() => handleSourceChange('local')}
             >
               {t('upload.form.changeSource')}
@@ -1938,7 +1937,7 @@ function UploadForm({
               className={formStyles.chooseButton}
               onClick={handleGoogleDriveClick}
               disabled={drivePending}
-              aria-label="Choose from Google Drive"
+              aria-label={t('upload.form.chooseFromDrive')}
             >
               {drivePending
                 ? t('upload.form.openingDrive')
@@ -1983,7 +1982,7 @@ function UploadForm({
         </a>
       )}
       <button
-        aria-label="Upload file"
+        aria-label={t('upload.form.uploadFileAria')}
         className={sharedStyles.hidden}
         ref={convertRef}
         type="submit"

--- a/web/src/pages/UploadPage/components/UploadForm/UploadSourceChips.test.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadSourceChips.test.tsx
@@ -1,4 +1,4 @@
-import { render, act } from '@testing-library/react';
+import { render, act, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { UploadSourceChips, type UploadSource } from './UploadSourceChips';
 
@@ -28,9 +28,10 @@ describe('UploadSourceChips', () => {
         googleDriveAvailable={false}
       />
     );
-    const dropboxBtn = container.querySelector('button[aria-label="Dropbox"]');
-    expect(dropboxBtn).not.toBeNull();
-    expect(dropboxBtn?.hasAttribute('disabled')).toBe(false);
+    const dropboxBtn = within(container).getByRole('button', {
+      name: 'Dropbox',
+    });
+    expect(dropboxBtn.hasAttribute('disabled')).toBe(false);
   });
 
   it('renders Dropbox chip disabled when not available', () => {
@@ -42,9 +43,10 @@ describe('UploadSourceChips', () => {
         googleDriveAvailable={false}
       />
     );
-    const dropboxBtn = container.querySelector('button[aria-label="Dropbox"]');
-    expect(dropboxBtn).not.toBeNull();
-    expect(dropboxBtn?.hasAttribute('disabled')).toBe(true);
+    const dropboxBtn = within(container).getByRole('button', {
+      name: 'Dropbox',
+    });
+    expect(dropboxBtn.hasAttribute('disabled')).toBe(true);
   });
 
   it('renders the Google Drive chip when available', () => {
@@ -56,11 +58,10 @@ describe('UploadSourceChips', () => {
         googleDriveAvailable={true}
       />
     );
-    const driveBtn = container.querySelector(
-      'button[aria-label="Google Drive"]'
-    );
-    expect(driveBtn).not.toBeNull();
-    expect(driveBtn?.hasAttribute('disabled')).toBe(false);
+    const driveBtn = within(container).getByRole('button', {
+      name: 'Google Drive',
+    });
+    expect(driveBtn.hasAttribute('disabled')).toBe(false);
   });
 
   it('renders Google Drive chip disabled when not available', () => {
@@ -72,11 +73,10 @@ describe('UploadSourceChips', () => {
         googleDriveAvailable={false}
       />
     );
-    const driveBtn = container.querySelector(
-      'button[aria-label="Google Drive"]'
-    );
-    expect(driveBtn).not.toBeNull();
-    expect(driveBtn?.hasAttribute('disabled')).toBe(true);
+    const driveBtn = within(container).getByRole('button', {
+      name: 'Google Drive',
+    });
+    expect(driveBtn.hasAttribute('disabled')).toBe(true);
   });
 
   it('calls onChange with "dropbox" when the Dropbox chip is clicked and local is active', async () => {
@@ -89,9 +89,9 @@ describe('UploadSourceChips', () => {
         googleDriveAvailable={false}
       />
     );
-    const dropboxBtn = container.querySelector(
-      'button[aria-label="Dropbox"]'
-    ) as HTMLButtonElement;
+    const dropboxBtn = within(container).getByRole('button', {
+      name: 'Dropbox',
+    });
     await act(async () => {
       dropboxBtn.click();
     });
@@ -108,9 +108,9 @@ describe('UploadSourceChips', () => {
         googleDriveAvailable={false}
       />
     );
-    const dropboxBtn = container.querySelector(
-      'button[aria-label="Dropbox"]'
-    ) as HTMLButtonElement;
+    const dropboxBtn = within(container).getByRole('button', {
+      name: 'Dropbox',
+    });
     await act(async () => {
       dropboxBtn.click();
     });
@@ -127,9 +127,9 @@ describe('UploadSourceChips', () => {
         googleDriveAvailable={true}
       />
     );
-    const driveBtn = container.querySelector(
-      'button[aria-label="Google Drive"]'
-    ) as HTMLButtonElement;
+    const driveBtn = within(container).getByRole('button', {
+      name: 'Google Drive',
+    });
     await act(async () => {
       driveBtn.click();
     });
@@ -145,8 +145,10 @@ describe('UploadSourceChips', () => {
         googleDriveAvailable={false}
       />
     );
-    const dropboxBtn = container.querySelector('button[aria-label="Dropbox"]');
-    expect(dropboxBtn?.getAttribute('aria-pressed')).toBe('true');
+    const dropboxBtn = within(container).getByRole('button', {
+      name: 'Dropbox',
+    });
+    expect(dropboxBtn.getAttribute('aria-pressed')).toBe('true');
   });
 
   it('does not render null class names', () => {

--- a/web/src/pages/UploadPage/components/UploadForm/UploadSourceChips.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadSourceChips.tsx
@@ -83,7 +83,6 @@ export function UploadSourceChips({
       >
         <button
           type="button"
-          aria-label="Dropbox"
           aria-pressed={active === 'dropbox'}
           disabled={!dropboxAvailable}
           className={`${styles.chip} ${active === 'dropbox' ? styles.chipActive : ''}`}
@@ -94,7 +93,6 @@ export function UploadSourceChips({
         </button>
         <button
           type="button"
-          aria-label="Google Drive"
           aria-pressed={active === 'google_drive'}
           disabled={!googleDriveAvailable}
           className={`${styles.chip} ${active === 'google_drive' ? styles.chipActive : ''}`}

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-16-a11y-keyboard-screenreader.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-16-a11y-keyboard-screenreader.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-16-a11y-keyboard-screenreader",
+  "date": "2026-08-16",
+  "type": "fix",
+  "title": "Keyboard and screen-reader support improved across upload, chat, and mind maps"
+}


### PR DESCRIPTION
## What
Ships the accessibility P1 batch from the codebase audit 2026-08-17 a11y findings (minus LandingPage, owned by the SEO PR) as one PR: visible focus indicators, real dialog focus management, a de-nested mind-map delete control, grouped segmented controls, theme-token colors, i18n for upload aria/live strings, and corrected heading levels.

## Why
Keyboard-only and screen-reader users hit concrete blocks: no visible focus on the chat composer or the mind-map title, two modals that neither trapped focus nor closed on Escape, a `<span role="button">` delete control nested inside the row `<button>` (invalid interactive nesting), orphan `<label>`s over segmented button groups, focus/knob colors hardcoded outside the theme system, six English-only aria-labels plus the upload `aria-live` announcements, and plan/empty-state headings that skipped from the page `<h1>`.

## How
- **Focus indicators**: `:focus-visible` rings (via `--color-focus-ring`) on the chat composer textarea and the contentEditable mind-map title.
- **Dialog focus management**: new shared `useDialogFocus` hook (focus-in, Tab/Shift+Tab trap, Escape-to-close, focus restore) wired into the mind-map ExportModal (now `role="dialog"`/`aria-modal`/`aria-labelledby`) and the upload OnboardingTour. Added an `isInsideDialog` guard to the mind-map canvas keyboard handler so global shortcuts don't fire while a dialog is focused.
- **Nested interactive**: MindmapList row is now a non-interactive container with sibling open + delete `<button>`s; the `stopPropagation` workaround is gone and keyboard activation is native.
- **Labels**: the deck icon and toggle-mode segmented groups use `role="group"` + `aria-labelledby`; the file-wide `label-has-associated-control` eslint-disable is removed (all remaining `<label>`s have associated controls — lint is clean).
- **Colors**: focus-ring `rgba(...)` → `var(--color-focus-ring)`; toggle knob `#fff` → `var(--color-bg-primary)`.
- **i18n**: upload live-status strings, the PDF-password / change-source / upload-file aria-labels, the Dropbox/Drive choose-button labels (reuse existing keys), UploadSourceChips (dropped the redundant chip aria-labels — visible text is now the accessible name), and HomePage's `Play:` prefix all move to `t()` in `common.json` across all 10 locales.
- **Headings**: PricingCard/UnlimitedCard titles `<p>`→`<h3>` (nest under the section `<h2>`s), ChatPanel empty-state `<h1>`→`<h2>` (it renders embedded under pages that already own the `<h1>`); same classes preserve visuals.

## Measuring success
No funnel/revenue metric — internal accessibility polish. Confirmed by: the golden-path Playwright check (no console errors at 375px), the new colocated tests that lock the behavior in CI (`useDialogFocus` focus/Escape/restore, `MindmapList` sibling-button delete, `a11yUploadKeys.parity` asserting the new keys + `{{count}}`/`{{title}}` placeholders exist in all 10 locales, `MindmapEditor` export-dialog Escape, `OnboardingTour` dialog focus + Escape), and a re-run of the audit against these surfaces.

## Testing
- Unit tests added: `useDialogFocus.test.tsx` (6), `MindmapList.test.tsx` (3), `a11yUploadKeys.parity.test.ts` (30 via `it.each`); extended `MindmapEditor.test.tsx` (export dialog semantics + Escape) and `OnboardingTour.test.tsx` (dialog focus-in + Escape).
- Updated `UploadSourceChips.test.tsx` and `UploadForm.test.tsx` to query chips by accessible name (visible text) instead of the removed chip aria-labels.
- Full web suite green: **367 files / 2908 tests passed**. Typecheck, `pnpm lint`, and tree-wide `pnpm format:check` all clean.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: `pnpm --filter 2anki-web test:golden-path` → 2 passed (landing + signed-in dashboard render without console errors at 375px) — used as the browser attestation. The two focus-ring coexistence questions below are worth a designer eyeball via `pnpm dev`.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-08-16-a11y-keyboard-screenreader.json` — "Keyboard and screen-reader support improved across upload, chat, and mind maps"

## Risks
Low. Behavior-only a11y changes; no data or API surface touched.
- The chat composer already showed a keyboard-focus ring via `.composerPill:focus-within`; the added textarea `:focus-visible` ring is defense-in-depth, so keyboard focus now shows both the outer pill glow and an inner rounded ring. Reads as a "strong focus" state — flagging for a designer eyeball in case one should win.
- Toggle knob now `var(--color-bg-primary)`: identical in light theme (`#ffffff`), but in dark theme the knob shifts from pure white to the dark page surface. Functional (track color still signals on/off) but a visual change; the sibling `PhotoToFlashcardsPage` toggle (out of scope) still uses `#fff`, so there's a minor cross-surface inconsistency until that's swept too.

## Goal alignment
None direct — internal accessibility/quality work, not an acquisition or revenue lever. Indirect: WCAG-AA keyboard/SR support is a stated product constraint and reduces friction/abandonment for assistive-tech users on the core upload and mind-map flows.

---

### Deviations / notes for review
- **Closed enumerated set honored.** The audit named exactly six upload aria-labels. While in the file I noticed three more hardcoded English aria-labels not in that set — `Ask Claude about {file}` (~1799), `Talk to Claude about {file}` (~1848), `download link` (~1976) — plus the locked-PDF panel's visible English strings (`This PDF is password-protected` headline, `Enter password` placeholder, `Unlock` button). Left untouched and flagged here rather than silently extending the batch; happy to fold them into a follow-up.
- **Translations need a native pass.** The 10-locale strings (live-status, aria-labels, `Play:`) were translated faithfully and terse but are not native-reviewed. Protected tokens (PDF, Dropbox, Google Drive, `{{count}}`/`{{title}}`) kept verbatim; product-name "Photo to Deck" matches each locale's existing `tryPhotoToDeck` phrasing. CLDR plural forms filled per language (ja `_other`; ru/pl `_one/_few/_many/_other`).
- **Sonar:** not run locally; PR decoration will report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbQZzLbjr2apKHQC7orhhw


## Sonar follow-up (post-push scan)

The PR scan's four findings: two `role="group"` segmented groups converted to native `fieldset`/`legend` (S6819) and the focus trap now uses `.at(-1)` (S7755) — both fixed in the follow-up commit. The remaining S6819 on MindmapEditor's `role="dialog"` is deliberately NOT converted: swapping two working div-based modals to native `<dialog>` changes focus/backdrop/Escape semantics and belongs in a dedicated follow-up; `role="dialog"` with a correct focus trap (this PR's `useDialogFocus`) is valid ARIA. Accepting this one finding knowingly.
