### PR TITLE
feat: add Organization schema, retarget marketplace title to sync

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -144,6 +144,20 @@
     }
   }
   </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "2anki",
+    "url": "https://2anki.net",
+    "logo": "https://2anki.net/android-chrome-512x512.png",
+    "sameAs": [
+      "https://github.com/2anki/server",
+      "https://apps.apple.com/app/id6775249373",
+      "https://www.notion.com/connections/2anki"
+    ]
+  }
+  </script>
   <!-- Hotjar Tracking Code for https://2anki.net (deferred until after load) -->
   <script>
     globalThis.addEventListener('load', function () {

--- a/web/scripts/prerenderLandingPages.test.ts
+++ b/web/scripts/prerenderLandingPages.test.ts
@@ -300,7 +300,7 @@ describe('emitNotionMarketplacePage', () => {
       'utf8'
     );
     expect(html).toContain(
-      '<title>Notion to Anki — automatic sync | 2anki</title>'
+      '<title>Sync Notion to Anki automatically | 2anki</title>'
     );
     expect(html).toContain(
       '<link rel="canonical" href="https://2anki.net/notion-marketplace/">'

--- a/web/scripts/prerenderLandingPages.ts
+++ b/web/scripts/prerenderLandingPages.ts
@@ -133,7 +133,7 @@ function rewriteRoot(html: string, copy: LandingCopy): string {
 
 const NOTION_MARKETPLACE_META = {
   pathname: '/notion-marketplace',
-  title: 'Notion to Anki — automatic sync | 2anki',
+  title: 'Sync Notion to Anki automatically | 2anki',
   description:
     'Connect your Notion workspace and your notes become Anki flashcards automatically. No exports, no zips. Included with Unlimited at $7.99/mo.',
   h1: 'Your Notion notes become Anki cards — automatically',

--- a/web/src/lib/i18n/locales/de/marketing.json
+++ b/web/src/lib/i18n/locales/de/marketing.json
@@ -145,7 +145,7 @@
     "ipadShot3Alt": "2anki auf dem iPad — KI-Chat-Eingabevorschläge"
   },
   "notionLanding": {
-    "metaTitle": "Notion zu Anki — verwandle deine Seiten in Karteikarten | 2anki",
+    "metaTitle": "Notion automatisch mit Anki synchronisieren | 2anki",
     "metaDescription": "Verwandle deine Notion-Seiten in Anki-Karteikarten. Unbegrenzte Karten im Monatstarif oder einmal zahlen mit einem Day Pass. Keine Exporte, keine Zips.",
     "heroHeadline": "Deine Notion-Notizen werden zu Anki-Karten",
     "heroSubhead": "Verbinde deinen Workspace in 5 Minuten. Keine Exporte, keine Zips, keine manuellen Schritte.",

--- a/web/src/lib/i18n/locales/en/marketing.json
+++ b/web/src/lib/i18n/locales/en/marketing.json
@@ -145,7 +145,7 @@
     "ipadShot3Alt": "2anki on iPad — AI chat prompt starters"
   },
   "notionLanding": {
-    "metaTitle": "Notion to Anki — turn your pages into flashcards | 2anki",
+    "metaTitle": "Sync Notion to Anki automatically | 2anki",
     "metaDescription": "Turn your Notion pages into Anki flashcards. Unlimited cards on a monthly plan, or pay once with a Day Pass. No exports, no zips.",
     "heroHeadline": "Your Notion notes become Anki cards",
     "heroSubhead": "Connect your workspace in 5 minutes. No exports, no zips, no manual steps.",

--- a/web/src/lib/i18n/locales/es/marketing.json
+++ b/web/src/lib/i18n/locales/es/marketing.json
@@ -145,7 +145,7 @@
     "ipadShot3Alt": "2anki en iPad — sugerencias para empezar en el chat de IA"
   },
   "notionLanding": {
-    "metaTitle": "Notion a Anki — convierte tus páginas en tarjetas | 2anki",
+    "metaTitle": "Sincroniza Notion con Anki automáticamente | 2anki",
     "metaDescription": "Convierte tus páginas de Notion en tarjetas de Anki. Tarjetas ilimitadas con un plan mensual, o paga una sola vez con un Day Pass. Sin exportaciones ni zips.",
     "heroHeadline": "Tus notas de Notion se convierten en tarjetas de Anki",
     "heroSubhead": "Conecta tu espacio en 5 minutos. Sin exportaciones, sin zips, sin pasos manuales.",

--- a/web/src/lib/i18n/locales/fr/marketing.json
+++ b/web/src/lib/i18n/locales/fr/marketing.json
@@ -145,7 +145,7 @@
     "ipadShot3Alt": "2anki sur iPad — suggestions de démarrage du chat IA"
   },
   "notionLanding": {
-    "metaTitle": "Notion vers Anki — transforme tes pages en cartes | 2anki",
+    "metaTitle": "Synchronise Notion avec Anki automatiquement | 2anki",
     "metaDescription": "Transforme tes pages Notion en cartes Anki. Cartes illimitées avec une offre mensuelle, ou paie une seule fois avec un Day Pass. Sans exports, sans zips.",
     "heroHeadline": "Tes notes Notion deviennent des cartes Anki",
     "heroSubhead": "Connecte ton espace de travail en 5 minutes. Sans exports, sans zips, sans étapes manuelles.",

--- a/web/src/lib/i18n/locales/it/marketing.json
+++ b/web/src/lib/i18n/locales/it/marketing.json
@@ -145,7 +145,7 @@
     "ipadShot3Alt": "2anki su iPad — spunti iniziali della chat AI"
   },
   "notionLanding": {
-    "metaTitle": "Da Notion ad Anki — trasforma le tue pagine in flashcard | 2anki",
+    "metaTitle": "Sincronizza Notion con Anki automaticamente | 2anki",
     "metaDescription": "Trasforma le tue pagine di Notion in flashcard Anki. Carte illimitate con un piano mensile, oppure paga una volta con un Day Pass. Niente export, niente zip.",
     "heroHeadline": "I tuoi appunti di Notion diventano carte Anki",
     "heroSubhead": "Connetti il tuo workspace in 5 minuti. Niente export, niente zip, nessun passaggio manuale.",

--- a/web/src/lib/i18n/locales/ja/marketing.json
+++ b/web/src/lib/i18n/locales/ja/marketing.json
@@ -142,7 +142,7 @@
     "ipadShot3Alt": "iPad 版 2anki — AI チャットのプロンプトのきっかけ"
   },
   "notionLanding": {
-    "metaTitle": "Notion から Anki へ — ページをフラッシュカードに変える | 2anki",
+    "metaTitle": "Notion を Anki に自動同期 | 2anki",
     "metaDescription": "Notion ページを Anki フラッシュカードに変える。月額プランで無制限のカード、または Day Pass で一度だけのお支払い。エクスポートも zip も不要。",
     "heroHeadline": "あなたの Notion のノートが Anki カードになる",
     "heroSubhead": "ワークスペースを 5 分で接続。エクスポートも zip も手作業も不要。",

--- a/web/src/lib/i18n/locales/nl/marketing.json
+++ b/web/src/lib/i18n/locales/nl/marketing.json
@@ -145,7 +145,7 @@
     "ipadShot3Alt": "2anki op iPad — AI-chat promptstarters"
   },
   "notionLanding": {
-    "metaTitle": "Notion naar Anki — zet je pagina's om in flashcards | 2anki",
+    "metaTitle": "Synchroniseer Notion automatisch met Anki | 2anki",
     "metaDescription": "Zet je Notion-pagina's om in Anki-flashcards. Onbeperkt kaarten met een maandabonnement, of betaal eenmalig met een Day Pass. Geen exports, geen zips.",
     "heroHeadline": "Je Notion-notities worden Anki-kaarten",
     "heroSubhead": "Verbind je workspace in 5 minuten. Geen exports, geen zips, geen handmatige stappen.",

--- a/web/src/lib/i18n/locales/pl/marketing.json
+++ b/web/src/lib/i18n/locales/pl/marketing.json
@@ -151,7 +151,7 @@
     "ipadShot3Alt": "2anki na iPad — podpowiedzi startowe czatu AI"
   },
   "notionLanding": {
-    "metaTitle": "Notion do Anki — zamień strony w fiszki | 2anki",
+    "metaTitle": "Automatyczna synchronizacja Notion z Anki | 2anki",
     "metaDescription": "Zamień strony Notion w fiszki Anki. Nieograniczone karty w planie miesięcznym albo zapłać raz z Day Pass. Bez eksportów, bez plików zip.",
     "heroHeadline": "Twoje notatki z Notion stają się kartami Anki",
     "heroSubhead": "Połącz przestrzeń roboczą w 5 minut. Bez eksportów, bez plików zip, bez ręcznych kroków.",

--- a/web/src/lib/i18n/locales/pt/marketing.json
+++ b/web/src/lib/i18n/locales/pt/marketing.json
@@ -145,7 +145,7 @@
     "ipadShot3Alt": "2anki no iPad — sugestões de prompts para o chat de IA"
   },
   "notionLanding": {
-    "metaTitle": "Notion para Anki — transforme suas páginas em flashcards | 2anki",
+    "metaTitle": "Sincronize o Notion com o Anki automaticamente | 2anki",
     "metaDescription": "Transforme suas páginas do Notion em flashcards do Anki. Cartões ilimitados em um plano mensal, ou pague uma vez com um Day Pass. Sem exportações, sem zips.",
     "heroHeadline": "Suas anotações do Notion viram cartões do Anki",
     "heroSubhead": "Conecte seu workspace em 5 minutos. Sem exportações, sem zips, sem passos manuais.",

--- a/web/src/lib/i18n/locales/ru/marketing.json
+++ b/web/src/lib/i18n/locales/ru/marketing.json
@@ -151,7 +151,7 @@
     "ipadShot3Alt": "2anki на iPad — подсказки для начала ИИ-чата"
   },
   "notionLanding": {
-    "metaTitle": "Notion в Anki — преврати свои страницы в карточки | 2anki",
+    "metaTitle": "Автоматическая синхронизация Notion с Anki | 2anki",
     "metaDescription": "Превращай свои страницы Notion в карточки Anki. Безлимит карт на месячном плане или плати разово с Day Pass. Без экспортов, без zip.",
     "heroHeadline": "Твои заметки Notion становятся картами Anki",
     "heroSubhead": "Подключи рабочее пространство за 5 минут. Без экспортов, без zip, без ручных шагов.",


### PR DESCRIPTION
## What

1. **Organization JSON-LD** on the homepage: name, url, logo, and `sameAs` pointing at the real profiles (GitHub repo, App Store record id6775249373, Notion Integration Gallery). Feeds knowledge panels and AI-engine entity resolution — the audit found no Organization entity anywhere.
2. **Marketplace title retarget**: `/notion-marketplace` led with the same "Notion to Anki" head term as `/notion-to-anki` — two of our own pages competing in one SERP. It now targets the distinct sync intent: **"Sync Notion to Anki automatically | 2anki"**, applied to the prerendered head and all 10 locale `metaTitle`s (native-speaker pass flagged for the 9 translations).

## Testing

NotionLandingPage + prerender + pricing-schema suites green (the one prerender test asserting the old title updated to the new contract), JSON-LD in index.html validated as parseable, `pnpm format:check` clean.

No changelog entry — crawler-facing metadata only.

Browser check: not applicable — head metadata and JSON-LD only, no rendered UI change.

Sonar: not run locally; PR decoration will report.

## Goal alignment

Scale/acquisition: stops self-cannibalization on the head term and gives AI engines a resolvable entity. Metric: distinct SERP rankings for "convert notion to anki" (converter page) vs "sync notion to anki" (marketplace page) in Search Console.