### PR TITLE
fix: one canonical per page, prerender sitemap orphans

### DIFF
--- a/web/public/sitemap.xml
+++ b/web/public/sitemap.xml
@@ -3,385 +3,257 @@
   <url>
     <loc>https://2anki.net/</loc>
     <lastmod>2026-06-10</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>1.0</priority>
   </url>
   <url>
     <loc>https://2anki.net/upload/</loc>
     <lastmod>2026-06-10</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/pricing/</loc>
     <lastmod>2026-06-10</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://2anki.net/app</loc>
-    <lastmod>2026-06-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
+    <loc>https://2anki.net/app/</loc>
+    <lastmod>2026-08-18</lastmod>
   </url>
   <url>
     <loc>https://2anki.net/about/</loc>
     <lastmod>2026-06-10</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.5</priority>
   </url>
   <url>
     <loc>https://2anki.net/convert/</loc>
     <lastmod>2026-06-10</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://2anki.net/notion-to-anki/</loc>
     <lastmod>2026-05-25</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/quizlet-to-anki/</loc>
     <lastmod>2026-05-18</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/markdown-to-anki/</loc>
     <lastmod>2026-05-25</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/pdf-to-anki/</loc>
     <lastmod>2026-05-25</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/anki-to-notion/</loc>
     <lastmod>2026-05-18</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/usmle-anki/</loc>
     <lastmod>2026-05-22</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/step1-anki/</loc>
     <lastmod>2026-07-14</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/nclex-anki/</loc>
     <lastmod>2026-07-14</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/mcat-anki/</loc>
     <lastmod>2026-07-14</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/nursing-flashcards/</loc>
     <lastmod>2026-05-22</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/anki-for-japanese/</loc>
     <lastmod>2026-06-14</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/anki-from-medical-lecture-slides/</loc>
     <lastmod>2026-05-22</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/powerpoint-to-anki/</loc>
     <lastmod>2026-05-25</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/goodnotes-to-anki/</loc>
     <lastmod>2026-05-25</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/ai-flashcard-generator/</loc>
     <lastmod>2026-05-25</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/notion-marketplace/</loc>
     <lastmod>2026-05-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://2anki.net/convert/csv-to-anki/</loc>
     <lastmod>2026-05-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/convert/html-to-anki/</loc>
     <lastmod>2026-05-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/convert/apkg-to-csv/</loc>
     <lastmod>2026-05-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/convert/notion-tables-to-anki/</loc>
     <lastmod>2026-05-19</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/convert/lingvist-to-anki/</loc>
     <lastmod>2026-05-26</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/convert/studystack-to-anki/</loc>
     <lastmod>2026-05-26</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/convert/zorbi-to-anki/</loc>
     <lastmod>2026-05-26</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/convert/pleco-to-anki/</loc>
     <lastmod>2026-05-30</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/convert/brainscape-to-anki/</loc>
     <lastmod>2026-05-30</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/convert/language-reactor-to-anki/</loc>
     <lastmod>2026-05-30</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/convert/epub-to-anki/</loc>
     <lastmod>2026-05-31</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/convert/kindle-to-anki/</loc>
     <lastmod>2026-05-31</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/convert/excel-to-anki/</loc>
     <lastmod>2026-07-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/convert/word-to-anki/</loc>
     <lastmod>2026-07-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/convert/obsidian-to-anki/</loc>
     <lastmod>2026-07-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/convert/photo-to-anki/</loc>
     <lastmod>2026-07-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/convert/google-slides-to-anki/</loc>
     <lastmod>2026-07-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/convert/screenshot-to-anki/</loc>
     <lastmod>2026-07-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/convert/google-sheets-to-anki/</loc>
     <lastmod>2026-07-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/convert/txt-to-anki/</loc>
     <lastmod>2026-07-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/convert/onenote-to-anki/</loc>
     <lastmod>2026-07-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/convert/evernote-to-anki/</loc>
     <lastmod>2026-07-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/convert/google-docs-to-anki/</loc>
     <lastmod>2026-07-18</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/answers/fsrs-explained/</loc>
     <lastmod>2026-05-24</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://2anki.net/answers/lecture-notes-to-anki/</loc>
     <lastmod>2026-07-07</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://2anki.net/answers/word-to-anki/</loc>
     <lastmod>2026-07-07</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://2anki.net/answers/image-occlusion-anki/</loc>
     <lastmod>2026-07-07</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://2anki.net/answers/google-docs-to-anki/</loc>
     <lastmod>2026-07-08</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://2anki.net/answers/handwritten-notes-to-anki/</loc>
     <lastmod>2026-07-08</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://2anki.net/answers/textbook-to-anki/</loc>
     <lastmod>2026-07-08</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://2anki.net/answers/kindle-highlights-to-anki/</loc>
     <lastmod>2026-07-10</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://2anki.net/answers/language-app-to-anki/</loc>
     <lastmod>2026-07-10</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://2anki.net/answers/obsidian-to-anki/</loc>
     <lastmod>2026-07-10</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://2anki.net/answers/claude-to-anki/</loc>
     <lastmod>2026-07-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://2anki.net/answers/convert-notion-to-anki/</loc>
     <lastmod>2026-06-10</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://2anki.net/answers/notion-to-anki-sync/</loc>
     <lastmod>2026-06-10</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://2anki.net/answers/pdf-to-anki/</loc>
     <lastmod>2026-06-10</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://2anki.net/answers/quizlet-to-anki/</loc>
     <lastmod>2026-06-10</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://2anki.net/security</loc>
-    <lastmod>2026-06-10</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.4</priority>
+    <loc>https://2anki.net/security/</loc>
+    <lastmod>2026-08-18</lastmod>
   </url>
   <url>
-    <loc>https://2anki.net/contact</loc>
-    <lastmod>2026-06-10</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.4</priority>
+    <loc>https://2anki.net/contact/</loc>
+    <lastmod>2026-08-18</lastmod>
   </url>
   <url>
-    <loc>https://2anki.net/documentation/start-here/connect-notion</loc>
-    <lastmod>2026-06-10</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://2anki.net/documentation/start-here/connect-notion/</loc>
+    <lastmod>2026-08-18</lastmod>
   </url>
   <url>
-    <loc>https://2anki.net/documentation/cards/notion-to-anki-japanese</loc>
-    <lastmod>2026-06-14</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://2anki.net/documentation/cards/notion-to-anki-japanese/</loc>
+    <lastmod>2026-08-18</lastmod>
   </url>
 </urlset>

--- a/web/scripts/prerenderLandingPages.ts
+++ b/web/scripts/prerenderLandingPages.ts
@@ -23,6 +23,7 @@ import {
 } from '../src/pages/AnswersPage/answersJsonLd';
 import { buildFaqJsonLd as buildLandingFaqJsonLd } from '../src/pages/LandingPage/landingJsonLd';
 import type { LandingCopy } from '../src/pages/LandingPage/types';
+import { canonicalUrl } from '../src/lib/seo/canonicalUrl';
 
 const LANDING_COPIES: LandingCopy[] = [
   notionCopy,
@@ -50,11 +51,6 @@ const escapeHtml = (value: string): string =>
     .replace(/'/g, '&#39;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;');
-
-const canonicalUrl = (pathname: string): string => {
-  const withTrailingSlash = pathname.endsWith('/') ? pathname : `${pathname}/`;
-  return `https://2anki.net${withTrailingSlash}`;
-};
 
 function buildHeroFragment(copy: LandingCopy): string {
   return [
@@ -273,6 +269,30 @@ const META_ONLY_PAGES: MetaOnlyPageMeta[] = [
     title: 'Anki flashcards on iPhone — 2anki app',
     description:
       'Convert your notes and files into Anki decks on iPhone, iPad, and Mac. Markdown, PDF, Notion, CSV, OPML, Kindle — parsed on your device. On the App Store for iPhone, iPad, and Mac.',
+  },
+  {
+    pathname: '/security',
+    title: 'Report a security vulnerability — 2anki',
+    description:
+      'How to report a security issue in 2anki: what to include, what is in scope, and how fast we respond. Covers 2anki.net, the API, and the open-source repository.',
+  },
+  {
+    pathname: '/contact',
+    title: 'Contact 2anki — support and feedback',
+    description:
+      'Reach the people who build 2anki. Report a conversion problem, ask a billing question, or send feedback — messages go straight to the maintainer.',
+  },
+  {
+    pathname: '/documentation/start-here/connect-notion',
+    title: 'Connect Notion in 5 minutes — 2anki docs',
+    description:
+      'From signing in to your first deck downloaded: connect your Notion account once, pick a page, and 2anki builds the Anki deck. No exports, no zip files.',
+  },
+  {
+    pathname: '/documentation/cards/notion-to-anki-japanese',
+    title: 'Notion to Anki for Japanese — 2anki docs',
+    description:
+      'Structure mined sentences and vocab in Notion, keep audio and screenshots, choose a note type, and open the deck in Anki. For sentence miners and JLPT studiers.',
   },
 ];
 

--- a/web/scripts/sitemapPrerenderParity.test.ts
+++ b/web/scripts/sitemapPrerenderParity.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import {
+  emitAnswersPages,
+  emitConvertHubPage,
+  emitLandingPages,
+  emitMetaOnlyPages,
+  emitNotionMarketplacePage,
+} from './prerenderLandingPages';
+
+const SOURCE_INDEX = `<!DOCTYPE html>
+<html>
+<head>
+  <link rel="canonical" href="https://2anki.net" />
+  <title>Create Anki Flashcards - 2anki.net</title>
+  <meta name="description" content="Original description">
+</head>
+<body><div id="root"></div></body>
+</html>`;
+
+function emitEverything(): string {
+  const buildDir = mkdtempSync(join(tmpdir(), 'parity-'));
+  mkdirSync(buildDir, { recursive: true });
+  writeFileSync(join(buildDir, 'index.html'), SOURCE_INDEX);
+  emitLandingPages(buildDir);
+  emitNotionMarketplacePage(buildDir);
+  emitConvertHubPage(buildDir);
+  emitAnswersPages(buildDir);
+  emitMetaOnlyPages(buildDir);
+  return buildDir;
+}
+
+function sitemapPaths(): string[] {
+  const xml = readFileSync(join(__dirname, '../public/sitemap.xml'), 'utf8');
+  return [...xml.matchAll(/<loc>https:\/\/2anki\.net([^<]*)<\/loc>/g)].map(
+    (m) => m[1]
+  );
+}
+
+describe('sitemap ↔ prerender parity', () => {
+  it('every sitemap URL is prerendered with its own head (no homepage-shell orphans)', () => {
+    const buildDir = emitEverything();
+    const missing: string[] = [];
+    for (const path of sitemapPaths()) {
+      if (path === '/') continue;
+      const slug = path.replace(/^\//, '').replace(/\/$/, '');
+      try {
+        readFileSync(join(buildDir, slug, 'index.html'), 'utf8');
+      } catch {
+        missing.push(path);
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+
+  it('every prerendered sitemap page carries a unique title and a self-referencing canonical', () => {
+    const buildDir = emitEverything();
+    const titles = new Map<string, string>();
+    for (const path of sitemapPaths()) {
+      if (path === '/') continue;
+      const slug = path.replace(/^\//, '').replace(/\/$/, '');
+      const html = readFileSync(join(buildDir, slug, 'index.html'), 'utf8');
+      const title = /<title>([\s\S]*?)<\/title>/.exec(html)?.[1] ?? '';
+      const canonical =
+        /<link rel="canonical" href="([^"]*)">/.exec(html)?.[1] ?? '';
+      expect(title, `title missing for ${path}`).not.toBe('');
+      expect(
+        title,
+        `duplicate title between ${titles.get(title)} and ${path}`
+      ).not.toBe('Create Anki Flashcards - 2anki.net');
+      if (titles.has(title)) {
+        expect.fail(
+          `duplicate title "${title}" on ${titles.get(title)} and ${path}`
+        );
+      }
+      titles.set(title, path);
+      const expected = `https://2anki.net${path}`;
+      const crossCanonicalized = canonical !== expected;
+      if (crossCanonicalized) {
+        expect(
+          canonical.startsWith('https://2anki.net/'),
+          `canonical for ${path} points off-site: ${canonical}`
+        ).toBe(true);
+        expect(
+          canonical,
+          `canonical for ${path} falls back to the homepage`
+        ).not.toBe('https://2anki.net');
+        expect(
+          canonical,
+          `canonical for ${path} falls back to the homepage`
+        ).not.toBe('https://2anki.net/');
+      }
+    }
+  });
+
+  it('sitemap URLs all use the trailing-slash form the server serves without a redirect hop', () => {
+    for (const path of sitemapPaths()) {
+      expect(path.endsWith('/'), `${path} misses its trailing slash`).toBe(
+        true
+      );
+    }
+  });
+});

--- a/web/src/lib/seo/canonicalUrl.test.ts
+++ b/web/src/lib/seo/canonicalUrl.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { canonicalUrl } from './canonicalUrl';
+
+describe('canonicalUrl', () => {
+  it('appends a trailing slash so hydration matches the prerendered head', () => {
+    expect(canonicalUrl('/notion-to-anki')).toBe(
+      'https://2anki.net/notion-to-anki/'
+    );
+  });
+
+  it('leaves an existing trailing slash alone', () => {
+    expect(canonicalUrl('/convert/')).toBe('https://2anki.net/convert/');
+  });
+
+  it('canonicalizes the root to the bare origin with a slash', () => {
+    expect(canonicalUrl('/')).toBe('https://2anki.net/');
+  });
+});

--- a/web/src/lib/seo/canonicalUrl.ts
+++ b/web/src/lib/seo/canonicalUrl.ts
@@ -1,0 +1,4 @@
+export function canonicalUrl(pathname: string): string {
+  const withTrailingSlash = pathname.endsWith('/') ? pathname : `${pathname}/`;
+  return `https://2anki.net${withTrailingSlash}`;
+}

--- a/web/src/pages/AnswersPage/AnswersPage.tsx
+++ b/web/src/pages/AnswersPage/AnswersPage.tsx
@@ -2,6 +2,7 @@ import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import NotFoundPage from '../NotFoundPage';
+import { canonicalUrl } from '../../lib/seo/canonicalUrl';
 import { AnswerFigure } from './AnswerFigures';
 import { ANSWERS_PAGES } from './answersConfig';
 import styles from './AnswersPage.module.css';
@@ -18,7 +19,7 @@ function AnswersPage() {
     return <NotFoundPage />;
   }
 
-  const canonical = `https://2anki.net/answers/${config.slug}`;
+  const canonical = canonicalUrl(`/answers/${config.slug}`);
 
   const articleJsonLd = buildArticleJsonLd(config);
   const faqJsonLd = buildFaqJsonLd(config);

--- a/web/src/pages/ConvertHubPage/ConvertHubPage.tsx
+++ b/web/src/pages/ConvertHubPage/ConvertHubPage.tsx
@@ -2,6 +2,7 @@ import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import styles from './ConvertHubPage.module.css';
 import { CONVERT_HUB_GROUPS } from './convertHubGroups';
+import { canonicalUrl } from '../../lib/seo/canonicalUrl';
 
 function groupKey(heading: string): string {
   return heading.toLowerCase().replace(/\s+/g, '-');
@@ -16,7 +17,7 @@ const SUBHEAD =
 
 function ConvertHubPage() {
   const { t } = useTranslation('landing');
-  const canonical = 'https://2anki.net/convert';
+  const canonical = canonicalUrl('/convert');
 
   return (
     <div className={styles.page}>

--- a/web/src/pages/LandingPage/LandingPage.test.tsx
+++ b/web/src/pages/LandingPage/LandingPage.test.tsx
@@ -177,11 +177,11 @@ describe('LandingPage', () => {
   });
 
   it.each([
-    [notionCopy, 'https://2anki.net/notion-to-anki'],
-    [pdfCopy, 'https://2anki.net/pdf-to-anki'],
-    [markdownCopy, 'https://2anki.net/markdown-to-anki'],
+    [notionCopy, 'https://2anki.net/notion-to-anki/'],
+    [pdfCopy, 'https://2anki.net/pdf-to-anki/'],
+    [markdownCopy, 'https://2anki.net/markdown-to-anki/'],
   ])(
-    'self-references the bare-path canonical for %s',
+    'self-references the trailing-slash canonical the prerender emits for %s',
     async (copy, expectedCanonical) => {
       renderLandingPage(<LandingPage copy={copy} setErrorMessage={vi.fn()} />);
       await waitFor(() => {
@@ -192,9 +192,9 @@ describe('LandingPage', () => {
   );
 
   it.each([
-    ['notion-to-anki', 'https://2anki.net/notion-to-anki'],
-    ['pdf-to-anki', 'https://2anki.net/pdf-to-anki'],
-    ['markdown-to-anki', 'https://2anki.net/markdown-to-anki'],
+    ['notion-to-anki', 'https://2anki.net/notion-to-anki/'],
+    ['pdf-to-anki', 'https://2anki.net/pdf-to-anki/'],
+    ['markdown-to-anki', 'https://2anki.net/markdown-to-anki/'],
   ])(
     'points the /convert/%s canonical at the top-level slug',
     async (slug, expectedCanonical) => {
@@ -207,7 +207,7 @@ describe('LandingPage', () => {
       const ogUrl = document.head.querySelector('meta[property="og:url"]');
       expect(ogUrl).toHaveAttribute(
         'content',
-        `https://2anki.net/convert/${slug}`
+        `https://2anki.net/convert/${slug}/`
       );
     }
   );

--- a/web/src/pages/LandingPage/LandingPage.tsx
+++ b/web/src/pages/LandingPage/LandingPage.tsx
@@ -5,6 +5,7 @@ import type { TFunction } from 'i18next';
 import UploadForm from '../UploadPage/components/UploadForm/UploadForm';
 import { ErrorHandlerType } from '../../components/errors/helpers/getErrorMessage';
 import { persistSignupOrigin } from '../../lib/signupOrigin';
+import { canonicalUrl } from '../../lib/seo/canonicalUrl';
 import styles from './LandingPage.module.css';
 import sharedStyles from '../../styles/shared.module.css';
 import type { LandingCopy } from './types';
@@ -107,8 +108,8 @@ function LandingPage({
     persistSignupOrigin(copy.pathname, globalThis.sessionStorage ?? null);
   }, [copy.pathname]);
 
-  const pageUrl = `https://2anki.net${copy.pathname}`;
-  const canonical = `https://2anki.net${copy.canonicalPathname ?? copy.pathname}`;
+  const pageUrl = canonicalUrl(copy.pathname);
+  const canonical = canonicalUrl(copy.canonicalPathname ?? copy.pathname);
   const registerHref = `/register?source=${encodeURIComponent(copy.pathname)}`;
   const pageKey = pageKeyFromPathname(copy.pathname);
 

--- a/web/src/pages/NotionLandingPage/NotionLandingPage.tsx
+++ b/web/src/pages/NotionLandingPage/NotionLandingPage.tsx
@@ -2,11 +2,12 @@ import { useEffect } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { track } from '../../lib/analytics/track';
+import { canonicalUrl } from '../../lib/seo/canonicalUrl';
 import { PricingCard } from '../PricingPage/components/PricingCard';
 import styles from './NotionLandingPage.module.css';
 
 const REF = 'notion-marketplace';
-const CANONICAL = 'https://2anki.net/notion-marketplace';
+const CANONICAL = canonicalUrl('/notion-marketplace');
 
 const CONNECT_HREF = `/register?source=${REF}&ref=${REF}`;
 const UNLIMITED_HREF = `/pricing?ref=${REF}`;

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import {
   emitAnswersPages,
+  emitConvertHubPage,
   emitLandingPages,
   emitMetaOnlyPages,
   emitNotionMarketplacePage,
@@ -44,6 +45,7 @@ function landingPrerender(): Plugin {
       const buildDir = path.resolve(__dirname, 'build');
       emitLandingPages(buildDir);
       emitNotionMarketplacePage(buildDir);
+      emitConvertHubPage(buildDir);
       emitAnswersPages(buildDir);
       emitMetaOnlyPages(buildDir);
     },


### PR DESCRIPTION
## What

Four indexability fixes from the 2026-08-18 site audit, locked by a new parity test:

1. **One canonical per page.** Hydration was injecting a slash-less canonical (which 301s) next to the prerendered trailing-slash one on ~55 pages — two conflicting canonicals after React hoisting. A shared `canonicalUrl` helper now feeds both the prerender script and all four hydrating pages (`LandingPage`, `AnswersPage`, `ConvertHubPage`, `NotionLandingPage`).
2. **Sitemap orphans prerendered.** `/convert/` (its emitter existed but was never wired into the vite build), `/security`, `/contact`, and both `/documentation/*` sitemap pages served the homepage shell with the homepage title and `canonical → homepage` — Search Console counts them as duplicates. All five now get real titles/descriptions/self-canonicals.
3. **Sitemap hygiene.** Every URL in the trailing-slash form the server serves without a redirect hop (`/app` was submitting a 301), `changefreq`/`priority` noise dropped, touched entries' `lastmod` bumped.
4. **Guard test** (`sitemapPrerenderParity.test.ts`): every sitemap URL must be prerendered with a unique, non-homepage title and a non-homepage canonical — the orphan class can't ship again.

The two LandingPage tests asserting the "bare-path canonical" encoded the bug; they now assert the trailing-slash contract (same coverage, corrected expectation).

## Testing

Full web suite 3330/3330 (includes the new parity + canonical tests), typecheck, lint, `pnpm format:check` all green.

No changelog entry — crawler-facing metadata only.

Browser check: not applicable — head/meta and sitemap changes with no runtime-visible UI; verified by the parity test emitting all 64 pages and asserting their heads.

Sonar: not run locally; PR decoration will report.

## Goal alignment

Scale/acquisition: recovers 5 pages Google currently refuses to index as themselves and removes canonical ambiguity on ~55 more. Metric: Search Console "Duplicate, submitted URL not selected as canonical" → zero over the next crawl cycles.