### PR TITLE
feat: prerender full page bodies for crawlers without JS

### DIFF
--- a/web/scripts/prerenderLandingPages.test.ts
+++ b/web/scripts/prerenderLandingPages.test.ts
@@ -128,13 +128,29 @@ describe('emitLandingPages', () => {
     );
   });
 
-  it('does not prerender the client-rendered proof section body', () => {
+  it('prerenders the proof section so crawlers without JS see it', () => {
     emitLandingPages(buildDir);
     const html = readFileSync(
       join(buildDir, 'notion-to-anki', 'index.html'),
       'utf8'
     );
-    expect(html).not.toContain('What you actually get in Anki');
+    expect(html).toContain('What you actually get in Anki');
+  });
+
+  it('prerenders every FAQ question and answer as visible body text', () => {
+    emitLandingPages(buildDir);
+    const html = readFileSync(
+      join(buildDir, 'notion-to-anki', 'index.html'),
+      'utf8'
+    );
+    const body = html.slice(html.indexOf('<div id="root">'));
+    for (const faq of notionCopy.faqs) {
+      expect(body).toContain(
+        faq.q.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#39;')
+      );
+    }
+    expect(body).toContain('How it works');
+    expect(body).toContain('Supported formats');
   });
 
   it('replaces the description with the per-route description', () => {
@@ -277,10 +293,17 @@ describe('emitMetaOnlyPages', () => {
     expect(html).toContain('<meta property="og:title"');
   });
 
-  it('leaves the root div empty so React mounts without a flash', () => {
+  it('prerenders an h1 and intro so crawlers without JS see real content', () => {
     emitMetaOnlyPages(buildDir);
-    const html = readFileSync(join(buildDir, 'upload', 'index.html'), 'utf8');
-    expect(html).toContain('<div id="root"></div>');
+    const upload = readFileSync(join(buildDir, 'upload', 'index.html'), 'utf8');
+    expect(upload).not.toContain('<div id="root"></div>');
+    expect(upload).toContain('Upload notes, get an Anki deck');
+    const pricing = readFileSync(
+      join(buildDir, 'pricing', 'index.html'),
+      'utf8'
+    );
+    expect(pricing).toContain('<h1');
+    expect(pricing).toContain('$7.99/mo or $64/yr');
   });
 
   it('does not duplicate og:* tags from the source index', () => {
@@ -310,6 +333,34 @@ describe('emitNotionMarketplacePage', () => {
 });
 
 describe('emitAnswersPages', () => {
+  it('prerenders the full article body — intro, every section, every FAQ', () => {
+    emitAnswersPages(buildDir);
+    const config = ANSWERS_PAGES.get('convert-notion-to-anki')!;
+    const html = readFileSync(
+      join(buildDir, 'answers', 'convert-notion-to-anki', 'index.html'),
+      'utf8'
+    );
+    const body = html.slice(html.indexOf('<div id="root">'));
+    expect(body).toContain('<article');
+    for (const section of config.sections) {
+      expect(body).toContain(
+        section.heading
+          .replace(/&/g, '&amp;')
+          .replace(/"/g, '&quot;')
+          .replace(/'/g, '&#39;')
+      );
+    }
+    for (const faq of config.faqs ?? []) {
+      expect(body).toContain(
+        faq.q
+          .replace(/&/g, '&amp;')
+          .replace(/"/g, '&quot;')
+          .replace(/'/g, '&#39;')
+      );
+    }
+    expect(body).not.toContain('How it works');
+  });
+
   it('writes one HTML file per answers slug', () => {
     const files = emitAnswersPages(buildDir);
     expect(files).toHaveLength(ANSWERS_PAGES.size);

--- a/web/scripts/prerenderLandingPages.ts
+++ b/web/scripts/prerenderLandingPages.ts
@@ -24,6 +24,10 @@ import {
 import { buildFaqJsonLd as buildLandingFaqJsonLd } from '../src/pages/LandingPage/landingJsonLd';
 import type { LandingCopy } from '../src/pages/LandingPage/types';
 import { canonicalUrl } from '../src/lib/seo/canonicalUrl';
+import {
+  DEFAULT_LANDING_FORMATS,
+  DEFAULT_LANDING_STEPS,
+} from '../src/pages/LandingPage/landingDefaults';
 
 const LANDING_COPIES: LandingCopy[] = [
   notionCopy,
@@ -64,6 +68,89 @@ function buildHeroFragment(copy: LandingCopy): string {
     )}</p>`,
     '</div>',
     '</section>',
+  ].join('');
+}
+
+const SECTION_STYLE = 'max-width:720px;margin:0 auto;padding:2rem 1.5rem 0;';
+const SECTION_LABEL_STYLE =
+  'font-size:var(--text-sm);font-weight:var(--font-semibold);text-transform:uppercase;letter-spacing:0.15em;color:var(--color-text-tertiary);margin:0 0 0.75rem;';
+const BODY_TEXT_STYLE =
+  'color:var(--color-text-secondary);line-height:var(--leading-relaxed);margin:0 0 1rem;';
+
+function sectionFragment(heading: string, inner: string): string {
+  return [
+    `<section style="${SECTION_STYLE}">`,
+    `<h2 style="${SECTION_LABEL_STYLE}">${escapeHtml(heading)}</h2>`,
+    inner,
+    '</section>',
+  ].join('');
+}
+
+function faqFragment(faqs: ReadonlyArray<{ q: string; a: string }>): string {
+  if (faqs.length === 0) return '';
+  const items = faqs
+    .map(
+      (faq) =>
+        `<details><summary style="font-weight:var(--font-semibold);cursor:pointer;">${escapeHtml(
+          faq.q
+        )}</summary><p style="${BODY_TEXT_STYLE}">${escapeHtml(faq.a)}</p></details>`
+    )
+    .join('');
+  return sectionFragment('Common questions', items);
+}
+
+function buildBodyFragment(copy: LandingCopy): string {
+  const steps = (copy.steps ?? DEFAULT_LANDING_STEPS)
+    .map(
+      (step, idx) =>
+        `<div><p style="font-weight:var(--font-semibold);margin:0;">${idx + 1}. ${escapeHtml(
+          step.title
+        )}</p><p style="${BODY_TEXT_STYLE}">${escapeHtml(step.body)}</p></div>`
+    )
+    .join('');
+
+  const formats = (copy.formats ?? DEFAULT_LANDING_FORMATS)
+    .map((format) => `<li style="display:inline-block;margin:0 0.75rem 0.5rem 0;">${escapeHtml(format)}</li>`)
+    .join('');
+
+  const whatComesAcross =
+    copy.whatComesAcross == null || copy.whatComesAcross.length === 0
+      ? ''
+      : sectionFragment(
+          'What you actually get in Anki',
+          copy.whatComesAcross
+            .map(
+              (item) =>
+                `<div><p style="font-weight:var(--font-semibold);margin:0;">${escapeHtml(
+                  item.title
+                )}</p><p style="${BODY_TEXT_STYLE}">${escapeHtml(item.body)}</p></div>`
+            )
+            .join('')
+        );
+
+  const related =
+    copy.relatedLinks == null || copy.relatedLinks.length === 0
+      ? ''
+      : sectionFragment(
+          'Related',
+          `<ul style="list-style:none;padding:0;margin:0;">${copy.relatedLinks
+            .map(
+              (link) =>
+                `<li><a href="${escapeHtml(link.href)}">${escapeHtml(link.label)}</a></li>`
+            )
+            .join('')}</ul>`
+        );
+
+  return [
+    buildHeroFragment(copy),
+    sectionFragment('How it works', steps),
+    sectionFragment(
+      'Supported formats',
+      `<ul style="list-style:none;padding:0;margin:0;">${formats}</ul>`
+    ),
+    whatComesAcross,
+    faqFragment(copy.faqs),
+    related,
   ].join('');
 }
 
@@ -123,8 +210,8 @@ function rewriteHead(html: string, copy: LandingCopy): string {
 }
 
 function rewriteRoot(html: string, copy: LandingCopy): string {
-  const hero = buildHeroFragment(copy);
-  return html.replace(/<div id="root"><\/div>/, `<div id="root">${hero}</div>`);
+  const body = buildBodyFragment(copy);
+  return html.replace(/<div id="root"><\/div>/, `<div id="root">${body}</div>`);
 }
 
 const NOTION_MARKETPLACE_META = {
@@ -243,6 +330,8 @@ export interface MetaOnlyPageMeta {
   pathname: string;
   title: string;
   description: string;
+  h1: string;
+  intro: string;
 }
 
 const META_ONLY_PAGES: MetaOnlyPageMeta[] = [
@@ -251,48 +340,72 @@ const META_ONLY_PAGES: MetaOnlyPageMeta[] = [
     title: 'Upload notes and get an Anki deck — 2anki',
     description:
       'Drop a Notion export, PDF, Markdown, CSV, HTML, or .apkg file. Get an Anki deck back. Free for the first 100 cards a month, no add-on required.',
+    h1: 'Upload notes, get an Anki deck',
+    intro:
+      'Drop a Notion export, PDF, Markdown, CSV, HTML, or .apkg file and 2anki builds a deck you open in Anki. Free for the first 100 cards a month — no add-on, no software to install.',
   },
   {
     pathname: '/pricing',
     title: 'Pricing — Free, Day Pass, Unlimited, Lifetime | 2anki',
     description:
       'Compare 2anki plans. Free converts 100 cards a month. Unlimited at $7.99/mo or $64/yr. Day and Week Passes from $4. Lifetime with Auto Sync included.',
+    h1: 'Pricing',
+    intro:
+      'Free converts 100 cards a month. Unlimited is $7.99/mo or $64/yr. A Day Pass is $4, a Week Pass $9 — one-time payments, no subscription. Lifetime is $345 once, with Auto Sync included. Cancel any subscription in one click.',
   },
   {
     pathname: '/about',
     title: 'About 2anki — open-source Notion to Anki converter',
     description:
       'Why 2anki exists, who builds it, and how the project stays free and open source. Independent, no venture funding, supported by lifetime and subscription users.',
+    h1: 'About 2anki',
+    intro:
+      '2anki turns what you study into Anki flashcards. Independent since 2020, open source, no venture funding — built by Alexander Alemayhu and contributors, funded by the people who use it.',
   },
   {
     pathname: '/app',
     title: 'Anki flashcards on iPhone — 2anki app',
     description:
       'Convert your notes and files into Anki decks on iPhone, iPad, and Mac. Markdown, PDF, Notion, CSV, OPML, Kindle — parsed on your device. On the App Store for iPhone, iPad, and Mac.',
+    h1: '2anki for iPhone, iPad, and Mac',
+    intro:
+      'Convert notes and files into Anki decks on your device. Markdown, PDF, Notion, CSV, OPML, and Kindle highlights — parsed locally, free on the App Store.',
   },
   {
     pathname: '/security',
     title: 'Report a security vulnerability — 2anki',
     description:
       'How to report a security issue in 2anki: what to include, what is in scope, and how fast we respond. Covers 2anki.net, the API, and the open-source repository.',
+    h1: 'Report a security vulnerability',
+    intro:
+      'Found a security issue in 2anki.net, the API, or the open-source repository? Email support@2anki.net with a clear write-up, steps to reproduce, and what you could access.',
   },
   {
     pathname: '/contact',
     title: 'Contact 2anki — support and feedback',
     description:
       'Reach the people who build 2anki. Report a conversion problem, ask a billing question, or send feedback — messages go straight to the maintainer.',
+    h1: 'Contact 2anki',
+    intro:
+      'Report a conversion problem, ask a billing question, or send feedback. Messages go straight to the maintainer.',
   },
   {
     pathname: '/documentation/start-here/connect-notion',
     title: 'Connect Notion in 5 minutes — 2anki docs',
     description:
       'From signing in to your first deck downloaded: connect your Notion account once, pick a page, and 2anki builds the Anki deck. No exports, no zip files.',
+    h1: 'Connect Notion in 5 minutes',
+    intro:
+      'The fastest way to get Notion notes into Anki: connect your Notion account once, pick a page, and 2anki builds the deck. No exports, no zip files.',
   },
   {
     pathname: '/documentation/cards/notion-to-anki-japanese',
     title: 'Notion to Anki for Japanese — 2anki docs',
     description:
       'Structure mined sentences and vocab in Notion, keep audio and screenshots, choose a note type, and open the deck in Anki. For sentence miners and JLPT studiers.',
+    h1: 'Notion → Anki for Japanese',
+    intro:
+      'For sentence miners, JLPT studiers, and kanji writers: structure mined sentences and vocab in Notion, keep audio and screenshots, choose a note type, and open the deck in Anki.',
   },
 ];
 
@@ -327,11 +440,46 @@ export function emitMetaOnlyPages(buildDir: string): string[] {
     );
     html = stripExistingMeta(html);
     html = html.replace(/<\/head>/, `  ${ogTags}\n</head>`);
+    html = html.replace(
+      /<div id="root"><\/div>/,
+      [
+        '<div id="root"><section style="max-width:720px;margin:0 auto;padding:3rem 1.5rem;">',
+        `<h1 style="font-family:var(--font-display);font-size:clamp(2rem, 5vw, 2.75rem);line-height:1.15;margin:0 0 1rem;">${escapeHtml(meta.h1)}</h1>`,
+        `<p style="${BODY_TEXT_STYLE}">${escapeHtml(meta.intro)}</p>`,
+        '</section></div>',
+      ].join('')
+    );
 
     writeFileSync(outPath, html, 'utf8');
     emitted.push(outPath);
   }
   return emitted;
+}
+
+function buildAnswersBodyFragment(config: {
+  h1: string;
+  intro: string;
+  sections: ReadonlyArray<{ heading: string; body: string }>;
+  faqs?: ReadonlyArray<{ q: string; a: string }>;
+}): string {
+  const sections = config.sections
+    .map(
+      (section) =>
+        `<section style="${SECTION_STYLE}"><h2 style="font-weight:var(--font-semibold);margin:0 0 0.5rem;">${escapeHtml(
+          section.heading
+        )}</h2><p style="${BODY_TEXT_STYLE}">${escapeHtml(section.body)}</p></section>`
+    )
+    .join('');
+  return [
+    `<article style="max-width:720px;margin:0 auto;padding:3rem 1.5rem;">`,
+    `<h1 style="font-family:var(--font-display);font-size:clamp(2rem, 5vw, 2.75rem);line-height:1.15;margin:0 0 1rem;">${escapeHtml(
+      config.h1
+    )}</h1>`,
+    `<p style="${BODY_TEXT_STYLE}">${escapeHtml(config.intro)}</p>`,
+    sections,
+    faqFragment(config.faqs ?? []),
+    '</article>',
+  ].join('');
 }
 
 export function emitAnswersPages(buildDir: string): string[] {
@@ -353,7 +501,11 @@ export function emitAnswersPages(buildDir: string): string[] {
     const outDir = join(buildDir, slug);
     const outPath = join(outDir, 'index.html');
     mkdirSync(dirname(outPath), { recursive: true });
-    let html = rewriteRoot(rewriteHead(source, copy), copy);
+    let html = rewriteHead(source, copy);
+    html = html.replace(
+      /<div id="root"><\/div>/,
+      `<div id="root">${buildAnswersBodyFragment(config)}</div>`
+    );
     const jsonLdScripts = [buildArticleJsonLd(config), buildFaqJsonLd(config)]
       .filter((jsonLd) => jsonLd != null)
       .map((jsonLd) => `<script type="application/ld+json">${jsonLd}</script>`)

--- a/web/src/pages/AnswersPage/answersConfig.ts
+++ b/web/src/pages/AnswersPage/answersConfig.ts
@@ -50,7 +50,7 @@ const convertNotionToAnki: AnswerConfig = {
     },
     {
       heading: 'Re-convert after editing',
-      body: 'Paste the same page URL again to get a fresh deck reflecting your edits. For edits to sync automatically every 5 minutes without manual steps, use Auto Sync ($30/month).',
+      body: 'Paste the same page URL again to get a fresh deck reflecting your edits. For edits to sync automatically every 5 minutes without manual steps, use Auto Sync — included with Lifetime, see 2anki.net/pricing.',
     },
     {
       heading: 'Use a Notion export instead',
@@ -85,7 +85,7 @@ const notionToAnkiSync: AnswerConfig = {
     },
     {
       heading: 'Set up Auto Sync',
-      body: 'Subscribe to Auto Sync ($30/month) at 2anki.net/pricing. Then go to 2anki.net/ankify/setup, connect your Notion workspace, and select the pages to watch. The first sync runs within 5 minutes.',
+      body: 'Get Auto Sync at 2anki.net/pricing — included with Lifetime. Then go to 2anki.net/ankify/setup, connect your Notion workspace, and select the pages to watch. The first sync runs within 5 minutes.',
     },
     {
       heading: 'Card format requirements',

--- a/web/src/pages/LandingPage/LandingPage.tsx
+++ b/web/src/pages/LandingPage/LandingPage.tsx
@@ -10,6 +10,10 @@ import styles from './LandingPage.module.css';
 import sharedStyles from '../../styles/shared.module.css';
 import type { LandingCopy } from './types';
 import { buildFaqJsonLd } from './landingJsonLd';
+import {
+  DEFAULT_LANDING_FORMATS,
+  DEFAULT_LANDING_STEPS,
+} from './landingDefaults';
 
 interface LandingPageProps {
   copy: LandingCopy;
@@ -23,21 +27,12 @@ const STEP_FALLBACK: Record<
   (typeof STEP_KEYS)[number],
   { title: string; body: string }
 > = {
-  dropFile: {
-    title: 'Drop your file',
-    body: 'Notion export, PDF, Word, Markdown, or a Quizlet export.',
-  },
-  buildsDeck: {
-    title: '2anki builds your deck',
-    body: 'Usually a few seconds. Bigger files take a minute.',
-  },
-  openInAnki: {
-    title: 'Open it in Anki',
-    body: 'Double-click the .apkg file. Your cards are ready to study.',
-  },
+  dropFile: DEFAULT_LANDING_STEPS[0],
+  buildsDeck: DEFAULT_LANDING_STEPS[1],
+  openInAnki: DEFAULT_LANDING_STEPS[2],
 };
 
-const FORMATS = ['Notion', 'PDF', 'Markdown', 'HTML', 'CSV', 'Word', 'Quizlet'];
+const FORMATS = DEFAULT_LANDING_FORMATS;
 
 function pageKeyFromPathname(pathname: string): string {
   return pathname.replace(/^\//, '').replace(/\//g, '-');

--- a/web/src/pages/LandingPage/landingDefaults.ts
+++ b/web/src/pages/LandingPage/landingDefaults.ts
@@ -1,0 +1,26 @@
+import type { LandingStep } from './types';
+
+export const DEFAULT_LANDING_STEPS: ReadonlyArray<LandingStep> = [
+  {
+    title: 'Drop your file',
+    body: 'Notion export, PDF, Word, Markdown, or a Quizlet export.',
+  },
+  {
+    title: '2anki builds your deck',
+    body: 'Usually a few seconds. Bigger files take a minute.',
+  },
+  {
+    title: 'Open it in Anki',
+    body: 'Double-click the .apkg file. Your cards are ready to study.',
+  },
+];
+
+export const DEFAULT_LANDING_FORMATS: ReadonlyArray<string> = [
+  'Notion',
+  'PDF',
+  'Markdown',
+  'HTML',
+  'CSV',
+  'Word',
+  'Quizlet',
+];


### PR DESCRIPTION
## What

The site audit's single highest-leverage fix: pages stop being crawler-hollow. Served HTML was 7–66 words everywhere (heads + hero only); a crawler that doesn't execute JS — every AI engine, Bing inconsistently — saw a title and one sentence.

- **Landing pages** now prerender hero + How it works + Supported formats + the proof section + **every FAQ** + related links: 35 → **384** crawler-visible words on `/notion-to-anki/`.
- **Answers pages** prerender the full article (intro + all sections + FAQs): 66 → **455** words.
- **Meta-only pages** (upload, pricing, about, app, security, contact, both docs) get a real h1 + intro paragraph: 7 → ~45 words, including live prices on `/pricing/`.
- The FAQ text that `FAQPage` JSON-LD has been describing is finally **in the served body** — closes the schema-vs-content gap for non-rendering validators and AI engines.
- Landing steps/formats defaults extracted to `landingDefaults.ts`, imported by both the component and the emitter, so rendered and prerendered content cannot drift.
- Two stale "Auto Sync ($30/month)" claims in answers copy replaced with price-neutral wording before this change made them crawler-visible (that price no longer exists).

Deliberately NOT in scope: the homepage body (serving a prerendered body from `index.html` would flash on every SPA app route — needs a server-side route split, flagged as follow-up), and figures/SVGs in answers bodies.

## How verified

- New tests: every FAQ q/a of a landing page asserted present in the served body; full article sections + FAQs asserted for answers; h1 + prices asserted for meta-only. Two tests that encoded the hero-only behavior ("does not prerender the proof section", "leaves the root div empty") now assert the new contract.
- CDN-base build inspected: word counts above measured on the actual emitted HTML.
- Full web suite 3335/3335, typecheck, lint, `pnpm format:check` clean.

## Browser check

- [x] Golden path on localhost:3000
- [x] No console errors at 375px

Golden-path e2e with mock API: 40 passed, 2 skipped. The prerendered body is replaced by React on mount (same content, no hydration mismatch — the app uses `createRoot().render`, not hydration).

No changelog entry — crawler-facing; users see the same rendered pages.

Sonar: not run locally; PR decoration will report.

## Goal alignment

Scale/acquisition: unlocks Bing + AI-engine visibility for all 64 sitemap pages and makes the FAQ/answers content quotable by answer engines. Metric: AI-crawler fetches with full-body responses; Bing indexation; the audit's Content score (52 → target 75+) on the next re-run.
