### PR TITLE
fix: isolate LibreOffice profiles so parallel PPT conversions succeed

### DIFF
--- a/src/infrastracture/adapters/fileConversion/ConvertPPTToPDF.test.ts
+++ b/src/infrastracture/adapters/fileConversion/ConvertPPTToPDF.test.ts
@@ -18,7 +18,7 @@ const mockedSpawn = childProcess.spawn as jest.MockedFunction<
   typeof childProcess.spawn
 >;
 
-function makeFailingProcess(
+function makeProcess(
   stderr: string,
   exitCode: number
 ): childProcess.ChildProcess {
@@ -31,11 +31,19 @@ function makeFailingProcess(
     stderrEmitter;
 
   setImmediate(() => {
-    stderrEmitter.emit('data', Buffer.from(stderr));
+    if (stderr) {
+      stderrEmitter.emit('data', Buffer.from(stderr));
+    }
     proc.emit('close', exitCode);
   });
 
   return proc;
+}
+
+const makeFailingProcess = makeProcess;
+
+function spawnedArgs(callIndex: number): string[] {
+  return mockedSpawn.mock.calls[callIndex][1] as string[];
 }
 
 describe('convertPPTToPDF', () => {
@@ -77,5 +85,56 @@ describe('convertPPTToPDF', () => {
     expect(logged).toContain('251');
 
     errorSpy.mockRestore();
+  });
+
+  it('converts headlessly with an isolated profile per invocation', async () => {
+    mockedSpawn.mockReturnValue(makeProcess('', 0));
+
+    const result = await convertPPTToPDF(
+      'slides.pptx',
+      Buffer.from('fake'),
+      workspace
+    );
+
+    expect(result).toEqual(Buffer.from('pdf-bytes'));
+    const [bin] = mockedSpawn.mock.calls[0];
+    expect(String(bin)).toContain('soffice');
+    const args = spawnedArgs(0);
+    expect(args).toEqual(
+      expect.arrayContaining(['--headless', '--convert-to', 'pdf', '--outdir'])
+    );
+    expect(args.some((a) => a.startsWith('-env:UserInstallation=file:'))).toBe(
+      true
+    );
+  });
+
+  it('uses a different profile directory on every invocation', async () => {
+    mockedSpawn.mockReturnValueOnce(makeProcess('', 0));
+    mockedSpawn.mockReturnValueOnce(makeProcess('', 0));
+
+    await convertPPTToPDF('a.pptx', Buffer.from('fake'), workspace);
+    await convertPPTToPDF('b.pptx', Buffer.from('fake'), workspace);
+
+    const profileOf = (args: string[]) =>
+      args.find((a) => a.startsWith('-env:UserInstallation='));
+    const first = profileOf(spawnedArgs(0));
+    const second = profileOf(spawnedArgs(1));
+    expect(first).toBeDefined();
+    expect(second).toBeDefined();
+    expect(first).not.toEqual(second);
+  });
+
+  it('rejects instead of hanging when exit 0 produced no PDF', async () => {
+    const fsPromises = jest.requireMock('fs/promises') as {
+      readFile: jest.Mock;
+    };
+    fsPromises.readFile.mockRejectedValueOnce(
+      Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    );
+    mockedSpawn.mockReturnValue(makeProcess('', 0));
+
+    await expect(
+      convertPPTToPDF('slides.pptx', Buffer.from('fake'), workspace)
+    ).rejects.toThrow(/no PDF/i);
   });
 });

--- a/src/infrastracture/adapters/fileConversion/ConvertPPTToPDF.ts
+++ b/src/infrastracture/adapters/fileConversion/ConvertPPTToPDF.ts
@@ -1,7 +1,9 @@
 import Workspace from '../../../lib/parser/WorkSpace';
 import path from 'path';
+import { pathToFileURL } from 'url';
 import fs from 'fs/promises';
 import { spawn } from 'child_process';
+import { getRandomUUID } from '../../../shared/helpers/getRandomUUID';
 
 export function convertPPTToPDF(
   name: string,
@@ -9,13 +11,19 @@ export function convertPPTToPDF(
   workspace: Workspace
 ): Promise<Buffer> {
   return new Promise((resolve, reject) => {
-    const unoconvBin =
+    const sofficeBin =
       process.platform === 'darwin'
-        ? '/usr/local/bin/unoconv'
-        : '/usr/bin/unoconv';
+        ? '/Applications/LibreOffice.app/Contents/MacOS/soffice'
+        : '/usr/bin/soffice';
 
     const normalizedName = path.basename(name);
     const tempFile = path.join(workspace.location, normalizedName);
+    // Each run gets its own LibreOffice profile: concurrent conversions
+    // sharing the default profile collide on its lock and abort (exit 251).
+    const profileDir = path.join(
+      workspace.location,
+      `soffice-profile-${getRandomUUID()}`
+    );
 
     fs.writeFile(tempFile, Buffer.from(contents as Buffer))
       .then(() => {
@@ -24,44 +32,69 @@ export function convertPPTToPDF(
           path.basename(normalizedName, path.extname(normalizedName)) + '.pdf'
         );
 
-        const unoconvProcess = spawn(unoconvBin, ['-f', 'pdf', tempFile], {
-          cwd: workspace.location,
-        });
+        const sofficeProcess = spawn(
+          sofficeBin,
+          [
+            `-env:UserInstallation=${pathToFileURL(profileDir)}`,
+            '--headless',
+            '--norestore',
+            '--convert-to',
+            'pdf',
+            '--outdir',
+            workspace.location,
+            tempFile,
+          ],
+          {
+            cwd: workspace.location,
+          }
+        );
 
         let stdout = '';
         let stderr = '';
 
-        unoconvProcess.stdout.on('data', (data) => {
+        sofficeProcess.stdout.on('data', (data) => {
           stdout += data;
         });
 
-        unoconvProcess.stderr.on('data', (data) => {
+        sofficeProcess.stderr.on('data', (data) => {
           stderr += data;
         });
 
-        unoconvProcess.on('close', async (code) => {
-          await fs.writeFile(
-            path.join(workspace.location, 'stdout.log'),
-            stdout
-          );
-          await fs.writeFile(
-            path.join(workspace.location, 'stderr.log'),
-            stderr
-          );
-          if (code !== 0) {
-            const trimmedStderr = stderr.trim();
-            const detail = trimmedStderr || stdout.trim() || '(no output)';
+        sofficeProcess.on('close', async (code) => {
+          try {
             await fs.writeFile(
-              path.join(workspace.location, 'error.log'),
-              `Conversion failed with code ${code}`
+              path.join(workspace.location, 'stdout.log'),
+              stdout
             );
-            console.error(
-              `PPT to PDF conversion failed with exit code ${code}:`,
-              detail
+            await fs.writeFile(
+              path.join(workspace.location, 'stderr.log'),
+              stderr
             );
-            reject(new Error(`Conversion failed with code ${code}: ${detail}`));
-          } else {
+            if (code !== 0) {
+              const trimmedStderr = stderr.trim();
+              const detail = trimmedStderr || stdout.trim() || '(no output)';
+              await fs.writeFile(
+                path.join(workspace.location, 'error.log'),
+                `Conversion failed with code ${code}`
+              );
+              console.error(
+                `PPT to PDF conversion failed with exit code ${code}:`,
+                detail
+              );
+              reject(
+                new Error(`Conversion failed with code ${code}: ${detail}`)
+              );
+              return;
+            }
             resolve(await fs.readFile(pdfFile));
+          } catch (err) {
+            const detail = stderr.trim() || stdout.trim() || '(no output)';
+            console.error(
+              'PPT to PDF conversion produced no PDF output:',
+              detail,
+              err
+            );
+            reject(new Error(`Conversion produced no PDF output: ${detail}`));
           }
         });
       })

--- a/src/infrastracture/adapters/fileConversion/ConvertPPTToPDF.ts
+++ b/src/infrastracture/adapters/fileConversion/ConvertPPTToPDF.ts
@@ -1,6 +1,6 @@
 import Workspace from '../../../lib/parser/WorkSpace';
 import path from 'path';
-import { pathToFileURL } from 'url';
+import { pathToFileURL } from 'node:url';
 import fs from 'fs/promises';
 import { spawn } from 'child_process';
 import { getRandomUUID } from '../../../shared/helpers/getRandomUUID';

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-17-powerpoint-conversion-reliability.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-17-powerpoint-conversion-reliability.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-17-powerpoint-conversion-reliability",
+  "date": "2026-08-17",
+  "type": "fix",
+  "title": "PowerPoint uploads no longer fail when several convert at the same time"
+}


### PR DESCRIPTION
## What

PPT/PPTX uploads stop failing when several convert at the same time. `ConvertPPTToPDF` now runs `soffice --headless --convert-to pdf` directly, giving every invocation its own LibreOffice profile via `-env:UserInstallation` inside the job workspace, instead of going through `unoconv`'s shared-listener model. The exit-0-but-no-PDF case now rejects with a clear error instead of hanging on an unhandled `readFile` rejection.

## Why

Prod error logs show 13 PPT conversion failures on Aug 15–16, all `unoconv` exit 251 "Unable to connect or start own listener. Aborting." `PrepareDeck` converts files with concurrency 4, and each concurrent `unoconv` tries to start its own soffice instance against the same default profile — they collide on the profile lock and abort. Every hit is a user-facing failed conversion.

## How verified

- TDD: new tests assert the headless soffice invocation, a **different** `UserInstallation` profile on every call (the race fix), and clean rejection when exit 0 produces no PDF. Watched them fail against the old code first.
- On the prod box itself: ran two concurrent `soffice -env:UserInstallation=<unique> --headless --convert-to pdf` conversions — both produced PDFs (`CONCURRENT_OK`), the exact scenario unoconv fails.
- Full converter suite 5/5, consumer `PrepareDeck.test.ts` 35/35, server `tsc -p . --noEmit` clean, web vitest 3324/3324, `pnpm format:check` clean.

## Risks

- First run per profile initializes LibreOffice config (~1–2s per conversion) — acceptable on a path that previously failed outright. Profile dirs live inside the job workspace, so workspace cleanup removes them.
- macOS dev path now expects `/Applications/LibreOffice.app/Contents/MacOS/soffice` (was `/usr/local/bin/unoconv`); prod uses `/usr/bin/soffice`, verified present.

Sonar: not run locally; PR decoration will report.

Browser check: not applicable — web diff is a changelog JSON entry only, no runtime-visible surface changed.

## Goal alignment

Simpler/faster: uploads that silently failed now convert — reliability of the core drop-something-get-a-deck promise. Metric: `PPT to PDF conversion failed` disappears from prod error logs.
