### PR TITLE
fix: align mindmap export media and node census on broken-edge maps

### DIFF
--- a/src/usecases/mindmaps/ExportMindmapUseCase.test.ts
+++ b/src/usecases/mindmaps/ExportMindmapUseCase.test.ts
@@ -28,6 +28,30 @@ const mapWithIsolatedImageNode: MindmapData = {
   edges: [{ source: 'a', target: 'b' }],
 };
 
+const mapWithRootlessCycle: MindmapData = {
+  nodes: [
+    {
+      id: 'anchor',
+      label: 'Anchor',
+      image: { url: 'mindmaps/2/1/anchor.png', width: 10, height: 10 },
+    },
+    {
+      id: 'x',
+      label: 'Cycle X',
+      image: { url: 'mindmaps/2/1/cyclex.png', width: 10, height: 10 },
+    },
+    {
+      id: 'y',
+      label: 'Cycle Y',
+      image: { url: 'mindmaps/2/1/cycley.png', width: 10, height: 10 },
+    },
+  ],
+  edges: [
+    { source: 'x', target: 'y' },
+    { source: 'y', target: 'x' },
+  ],
+};
+
 function buildUseCase(data: MindmapData) {
   const repo = {
     findById: jest.fn().mockResolvedValue({ id: 1, title: 'Anatomy', data }),
@@ -75,9 +99,26 @@ describe('ExportMindmapUseCase media bundling', () => {
     expect(result.buffer.toString()).toContain('floating.png');
   });
 
-  it('fetches every node image on markmap export', async () => {
+  it('bundles reachable-node images on markmap export', async () => {
     const { storage } = await runExport(mapWithIsolatedImageNode, 'markmap');
-    expect(storage.getFileContents).toHaveBeenCalledTimes(3);
+    const fetchedKeys = storage.getFileContents.mock.calls.map((c) => c[0]);
+    expect(fetchedKeys).toContain('mindmaps/2/1/heart.png');
+    expect(fetchedKeys).toContain('mindmaps/2/1/aorta.png');
+    expect(fetchedKeys).toContain('mindmaps/2/1/floating.png');
+  });
+
+  it('does not bundle rootless-cycle node media on markmap export', async () => {
+    const { result, storage } = await runExport(
+      mapWithRootlessCycle,
+      'markmap'
+    );
+    const fetchedKeys = storage.getFileContents.mock.calls.map((c) => c[0]);
+    expect(fetchedKeys).toContain('mindmaps/2/1/anchor.png');
+    expect(fetchedKeys).not.toContain('mindmaps/2/1/cyclex.png');
+    expect(fetchedKeys).not.toContain('mindmaps/2/1/cycley.png');
+    expect(result.buffer.toString()).not.toContain('cyclex.png');
+    expect(result.buffer.toString()).not.toContain('cycley.png');
+    expect(result.excludedNodeCount).toBe(2);
   });
 
   it('keeps connected-node media intact on basic export', async () => {

--- a/src/usecases/mindmaps/UpdateMindmapUseCase.test.ts
+++ b/src/usecases/mindmaps/UpdateMindmapUseCase.test.ts
@@ -288,6 +288,35 @@ describe('UpdateMindmapUseCase', () => {
     expect(savedImage.url).toBe('mindmaps/1/map-1/uuid.png');
   });
 
+  it('drops edges referencing a missing node id before persisting', async () => {
+    const repo = makeRepo(makeMap(2));
+    const useCase = new UpdateMindmapUseCase(repo);
+
+    await useCase.execute({
+      id: 'map-1' as MindmapsId,
+      userId: 1 as UsersId,
+      data: {
+        nodes: [
+          { id: 'a', label: 'A' },
+          { id: 'b', label: 'B' },
+        ],
+        edges: [
+          { source: 'a', target: 'b' },
+          { source: 'a', target: 'ghost' },
+          { source: 'ghost', target: 'b' },
+        ],
+      },
+      user: FREE_USER,
+      subscriptions: [],
+      isPaying: false,
+    });
+
+    const saved = (repo.update as jest.Mock).mock.calls[0][2] as {
+      data: MindmapData;
+    };
+    expect(saved.data.edges).toEqual([{ source: 'a', target: 'b' }]);
+  });
+
   it('rejects cross-tenant s3Key: key for user 99 in map belonging to user 1', async () => {
     const repo = makeRepo(makeMap(1));
     const useCase = new UpdateMindmapUseCase(repo);

--- a/src/usecases/mindmaps/UpdateMindmapUseCase.ts
+++ b/src/usecases/mindmaps/UpdateMindmapUseCase.ts
@@ -78,12 +78,16 @@ function sanitizeData(
   userId: UsersId,
   mapId: MindmapsId
 ): MindmapData {
+  const nodeIds = new Set(data.nodes.map((node) => node.id));
   return {
     ...data,
     nodes: data.nodes.map((node) => {
       if (node.image == null) return node;
       return { ...node, image: sanitizeImageUrl(node.image, userId, mapId) };
     }),
+    edges: data.edges.filter(
+      (edge) => nodeIds.has(edge.source) && nodeIds.has(edge.target)
+    ),
   };
 }
 

--- a/src/usecases/mindmaps/mindmapExportCensus.test.ts
+++ b/src/usecases/mindmaps/mindmapExportCensus.test.ts
@@ -61,4 +61,19 @@ describe('countExcludedMindmapNodes', () => {
     expect(countExcludedMindmapNodes(edgeFree, 'basic')).toBe(2);
     expect(countExcludedMindmapNodes(edgeFree, 'cloze')).toBe(0);
   });
+
+  it('counts a node whose only edge dangles as excluded from basic export', () => {
+    const danglingOnly = {
+      nodes: [
+        { id: '1', label: 'Root' },
+        { id: '2', label: 'Child' },
+        { id: 'lonely', label: 'Dangling-only' },
+      ],
+      edges: [
+        { source: '1', target: '2' },
+        { source: 'lonely', target: 'ghost' },
+      ],
+    };
+    expect(countExcludedMindmapNodes(danglingOnly, 'basic')).toBe(1);
+  });
 });

--- a/src/usecases/mindmaps/mindmapExportCensus.ts
+++ b/src/usecases/mindmaps/mindmapExportCensus.ts
@@ -2,40 +2,31 @@ import { MindmapData } from './MindmapData';
 import type { MindmapCardType } from './ExportMindmapUseCase';
 import { reachableNodeIds } from './mindmapGraph';
 
-function edgeIncidentNodeIds(data: MindmapData): Set<string> {
+function realEdgeIncidentNodeIds(data: MindmapData): Set<string> {
+  const nodeIds = new Set(data.nodes.map((n) => n.id));
   const incident = new Set<string>();
   for (const edge of data.edges) {
+    if (!nodeIds.has(edge.source) || !nodeIds.has(edge.target)) continue;
     incident.add(edge.source);
     incident.add(edge.target);
   }
   return incident;
 }
 
-function countIsolatedNodes(data: MindmapData): number {
-  const incident = edgeIncidentNodeIds(data);
-  return data.nodes.filter((n) => !incident.has(n.id)).length;
-}
-
 export function mediaEligibleNodeIds(
   data: MindmapData,
   cardType: MindmapCardType
-): Set<string> | null {
+): Set<string> {
   if (cardType === 'basic') {
-    return edgeIncidentNodeIds(data);
+    return realEdgeIncidentNodeIds(data);
   }
-  if (cardType === 'cloze') {
-    return reachableNodeIds(data);
-  }
-  return null;
+  return reachableNodeIds(data);
 }
 
 export function countExcludedMindmapNodes(
   data: MindmapData,
   cardType: MindmapCardType
 ): number {
-  if (cardType === 'basic') {
-    return countIsolatedNodes(data);
-  }
-  const reachable = reachableNodeIds(data);
-  return data.nodes.filter((n) => !reachable.has(n.id)).length;
+  const eligible = mediaEligibleNodeIds(data, cardType);
+  return data.nodes.filter((n) => !eligible.has(n.id)).length;
 }

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-20-mindmap-export-leftover-node-images.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-20-mindmap-export-leftover-node-images.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-20-mindmap-export-leftover-node-images",
+  "date": "2026-08-20",
+  "type": "fix",
+  "title": "Mind map exports no longer carry images from nodes left out of the deck, and the skipped-node count is now accurate"
+}


### PR DESCRIPTION
## What
Closes two server-side consistency gaps in mindmap export where the generated `.apkg` and the excluded-node notice disagreed. Markmap exports no longer bundle images of nodes that aren't rendered, and the "N nodes were left out" count is now honest for maps with broken (dangling) edges. The write path also drops dangling edges before persisting.

## Why
Progresses #4081 (Audit mindmaps end to end). Two verified gaps remained after #4093/#4108:

- **Markmap orphan media.** Markmap only renders the forest reachable from roots, so nodes stuck in a rootless cycle never appear — yet their images were still fetched and attached to the note, while the census counted those same nodes as excluded. The `.apkg` and the notice contradicted each other.
- **Dangling-edge silent drop (basic).** A node whose only edges reference missing node ids produced no card, but the basic census counted it as *included* (it was incident to *an* edge) — a silent drop, exactly what this audit exists to eliminate. Separately, nothing server-side validated edges: the API accepted edges referencing non-existent node ids.

## How
- `mindmapExportCensus.ts`: markmap media eligibility now uses the reachable-from-forest set (`reachableNodeIds`), the same walk the markmap tree builder uses — so media and census agree. The basic branch now treats an edge as real only when **both** endpoints exist in the node set, so a node incident only to dangling edges is counted excluded and drives basic media eligibility too. `countExcludedMindmapNodes` is now simply "nodes not in the media-eligible set" for every card type.
- `UpdateMindmapUseCase.ts`: `sanitizeData` drops edges whose source or target references a missing node id before persisting.

## Measuring success
The census already surfaces via `X-Excluded-Node-Count` → the web toast. A correct export now satisfies the invariant: for any map, the set of node images written into the `.apkg` equals the set of nodes the census counts as *included* (total nodes − `excludedNodeCount`). The two unit suites below lock this per card type; in prod the tell is that a re-exported broken-edge map no longer ships images with no matching card, and its toast count matches the nodes actually dropped.

## Testing
- Unit tests added:
  - `mindmapExportCensus.test.ts`: a node whose only edge dangles counts as excluded from basic export.
  - `ExportMindmapUseCase.test.ts`: replaced the "fetches every node image on markmap" assertion (which encoded the orphan-media bug) with a reachable-node positive test + a rootless-cycle test asserting the unrendered nodes' media is **not** bundled.
  - `UpdateMindmapUseCase.test.ts`: edges referencing a missing node id are dropped before persisting.
- Full server suite: 6484 passed; the only failures (74) are the documented environmental ones — the Python `create_deck` bridge (`PythonExitError`) and `pdfinfo`-less `getPageCount`, none in mindmaps or touched files.
- Full web suite: 374 files / 3335 tests passing (includes the new changelog entry loading).
- `tsc -p . --noEmit`: clean. `pnpm format:check`: clean.
- Sonar: not run locally; PR decoration will report.

## Browser check
Browser check: not applicable — server-only export/census change; the only web/src file is a changelog JSON, verified by the changelog loader test.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-08-20-mindmap-export-leftover-node-images.json` — "Mind map exports no longer carry images from nodes left out of the deck, and the skipped-node count is now accurate"

## Risks
Low, and scoped to `src/usecases/mindmaps/**`. Markmap media eligibility went from "all nodes" to "reachable nodes"; for any map with no rootless cycle the set is identical, so normal maps are unaffected. Dropping dangling edges on write only removes edges that already produced nothing. No limit, gate, or `MindmapLimitError` behavior changed (node-count caps run on the raw input before sanitization). Rollback is a straight revert.

## Decisions made overnight
- **Drop, not reject, dangling edges on write.** The editor already strips incident edges when a node is deleted, so dropping matches its own behavior; rejecting would brick already-stored maps that predate this fix. No new error path was added.
- **Markmap eligibility = reachable-from-forest**, not "all nodes." This is exactly the set the tree builder renders (roots + descendants), so media and census stay in lockstep. Cloze already used the same set; basic uses the real-edge incident set. Unified: `countExcludedMindmapNodes` = nodes not in `mediaEligibleNodeIds` for all three types.
- **Kept scope to basic for the dangling-edge census fix**, per the task. Cloze/markmap already tolerate dangling edges for census/media (phantom ids land only in the reachable set, which iterates real nodes only). One remaining cloze observation for #4081's open scope: an already-stored map with a dangling edge, exported as cloze, can still emit a card path containing the raw missing id — the write-path drop prevents new occurrences, but pre-existing maps aren't rewritten. Left out of this PR to keep it tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbQZzLbjr2apKHQC7orhhw

