### PR TITLE
fix: offer the real Day Pass, not a trial that does not exist

### DIFF
--- a/web/src/lib/i18n/locales/de/landing.json
+++ b/web/src/lib/i18n/locales/de/landing.json
@@ -24,7 +24,7 @@
     "freeQuota": "Kostenlos · bis zu 1 000 Karten pro Import",
     "orPrefix": "oder ",
     "signUpFree": "kostenlos registrieren",
-    "tryUnlimited": "Unlimited 1 Stunde kostenlos testen"
+    "getDayPass": "hol dir einen Day Pass für $4"
   },
   "footer": {
     "readyPrefix": "Bereit zum Ausprobieren? ",

--- a/web/src/lib/i18n/locales/en/landing.json
+++ b/web/src/lib/i18n/locales/en/landing.json
@@ -24,7 +24,7 @@
     "freeQuota": "Free · up to 1 000 cards per import",
     "orPrefix": "or ",
     "signUpFree": "sign up free",
-    "tryUnlimited": "try Unlimited free for 1 hour"
+    "getDayPass": "get a Day Pass for $4"
   },
   "footer": {
     "readyPrefix": "Ready to try it? ",

--- a/web/src/lib/i18n/locales/es/landing.json
+++ b/web/src/lib/i18n/locales/es/landing.json
@@ -24,7 +24,7 @@
     "freeQuota": "Gratis · hasta 1 000 tarjetas por importación",
     "orPrefix": "o ",
     "signUpFree": "regístrate gratis",
-    "tryUnlimited": "prueba Unlimited gratis durante 1 hora"
+    "getDayPass": "consigue un Day Pass por $4"
   },
   "footer": {
     "readyPrefix": "¿Listo para probarlo? ",

--- a/web/src/lib/i18n/locales/fr/landing.json
+++ b/web/src/lib/i18n/locales/fr/landing.json
@@ -24,7 +24,7 @@
     "freeQuota": "Gratuit · jusqu'à 1 000 cartes par import",
     "orPrefix": "ou ",
     "signUpFree": "inscris-toi gratuitement",
-    "tryUnlimited": "essaie Unlimited gratuitement pendant 1 heure"
+    "getDayPass": "prends un Day Pass à $4"
   },
   "footer": {
     "readyPrefix": "Prêt à essayer ? ",

--- a/web/src/lib/i18n/locales/it/landing.json
+++ b/web/src/lib/i18n/locales/it/landing.json
@@ -24,7 +24,7 @@
     "freeQuota": "Gratis · fino a 1 000 carte per importazione",
     "orPrefix": "oppure ",
     "signUpFree": "registrati gratis",
-    "tryUnlimited": "prova Unlimited gratis per 1 ora"
+    "getDayPass": "prendi un Day Pass a $4"
   },
   "footer": {
     "readyPrefix": "Pronto a provarlo? ",

--- a/web/src/lib/i18n/locales/ja/landing.json
+++ b/web/src/lib/i18n/locales/ja/landing.json
@@ -24,7 +24,7 @@
     "freeQuota": "無料 · 1 回のインポートで最大 1 000 枚",
     "orPrefix": "または ",
     "signUpFree": "無料で登録",
-    "tryUnlimited": "Unlimited を 1 時間無料で試す"
+    "getDayPass": "$4 の Day Pass を購入"
   },
   "footer": {
     "readyPrefix": "試してみますか？ ",

--- a/web/src/lib/i18n/locales/nl/landing.json
+++ b/web/src/lib/i18n/locales/nl/landing.json
@@ -24,7 +24,7 @@
     "freeQuota": "Gratis · tot 1 000 kaarten per import",
     "orPrefix": "of ",
     "signUpFree": "meld je gratis aan",
-    "tryUnlimited": "probeer Unlimited 1 uur gratis"
+    "getDayPass": "koop een Day Pass voor $4"
   },
   "footer": {
     "readyPrefix": "Klaar om het te proberen? ",

--- a/web/src/lib/i18n/locales/pl/landing.json
+++ b/web/src/lib/i18n/locales/pl/landing.json
@@ -24,7 +24,7 @@
     "freeQuota": "Za darmo · do 1 000 kart na import",
     "orPrefix": "albo ",
     "signUpFree": "zarejestruj się za darmo",
-    "tryUnlimited": "wypróbuj Unlimited za darmo przez 1 godzinę"
+    "getDayPass": "kup Day Pass za $4"
   },
   "footer": {
     "readyPrefix": "Gotowy, aby spróbować? ",

--- a/web/src/lib/i18n/locales/pt/landing.json
+++ b/web/src/lib/i18n/locales/pt/landing.json
@@ -24,7 +24,7 @@
     "freeQuota": "Grátis · até 1 000 cartões por importação",
     "orPrefix": "ou ",
     "signUpFree": "cadastre-se grátis",
-    "tryUnlimited": "teste o Unlimited grátis por 1 hora"
+    "getDayPass": "pegue um Day Pass por $4"
   },
   "footer": {
     "readyPrefix": "Pronto para testar? ",

--- a/web/src/lib/i18n/locales/ru/landing.json
+++ b/web/src/lib/i18n/locales/ru/landing.json
@@ -24,7 +24,7 @@
     "freeQuota": "Бесплатно · до 1 000 карт за один импорт",
     "orPrefix": "или ",
     "signUpFree": "зарегистрируйся бесплатно",
-    "tryUnlimited": "попробуй Unlimited бесплатно на 1 час"
+    "getDayPass": "купи Day Pass за $4"
   },
   "footer": {
     "readyPrefix": "Готов попробовать? ",

--- a/web/src/pages/LandingPage/LandingPage.tsx
+++ b/web/src/pages/LandingPage/LandingPage.tsx
@@ -88,8 +88,8 @@ function renderHeroAction({
         </a>
         {' — '}
         <a href="/pricing">
-          {t('hero.tryUnlimited', {
-            defaultValue: 'try Unlimited free for 1 hour',
+          {t('hero.getDayPass', {
+            defaultValue: 'get a Day Pass for $4',
           })}
         </a>
       </p>

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-18-day-pass-link.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-18-day-pass-link.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-18-day-pass-link",
+  "date": "2026-08-18",
+  "type": "fix",
+  "title": "Landing pages now offer the $4 Day Pass instead of a trial that no longer exists"
+}


### PR DESCRIPTION
## What

The landing-page hero link "try Unlimited free for 1 hour" → **"get a Day Pass for $4"** (still pointing at /pricing). Key renamed `hero.tryUnlimited` → `hero.getDayPass`, updated in all 10 locales.

## Why

Site-audit SXO finding (High): two landing pages promised a free hour; /pricing shows "$7.99 billed today" and no trial exists anywhere in the product. A user who clicks the promise and meets a charge is churn-with-resentment. Designer decision: name the true low-commitment offer (the $4 Day Pass is real and listed on /pricing), keep the paid nudge.

## Decisions

- Copy: "get a Day Pass for $4" (designer's call — VOICE 'specific over generic'). Swap if you'd word it differently.
- "Day Pass" and "$4" stay literal in all locales; only the verb is translated. **Native-speaker pass flagged** for the 9 non-English strings.
- Deliberately did NOT build an hour trial — copy now matches the product instead.

## Testing

i18n parity + LandingPage suites 630/630, web typecheck, `pnpm format:check` green. Changelog entry included.

Browser check: not applicable — one-line text swap in an existing link, no layout or interaction change; covered by the LandingPage render tests.

Sonar: not run locally; PR decoration will report.

## Goal alignment

Trust at the decision moment; funnel metric: landing→pricing clickthrough keeps its intent honest (watch pricing_page→checkout conversion for drift after deploy).