### PR TITLE
feat: surface pricing in the nav and exam pages from the homepage

### DIFF
--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -18,6 +18,7 @@ function Footer() {
           <a href="/about">{t('common:nav.about')}</a>
           <a href="/app">{t('footer.iosApp')}</a>
           <a href="/documentation">{t('common:nav.docs')}</a>
+          <a href="/pricing">{t('common:nav.pricing')}</a>
           <a href="/contact">{t('common:nav.contact')}</a>
         </div>
         <div className={styles.group}>

--- a/web/src/components/NavigationBar/components/RightSide.test.tsx
+++ b/web/src/components/NavigationBar/components/RightSide.test.tsx
@@ -27,11 +27,16 @@ describe('RightSide (anonymous nav)', () => {
     expect(docsIdx).toBeGreaterThan(uploadIdx);
   });
 
-  it('omits the Pricing link for logged-out visitors', () => {
+  it('shows the Pricing link to logged-out visitors, before Download', () => {
     render(<RightSide path="/" isLoggedIn={false} />);
-    expect(
-      screen.queryByRole('link', { name: 'Pricing' })
-    ).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Pricing' })).toHaveAttribute(
+      'href',
+      '/pricing'
+    );
+    const positions = getNavLinks().map((a) => a.textContent);
+    expect(positions.indexOf('Pricing')).toBeLessThan(
+      positions.indexOf('Download')
+    );
   });
 
   it('keeps the Pricing link for logged-in visitors', () => {

--- a/web/src/components/NavigationBar/components/RightSide.tsx
+++ b/web/src/components/NavigationBar/components/RightSide.tsx
@@ -22,11 +22,9 @@ export function RightSide({ path, isLoggedIn }: Readonly<RightSideProps>) {
       <NavbarItem href="/documentation" path={path}>
         {t('nav.docs')}
       </NavbarItem>
-      {isLoggedIn && (
-        <NavbarItem href="/pricing" path={path}>
-          {t('nav.pricing')}
-        </NavbarItem>
-      )}
+      <NavbarItem href="/pricing" path={path}>
+        {t('nav.pricing')}
+      </NavbarItem>
       {!isLoggedIn && (
         <NavbarItem href="/app" path={path}>
           {t('nav.download')}

--- a/web/src/lib/i18n/locales/de/common.json
+++ b/web/src/lib/i18n/locales/de/common.json
@@ -104,6 +104,11 @@
       "showAll_one": "▾ {{count}} Video anzeigen",
       "showAll_other": "▾ Alle {{count}} Videos anzeigen",
       "playVideo": "Abspielen: {{title}}"
+    },
+    "studyLinks": {
+      "heading": "Für dein Studium gemacht",
+      "nursingSchool": "Pflegeausbildung",
+      "japanese": "Japanisch"
     }
   },
   "upload": {

--- a/web/src/lib/i18n/locales/en/common.json
+++ b/web/src/lib/i18n/locales/en/common.json
@@ -104,6 +104,11 @@
       "showAll_one": "▾ Show {{count}} video",
       "showAll_other": "▾ Show all {{count}} videos",
       "playVideo": "Play: {{title}}"
+    },
+    "studyLinks": {
+      "heading": "Made for what you study",
+      "nursingSchool": "Nursing school",
+      "japanese": "Japanese"
     }
   },
   "upload": {

--- a/web/src/lib/i18n/locales/es/common.json
+++ b/web/src/lib/i18n/locales/es/common.json
@@ -104,6 +104,11 @@
       "showAll_one": "▾ Mostrar {{count}} vídeo",
       "showAll_other": "▾ Mostrar los {{count}} vídeos",
       "playVideo": "Reproducir: {{title}}"
+    },
+    "studyLinks": {
+      "heading": "Hecho para lo que estudias",
+      "nursingSchool": "Enfermería",
+      "japanese": "Japonés"
     }
   },
   "upload": {

--- a/web/src/lib/i18n/locales/fr/common.json
+++ b/web/src/lib/i18n/locales/fr/common.json
@@ -104,6 +104,11 @@
       "showAll_one": "▾ Afficher {{count}} vidéo",
       "showAll_other": "▾ Afficher les {{count}} vidéos",
       "playVideo": "Lire : {{title}}"
+    },
+    "studyLinks": {
+      "heading": "Fait pour ce que tu étudies",
+      "nursingSchool": "Soins infirmiers",
+      "japanese": "Japonais"
     }
   },
   "upload": {

--- a/web/src/lib/i18n/locales/it/common.json
+++ b/web/src/lib/i18n/locales/it/common.json
@@ -104,6 +104,11 @@
       "showAll_one": "▾ Mostra {{count}} video",
       "showAll_other": "▾ Mostra tutti i {{count}} video",
       "playVideo": "Riproduci: {{title}}"
+    },
+    "studyLinks": {
+      "heading": "Fatto per ciò che studi",
+      "nursingSchool": "Infermieristica",
+      "japanese": "Giapponese"
     }
   },
   "upload": {

--- a/web/src/lib/i18n/locales/ja/common.json
+++ b/web/src/lib/i18n/locales/ja/common.json
@@ -103,6 +103,11 @@
       "showFewer": "▴ 表示を減らす",
       "showAll_other": "▾ {{count}} 本の動画をすべて表示",
       "playVideo": "再生: {{title}}"
+    },
+    "studyLinks": {
+      "heading": "学ぶ内容に合わせて",
+      "nursingSchool": "看護学校",
+      "japanese": "日本語学習"
     }
   },
   "upload": {

--- a/web/src/lib/i18n/locales/nl/common.json
+++ b/web/src/lib/i18n/locales/nl/common.json
@@ -104,6 +104,11 @@
       "showAll_one": "▾ {{count}} video tonen",
       "showAll_other": "▾ Alle {{count}} video's tonen",
       "playVideo": "Afspelen: {{title}}"
+    },
+    "studyLinks": {
+      "heading": "Gemaakt voor wat jij studeert",
+      "nursingSchool": "Verpleegkunde",
+      "japanese": "Japans"
     }
   },
   "upload": {

--- a/web/src/lib/i18n/locales/pl/common.json
+++ b/web/src/lib/i18n/locales/pl/common.json
@@ -106,6 +106,11 @@
       "showAll_many": "▾ Pokaż wszystkie {{count}} filmów",
       "showAll_other": "▾ Pokaż wszystkie {{count}} filmu",
       "playVideo": "Odtwórz: {{title}}"
+    },
+    "studyLinks": {
+      "heading": "Stworzone dla tego, czego się uczysz",
+      "nursingSchool": "Pielęgniarstwo",
+      "japanese": "Japoński"
     }
   },
   "upload": {

--- a/web/src/lib/i18n/locales/pt/common.json
+++ b/web/src/lib/i18n/locales/pt/common.json
@@ -104,6 +104,11 @@
       "showAll_one": "▾ Mostrar {{count}} vídeo",
       "showAll_other": "▾ Mostrar todos os {{count}} vídeos",
       "playVideo": "Reproduzir: {{title}}"
+    },
+    "studyLinks": {
+      "heading": "Feito para o que você estuda",
+      "nursingSchool": "Enfermagem",
+      "japanese": "Japonês"
     }
   },
   "upload": {

--- a/web/src/lib/i18n/locales/ru/common.json
+++ b/web/src/lib/i18n/locales/ru/common.json
@@ -106,6 +106,11 @@
       "showAll_many": "▾ Показать все {{count}} видео",
       "showAll_other": "▾ Показать все {{count}} видео",
       "playVideo": "Воспроизвести: {{title}}"
+    },
+    "studyLinks": {
+      "heading": "Для того, что ты учишь",
+      "nursingSchool": "Сестринское дело",
+      "japanese": "Японский"
     }
   },
   "upload": {

--- a/web/src/pages/HomePage/HomePage.module.css
+++ b/web/src/pages/HomePage/HomePage.module.css
@@ -503,3 +503,37 @@
     padding: 8px;
   }
 }
+
+.studyLinks {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 0 1.5rem 2.5rem;
+}
+
+.studyLinksHeading {
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: var(--color-text-tertiary);
+  margin: 0 0 0.75rem;
+}
+
+.studyLinksList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1.25rem;
+}
+
+.studyLink {
+  color: var(--color-text-link);
+  text-decoration: none;
+  font-size: var(--text-base);
+}
+
+.studyLink:hover {
+  text-decoration: underline;
+}

--- a/web/src/pages/HomePage/HomePage.tsx
+++ b/web/src/pages/HomePage/HomePage.tsx
@@ -40,6 +40,15 @@ interface HomePageProps {
   isLoggedIn: boolean;
 }
 
+const STUDY_LINKS = [
+  { href: '/usmle-anki', label: 'USMLE' },
+  { href: '/step1-anki', label: 'Step 1' },
+  { href: '/nclex-anki', label: 'NCLEX' },
+  { href: '/mcat-anki', label: 'MCAT' },
+  { href: '/nursing-flashcards', labelKey: 'home.studyLinks.nursingSchool' },
+  { href: '/anki-for-japanese', labelKey: 'home.studyLinks.japanese' },
+] as const;
+
 const STEPS = [
   {
     title: 'Upload',
@@ -286,6 +295,30 @@ export function HomePage({
           </button>
         </div>
       </section>
+
+      <nav
+        className={styles.studyLinks}
+        aria-label={t('home.studyLinks.heading', {
+          defaultValue: 'Made for what you study',
+        })}
+      >
+        <h2 className={styles.studyLinksHeading}>
+          {t('home.studyLinks.heading', {
+            defaultValue: 'Made for what you study',
+          })}
+        </h2>
+        <ul className={styles.studyLinksList}>
+          {STUDY_LINKS.map((link) => (
+            <li key={link.href}>
+              <a href={link.href} className={styles.studyLink}>
+                {'labelKey' in link
+                  ? t(link.labelKey, { defaultValue: link.href.slice(1) })
+                  : link.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
 
       <TrustNote />
     </div>

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-18-pricing-study-links.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-18-pricing-study-links.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-18-pricing-study-links",
+  "date": "2026-08-18",
+  "type": "feature",
+  "title": "Pricing is one click from anywhere, and the homepage links straight to USMLE, NCLEX, MCAT, nursing, and Japanese pages"
+}


### PR DESCRIPTION
## What

Three homepage→money-page links from the site audit's SXO findings, per designer decisions:

1. **Pricing in the nav for everyone** — it was gated to logged-in users, so logged-out visitors (the only people who can make a first purchase) saw Download instead. Now: Make flashcards · Print Decks · Docs · **Pricing** · Download · Log in.
2. **Pricing in the footer** Product group (persistent fallback).
3. **"Made for what you study" link row** on the homepage (between walkthroughs and the trust note): USMLE · Step 1 · NCLEX · MCAT · Nursing school · Japanese — the six persona landing pages that existed in the sitemap with zero paths from the homepage. Mirrors the landing pages' related-links pattern; a link block, not a new surface.

## Decisions made (designer)

- Heading "Made for what you study" (not "Made for your exam" — the Japanese link isn't an exam). Swap if you'd word it differently.
- Exam acronyms stay literal in all 10 locales; "Nursing school" and "Japanese" translated, **native-speaker pass flagged**.
- Pricing placed before Download in the nav: page→checkout is the tracked funnel step; Download is secondary for web visitors.

## Browser check

- [x] Golden path on localhost:3000
- [x] No console errors at 375px

Golden-path e2e with mock API: 40 passed, 2 skipped. Also verified on a production static build in headless Chrome: Pricing renders in the logged-out nav and footer, all six study links render, section sits between walkthroughs and trust note (screenshot reviewed).

## Testing

NavigationBar/HomePage/i18n suites 639/639 (the RightSide test asserting "omits Pricing for logged-out" encoded the old gating and now asserts the new contract + ordering), web typecheck clean, `pnpm format:check` clean. Changelog entry included.

Sonar: not run locally; PR decoration will report.

## Goal alignment

Acquisition/funnel: gives every visitor a path to the pricing page and un-strands six high-intent SEO pages. Metric: `pricing_page_view` from logged-out sessions and entrances to the exam pages from `/` — read at `/api/ops/metrics` after a week.
