### PR TITLE
docs: fold strategy pillars and parked ideas into repo docs

### DIFF
--- a/Documentation/strategy/2026-07-go-to-place.md
+++ b/Documentation/strategy/2026-07-go-to-place.md
@@ -231,7 +231,7 @@ channel · Android/desktop by the numbers.
 | P1 "Anything → Anki" positioning | Open. Format breadth largely shipped (PPT, DOCX, images route to vision as of 2026-08-21); AnkiHub-era positioning/outreach not started. Was #3683 |
 | P2 Price to the lifecycle | Partially shipped: pricing v2 (2026-06-10), day/week passes, pause offer (kept — 4 saves/60d, review 2026-08-21), win-back email. Semester pass parked (ROADMAP). Was #3684 |
 | P3 Reasons to return | Verdict in: shared-deck library REMOVED at T+28 with zero publishes (#3832); webhook sync built but unfed (Notion-side registration deferred, `src/lib/ankify/FEATURE.md`). Was #3685 |
-| P4 Hosted MCP server | ✅ Shipped (#3686), KEEP verdict at T+30 (37 users/30d). Directory submissions tracked in #3798's kit |
+| P4 Hosted MCP server | ✅ Shipped (#3686), KEEP verdict at T+30 (37 users/30d). Directory listings: Smithery ✅, mcp.so ✅ (submitted 2026-08-21), PulseMCP auto-ingests the official registry. Two remain owner-only: Anthropic Connectors Directory (needs claude.ai org Owner) and the official MCP Registry (`mcp-publisher` CLI + DNS auth on 2anki.net) — canonical listing facts in closed #3798 |
 | P5 Developer API tier | ❌ REMOVED at adoption review 2026-08-21 (1 external key, used once). Was #3687/#3780 |
 | P6 Native app | Executes in the `Laer-Smart/2anki.app` repo. Was #3688 |
 

--- a/Documentation/strategy/2026-07-go-to-place.md
+++ b/Documentation/strategy/2026-07-go-to-place.md
@@ -223,6 +223,20 @@ channel · Android/desktop by the numbers.
 
 ---
 
+## Pillar status (2026-08-21 — tracking moved here from GitHub issues #3683–#3689, now closed)
+
+| Pillar | State |
+|---|---|
+| P0 Instrumentation | ✅ Shipped (#3682): funnel events, `input_format` segmentation (#4088), MCP + native attribution (#4094) |
+| P1 "Anything → Anki" positioning | Open. Format breadth largely shipped (PPT, DOCX, images route to vision as of 2026-08-21); AnkiHub-era positioning/outreach not started. Was #3683 |
+| P2 Price to the lifecycle | Partially shipped: pricing v2 (2026-06-10), day/week passes, pause offer (kept — 4 saves/60d, review 2026-08-21), win-back email. Semester pass parked (ROADMAP). Was #3684 |
+| P3 Reasons to return | Verdict in: shared-deck library REMOVED at T+28 with zero publishes (#3832); webhook sync built but unfed (Notion-side registration deferred, `src/lib/ankify/FEATURE.md`). Was #3685 |
+| P4 Hosted MCP server | ✅ Shipped (#3686), KEEP verdict at T+30 (37 users/30d). Directory submissions tracked in #3798's kit |
+| P5 Developer API tier | ❌ REMOVED at adoption review 2026-08-21 (1 external key, used once). Was #3687/#3780 |
+| P6 Native app | Executes in the `Laer-Smart/2anki.app` repo. Was #3688 |
+
+The weekly allocation rule (one acquisition-facing change ships first, every week) lives in CLAUDE.md and remains the standing guardrail; per-pillar issue tracking ends here — new work gets fresh, scoped issues.
+
 *Repo anchors: pricing `src/usecases/checkout/pricingV2.ts` · quotas
 `src/usecases/users/CheckMonthly*` · AI `src/lib/claude/ClaudeService.ts` · API docs
 `src/config/swagger.ts` (`/api/docs`) · shares `src/routes/ShareRouter.ts` · sync design

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -81,6 +81,14 @@ Mission: give people the simplest, fastest way to turn what they're studying int
 - 🔴 Per-locale landing pages (i18n)
 - 🔴 Full HTML → Notion rich text conversion (tables, code blocks, LaTeX) for APKG import v2
 
+## Parked ideas (issue backlog folded in 2026-08-21; the surface-lifecycle gate allows one new surface at a time)
+
+- 🔴 AI-native fallback for unrecognized upload formats — magic-byte sniffing, known formats keep deterministic parsers, everything else falls through to the vision/AI path instead of a flat reject (was #3833; generalizes the shipped PDF-vision fallback)
+- 🔴 Contextual structure interview — when a conversion's yield disagrees wildly with the page's block census, ask one evidence-based question at the result screen and record the answer as that page's parser rules (was #3949; per-page, never per-account)
+- 🔴 Resumable or direct-to-storage upload for very large exports — the browser-side half of the large-export incident; Safari dies on a ~643MB multipart POST before any server cap applies (was #3957; server-side extraction already bounded by #3956)
+- 🔴 Re-record the walkthrough videos against the v2 UI — recording task for the maintainer; the written docs are current, the home/start-here videos still show the pre-v2 interface (was #4061)
+- 🔴 Semester Pass one-time tier — pricing-lifecycle idea from the P2 pillar; revisit against pass-sales data (was spec PR #3621; passes shipped as day/week passes instead)
+
 ---
 
 ## Current numbers


### PR DESCRIPTION
Part of the zero-backlog sweep. Pillar tracking for the go-to-place strategy moves from issues #3683–#3689 into the strategy doc (with current per-pillar state as of today), and five long-horizon ideas park in ROADMAP.md (#3833 AI-native fallback, #3949 structure interview, #3957 resumable upload, #4061 video re-record, semester pass from spec PR #3621). The named issues close when this merges — the ideas stay versioned and reviewable in the repo instead of aging as open issues, per the repo's own memory policy.

No changelog entry — internal docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbQZzLbjr2apKHQC7orhhw