### PR TITLE
fix: add HSTS, nosniff, referrer-policy; drop x-powered-by

### DIFF
--- a/src/routes/middleware/securityHeaders.test.ts
+++ b/src/routes/middleware/securityHeaders.test.ts
@@ -1,0 +1,56 @@
+import { Request, Response, NextFunction } from 'express';
+import { securityHeaders } from './securityHeaders';
+
+function mockReq(): Request {
+  return {} as Request;
+}
+
+function mockRes(): { headers: Record<string, string>; setHeader: jest.Mock } {
+  const headers: Record<string, string> = {};
+  return {
+    headers,
+    setHeader: jest.fn((name: string, value: string) => {
+      headers[name] = value;
+    }),
+  };
+}
+
+describe('securityHeaders', () => {
+  it('sets Strict-Transport-Security for one year including subdomains', () => {
+    const res = mockRes();
+    const next = jest.fn();
+    securityHeaders(
+      mockReq(),
+      res as unknown as Response,
+      next as NextFunction
+    );
+    expect(res.headers['Strict-Transport-Security']).toBe(
+      'max-age=31536000; includeSubDomains'
+    );
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('sets X-Content-Type-Options to nosniff', () => {
+    const res = mockRes();
+    const next = jest.fn();
+    securityHeaders(
+      mockReq(),
+      res as unknown as Response,
+      next as NextFunction
+    );
+    expect(res.headers['X-Content-Type-Options']).toBe('nosniff');
+  });
+
+  it('sets Referrer-Policy to strict-origin-when-cross-origin', () => {
+    const res = mockRes();
+    const next = jest.fn();
+    securityHeaders(
+      mockReq(),
+      res as unknown as Response,
+      next as NextFunction
+    );
+    expect(res.headers['Referrer-Policy']).toBe(
+      'strict-origin-when-cross-origin'
+    );
+  });
+});

--- a/src/routes/middleware/securityHeaders.ts
+++ b/src/routes/middleware/securityHeaders.ts
@@ -1,0 +1,15 @@
+import { Request, Response, NextFunction } from 'express';
+
+export function securityHeaders(
+  _req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  res.setHeader(
+    'Strict-Transport-Security',
+    'max-age=31536000; includeSubDomains'
+  );
+  res.setHeader('X-Content-Type-Options', 'nosniff');
+  res.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
+  next();
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -43,6 +43,7 @@ import templatesRouter from './routes/TemplatesRouter';
 import defaultRouter from './routes/DefaultRouter';
 import rejectScannerProbes from './routes/middleware/rejectScannerProbes';
 import { denyFraming } from './routes/middleware/denyFraming';
+import { securityHeaders } from './routes/middleware/securityHeaders';
 import { noindexNonCanonicalHosts } from './routes/middleware/noindexNonCanonicalHosts';
 import { redirectNonCanonicalHosts } from './routes/middleware/redirectNonCanonicalHosts';
 import { redirectConvertDuplicates } from './routes/middleware/redirectConvertDuplicates';
@@ -152,6 +153,7 @@ const serve = async () => {
   const app = express();
   // nginx on the same box terminates SSL and forwards over loopback; trust exactly one hop.
   app.set('trust proxy', 1);
+  app.disable('x-powered-by');
   const server = http.createServer(app);
 
   app.use(webhookRouter());
@@ -161,6 +163,7 @@ const serve = async () => {
   app.use(express.json({ limit: '50mb' }) as RequestHandler);
   app.use(cookieParser());
   app.use(denyFraming);
+  app.use(securityHeaders);
   app.use(anonIdMiddleware);
   app.use(noindexNonCanonicalHosts);
   app.use(redirectConvertDuplicates);


### PR DESCRIPTION
## What

New `securityHeaders` middleware (mounted beside `denyFraming`) sets `Strict-Transport-Security: max-age=31536000; includeSubDomains`, `X-Content-Type-Options: nosniff`, and `Referrer-Policy: strict-origin-when-cross-origin` on every response; `app.disable('x-powered-by')` stops advertising Express.

## Why

2026-08-18 site audit (Phase 1, item 5): apex served none of these. HSTS closes the first-visit downgrade window, nosniff kills MIME confusion on served uploads, Referrer-Policy stops leaking full URLs cross-origin.

## Testing

3 unit tests on the middleware (exact header values), `tsc -p . --noEmit` clean, `pnpm format:check` clean. Post-deploy verify: `curl -sI https://2anki.net/ | grep -iE 'strict-transport|content-type-options|referrer|powered'`.

No changelog entry — headers are invisible to users.

Sonar: not run locally; PR decoration will report.

## Goal alignment

Trust/security hardening on every response; no funnel metric — internal.