### PR TITLE
fix: keep font URLs same-origin so the display font loads

### DIFF
--- a/web/scripts/sameOriginBuiltUrl.test.ts
+++ b/web/scripts/sameOriginBuiltUrl.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { sameOriginBuiltUrl } from './sameOriginBuiltUrl';
+
+describe('sameOriginBuiltUrl', () => {
+  it('keeps font files same-origin so the CDN base never applies', () => {
+    expect(sameOriginBuiltUrl('fonts/Fraunces/Fraunces-600.woff2')).toBe(
+      '/fonts/Fraunces/Fraunces-600.woff2'
+    );
+  });
+
+  it('handles a leading slash the bundler may pass through', () => {
+    expect(sameOriginBuiltUrl('/fonts/Fraunces/Fraunces-500.woff2')).toBe(
+      '/fonts/Fraunces/Fraunces-500.woff2'
+    );
+  });
+
+  it('leaves hashed bundle assets on the default CDN base', () => {
+    expect(sameOriginBuiltUrl('assets/index-Dr0U61s3.css')).toBeUndefined();
+    expect(sameOriginBuiltUrl('assets/index-abc123.js')).toBeUndefined();
+  });
+});

--- a/web/scripts/sameOriginBuiltUrl.ts
+++ b/web/scripts/sameOriginBuiltUrl.ts
@@ -1,0 +1,7 @@
+const SAME_ORIGIN_PREFIXES = ['fonts/'];
+
+export function sameOriginBuiltUrl(filename: string): string | undefined {
+  const normalized = filename.replace(/^\/+/, '');
+  const prefix = SAME_ORIGIN_PREFIXES.find((p) => normalized.startsWith(p));
+  return prefix == null ? undefined : `/${normalized}`;
+}

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-18-heading-font-restored.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-18-heading-font-restored.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-18-heading-font-restored",
+  "date": "2026-08-18",
+  "type": "fix",
+  "title": "Headings render in the intended typeface again"
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -10,6 +10,7 @@ import {
   emitNotionMarketplacePage,
 } from './scripts/prerenderLandingPages';
 import { keepRootAssetsSameOrigin } from './scripts/keepRootAssetsSameOrigin';
+import { sameOriginBuiltUrl } from './scripts/sameOriginBuiltUrl';
 
 const SHORT_SHA_LENGTH = 7;
 const FULL_SHA_PATTERN = /^[0-9a-f]{40}$/i;
@@ -73,6 +74,12 @@ export default defineConfig(({ command, mode }) => {
 
   return {
     base,
+
+    experimental: {
+      renderBuiltUrl(filename) {
+        return sameOriginBuiltUrl(filename);
+      },
+    },
 
     plugins: [
       react(),


### PR DESCRIPTION
## What

The Fraunces display font loads again. Vite's CDN asset base was rebasing the bundled CSS `url('/fonts/…')` references to the DigitalOcean Spaces bucket, which never received a `fonts/` directory — both weights 404 for every visitor, so headings have been silently rendering in the fallback system sans in production (screenshot-confirmed in today's site audit). Meanwhile `index.html` preloads the same-origin copy the CSS never requested — a wasted preload plus a guaranteed console error on every page view.

`experimental.renderBuiltUrl` now pins anything under `fonts/` to a same-origin URL while leaving hashed bundles on the CDN. Same-origin matches the existing preload and sidesteps cross-origin font CORS entirely; at 26KB per file the CDN buys nothing.

## How verified

- Built with `ASSET_BASE_URL=https://2anki-assets.fra1.cdn.digitaloceanspaces.com` and inspected the emitted CSS: `url(/fonts/Fraunces/Fraunces-500.woff2)` / `-600` same-origin, JS bundle still CDN-prefixed.
- New unit test on the `sameOriginBuiltUrl` helper (fonts pinned, hashed assets untouched); full web suite 3327/3327, typecheck, lint, `pnpm format:check` all green.

Browser check: not applicable — the defect only manifests behind the production CDN base (local dev serves everything same-origin, so the browser shows no difference); verification is the CDN-base build artifact inspection above. Post-deploy check: zero console errors on 2anki.net and serif headings visible.

Sonar: not run locally; PR decoration will report.

## Goal alignment

More beautiful, literally — restores the brand typeface for every visitor. Metric: the font 404 disappears from browser consoles; visual check post-deploy.

Part of the 2026-08-18 site-audit fix batch (Phase 1, item 1).
