### PR TITLE
fix: convert image uploads through the vision pipeline

### DIFF
--- a/src/lib/upload/decodeUploadImage.test.ts
+++ b/src/lib/upload/decodeUploadImage.test.ts
@@ -1,0 +1,32 @@
+import { decodeUploadImage } from './decodeUploadImage';
+
+const ONE_BY_ONE_PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+describe('decodeUploadImage', () => {
+  it('decodes a PNG buffer into base64, media type, and dimensions', () => {
+    const buffer = Buffer.from(ONE_BY_ONE_PNG_BASE64, 'base64');
+
+    const decoded = decodeUploadImage(buffer);
+
+    expect(decoded).toEqual({
+      imageBase64: ONE_BY_ONE_PNG_BASE64,
+      mediaType: 'image/png',
+      width: 1,
+      height: 1,
+    });
+  });
+
+  it('returns null for an empty buffer', () => {
+    expect(decodeUploadImage(Buffer.alloc(0))).toBeNull();
+  });
+
+  it('returns null for a non-image buffer', () => {
+    expect(decodeUploadImage(Buffer.from('not an image', 'utf8'))).toBeNull();
+  });
+
+  it('returns null for a PDF buffer even though it is a real file', () => {
+    const pdf = Buffer.from('%PDF-1.4\n%âãÏÓ\n', 'binary');
+    expect(decodeUploadImage(pdf)).toBeNull();
+  });
+});

--- a/src/lib/upload/decodeUploadImage.ts
+++ b/src/lib/upload/decodeUploadImage.ts
@@ -1,0 +1,50 @@
+import imageSize from 'image-size';
+
+import { detectFileMime } from '../detectFileMime';
+import type { VisionMediaType } from '../claude/countVisionTokens';
+
+const VISION_MEDIA_TYPES: VisionMediaType[] = [
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/gif',
+];
+
+export interface DecodedUploadImage {
+  imageBase64: string;
+  mediaType: VisionMediaType;
+  width: number;
+  height: number;
+}
+
+function isVisionMediaType(value: string | null): value is VisionMediaType {
+  return value != null && (VISION_MEDIA_TYPES as string[]).includes(value);
+}
+
+export function decodeUploadImage(buffer: Buffer): DecodedUploadImage | null {
+  if (buffer.length === 0) {
+    return null;
+  }
+  const mediaType = detectFileMime(buffer);
+  if (!isVisionMediaType(mediaType)) {
+    return null;
+  }
+  let width: number | undefined;
+  let height: number | undefined;
+  try {
+    const dims = imageSize(buffer);
+    width = dims.width;
+    height = dims.height;
+  } catch {
+    return null;
+  }
+  if (width == null || height == null) {
+    return null;
+  }
+  return {
+    imageBase64: buffer.toString('base64'),
+    mediaType,
+    width,
+    height,
+  };
+}

--- a/src/routes/McpRouter.ts
+++ b/src/routes/McpRouter.ts
@@ -70,7 +70,8 @@ const McpRouter = () => {
     undefined,
     undefined,
     new ConversionRuleScoresRepository(database),
-    new CardGuidLedgerRepository(database)
+    new CardGuidLedgerRepository(database),
+    new PhotoToFlashcardsUseCase(new EventsRepository(database))
   );
   const storage = new StorageHandler();
   const toolsService = new McpToolsService(

--- a/src/routes/UploadRouter.ts
+++ b/src/routes/UploadRouter.ts
@@ -35,6 +35,8 @@ import { DeleteGoogleDriveUploadUseCase } from '../usecases/uploads/DeleteGoogle
 import DeleteJobUseCase from '../usecases/jobs/DeleteJobUseCase';
 import { ConversionRuleScoresRepository } from '../data_layer/ConversionRuleScoresRepository';
 import { CardGuidLedgerRepository } from '../data_layer/CardGuidLedgerRepository';
+import { EventsRepository } from '../data_layer/EventsRepository';
+import { PhotoToFlashcardsUseCase } from '../usecases/imageOcclusion/PhotoToFlashcardsUseCase';
 import NotionTopLevelPagesRepository from '../data_layer/NotionTopLevelPagesRepository';
 import { GetRecentSourcesUseCase } from '../usecases/uploads/GetRecentSourcesUseCase';
 import { RecentSourcesController } from '../controllers/Upload/RecentSourcesController';
@@ -60,7 +62,8 @@ const UploadRouter = () => {
         tierKey
       ),
     new ConversionRuleScoresRepository(database),
-    new CardGuidLedgerRepository(database)
+    new CardGuidLedgerRepository(database),
+    new PhotoToFlashcardsUseCase(new EventsRepository(database))
   );
   const jobController = new JobController(
     jobService,

--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -72,6 +72,7 @@ jest.mock('../lib/storage/StorageHandler', () => {
 });
 
 import GeneratePackagesUseCase from '../usecases/uploads/GeneratePackagesUseCase';
+import type { PhotoToFlashcardsUseCase } from '../usecases/imageOcclusion/PhotoToFlashcardsUseCase';
 import { EmptyDeckError } from '../usecases/jobs/EmptyDeckError';
 import { DeckTooLargeError } from '../lib/parser/exporters/DeckTooLargeError';
 import UploadService from './UploadService';
@@ -3125,5 +3126,151 @@ describe('UploadService.handleUpload — in-flight duplicate guard', () => {
     await service.handleUpload(buildAiRequest('shared bytes'), otherUser.res);
 
     expect(otherUser.capturedStatus()).toBe(202);
+  });
+});
+
+describe('UploadService.handleUpload — image uploads route through vision', () => {
+  const originalWorkspaceBase = process.env.WORKSPACE_BASE;
+  const ONE_BY_ONE_PNG_BASE64 =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+  beforeAll(() => {
+    process.env.WORKSPACE_BASE = path.join(os.tmpdir(), 'upload-service-test');
+  });
+
+  afterAll(() => {
+    process.env.WORKSPACE_BASE = originalWorkspaceBase;
+  });
+
+  beforeEach(() => {
+    MockGeneratePackagesUseCase.mockClear();
+    MockGeneratePackagesUseCase.mockImplementation(
+      () =>
+        ({
+          execute: jest.fn().mockResolvedValue({ packages: [] }),
+        }) as unknown as InstanceType<typeof GeneratePackagesUseCase>
+    );
+    trackMock.mockClear();
+    mockWorkspaceId = 'image-ws-id';
+  });
+
+  function buildVisionUseCase(execute: jest.Mock) {
+    return { execute } as unknown as PhotoToFlashcardsUseCase;
+  }
+
+  function buildServiceWithVision(vision: PhotoToFlashcardsUseCase) {
+    return new UploadService(
+      buildRepository(),
+      {
+        create: jest.fn().mockResolvedValue(undefined),
+      } as unknown as JobRepository,
+      buildUsersRepo(),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      vision
+    );
+  }
+
+  function buildImageRequest(overrides: Partial<express.Request> = {}) {
+    return buildRequest({
+      files: [
+        {
+          originalname: 'lecture-slide.png',
+          mimetype: 'image/png',
+          size: 2048,
+          buffer: Buffer.from(ONE_BY_ONE_PNG_BASE64, 'base64'),
+        },
+      ],
+      body: {},
+      ...overrides,
+    } as unknown as Partial<express.Request>);
+  }
+
+  function signedInResponse() {
+    const built = buildResponse();
+    (built.res.locals as Record<string, unknown>).owner = 42;
+    return built;
+  }
+
+  it('converts a single-image upload through the vision pipeline and returns the apkg', async () => {
+    const apkgPath = path.join(os.tmpdir(), `vision-upload-${Date.now()}.apkg`);
+    const apkgBytes = Buffer.from('fake-apkg-bytes');
+    fs.writeFileSync(apkgPath, apkgBytes);
+    const execute = jest.fn().mockResolvedValue({
+      apkgPath,
+      cardCount: 7,
+      estimatedCostUsd: 0.01,
+      tileCount: 1,
+      mcqCount: 0,
+      mcqSkippedCount: 0,
+    });
+    const service = buildServiceWithVision(buildVisionUseCase(execute));
+    const { res, capturedStatus, capturedSend } = signedInResponse();
+
+    await service.handleUpload(buildImageRequest(), res);
+
+    expect(execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        imageBase64: ONE_BY_ONE_PNG_BASE64,
+        mediaType: 'image/png',
+        owner: '42',
+        imageDimensions: { width: 1, height: 1 },
+        usageSurface: 'photo_to_deck_upload',
+      })
+    );
+    expect(capturedStatus()).toBe(200);
+    expect(capturedSend()).toEqual(apkgBytes);
+    expect(trackMock).toHaveBeenCalledWith(
+      'conversion_succeeded',
+      expect.objectContaining({ userId: 42 })
+    );
+  });
+
+  it('surfaces the vision quota error with its status instead of a silent failure', async () => {
+    const quotaError = Object.assign(
+      new Error(
+        "Free plan is 5 photos per month. You've used 5. Upgrade for unlimited."
+      ),
+      { status: 429, used: 5, limit: 5 }
+    );
+    const execute = jest.fn().mockRejectedValue(quotaError);
+    const service = buildServiceWithVision(buildVisionUseCase(execute));
+    const { res, capturedStatus, capturedJson } = signedInResponse();
+
+    await service.handleUpload(buildImageRequest(), res);
+
+    expect(capturedStatus()).toBe(429);
+    const body = capturedJson() as {
+      code: string;
+      message: string;
+      limit?: number;
+    };
+    expect(body.code).toBe('image_conversion_failed');
+    expect(body.limit).toBe(5);
+    expect(trackMock).toHaveBeenCalledWith(
+      'conversion_failed',
+      expect.objectContaining({
+        props: expect.objectContaining({ reason: 'image_429' }),
+      })
+    );
+  });
+
+  it('leaves an anonymous image upload on the image_only_no_text floor and never calls vision', async () => {
+    const execute = jest.fn();
+    const service = buildServiceWithVision(buildVisionUseCase(execute));
+    const { res, capturedStatus, capturedJson } = buildResponse();
+
+    await service.handleUpload(buildImageRequest(), res);
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(capturedStatus()).toBe(400);
+    expect((capturedJson() as { code: string }).code).toBe(
+      'image_only_no_text'
+    );
   });
 });

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -24,6 +24,8 @@ import { isLimitError } from '../lib/misc/isLimitError';
 import { handleUploadLimitError } from '../controllers/Upload/helpers/handleUploadLimitError';
 import { getUploadValidationError } from '../lib/upload/getUploadValidationError';
 import { isImageOnlyUpload } from '../lib/upload/isImageOnlyUpload';
+import { decodeUploadImage } from '../lib/upload/decodeUploadImage';
+import { PhotoToFlashcardsUseCase } from '../usecases/imageOcclusion/PhotoToFlashcardsUseCase';
 import { EmptyDeckError } from '../usecases/jobs/EmptyDeckError';
 import { UploadFileUnavailableError } from '../usecases/uploads/UploadFileUnavailableError';
 import { isExpectedClientFault } from '../lib/misc/isExpectedClientFault';
@@ -185,6 +187,35 @@ function sumExpiredNotionImages(
 function hasSessionToken(req: express.Request): boolean {
   const token = (req.cookies as Record<string, unknown> | undefined)?.token;
   return typeof token === 'string' && token.length > 0;
+}
+
+async function readUploadBytes(file: UploadedFile): Promise<Buffer | null> {
+  if (file.buffer != null) {
+    return file.buffer;
+  }
+  if (file.path != null && file.path !== '') {
+    try {
+      return await fs.promises.readFile(file.path);
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+function deckNameFromImageFilename(name: string): string {
+  const base = name.replace(/\.[^./\\]+$/, '').trim();
+  return base.length > 0 ? base : 'Photo deck';
+}
+
+function imageConversionErrorStatus(err: unknown): number | null {
+  if (err instanceof Error) {
+    const status = (err as Error & { status?: unknown }).status;
+    if (typeof status === 'number') {
+      return status;
+    }
+  }
+  return null;
 }
 
 const CONVERSION_SETTINGS_FILENAME = 'conversion-settings.json';
@@ -354,7 +385,8 @@ class UploadService {
     private readonly apiKeyUsageRepository?: IApiKeyUsageRepository,
     private readonly apiUsageWarner?: ApiUsageWarner,
     private readonly conversionRuleScoresRepository?: IConversionRuleScoresRepository,
-    private readonly cardGuidLedgerRepository?: ICardGuidLedgerRepository
+    private readonly cardGuidLedgerRepository?: ICardGuidLedgerRepository,
+    private readonly photoToFlashcardsUseCase?: PhotoToFlashcardsUseCase
   ) {}
 
   private apiTierOf(res: express.Response): ResolvedDeveloperTier | null {
@@ -758,6 +790,16 @@ class UploadService {
           device: classifyDevice(req.headers?.['user-agent']),
         },
       });
+
+      const files = req.files as UploadedFile[];
+      if (
+        owner != null &&
+        this.photoToFlashcardsUseCase != null &&
+        files.length === 1 &&
+        isImageOnlyUpload(files)
+      ) {
+        return await this.handleImageUpload(req, res, String(owner), paying);
+      }
 
       if (owner != null && paying && settings.claudeAIFlashcards) {
         return await this.handleAsyncUpload(
@@ -1352,6 +1394,122 @@ class UploadService {
           sumExpiredNotionImages(packages)
         )
       );
+  }
+
+  // Image uploads convert through the same vision pipeline as Photo to Deck
+  // (its 5-per-month free quota, unlimited-for-paying gate, and Claude cost all
+  // live inside PhotoToFlashcardsUseCase), so dropping a photo on the file
+  // uploader succeeds instead of failing with an empty deck. Anonymous and
+  // multi-file image uploads never reach here — they keep the image_only_no_text
+  // guidance floor.
+  private async handleImageUpload(
+    req: express.Request,
+    res: express.Response,
+    owner: string,
+    paying: boolean
+  ) {
+    const file = (req.files as UploadedFile[])[0];
+    track('conversion_started', {
+      userId: Number(owner),
+      anonymousId: this.resolveAnonId(req),
+      props: { source: this.resolveUploadSource(req), mode: 'image' },
+    });
+
+    const bytes = await readUploadBytes(file);
+    const decoded = bytes == null ? null : decodeUploadImage(bytes);
+    if (decoded == null) {
+      track('conversion_failed', {
+        userId: Number(owner),
+        anonymousId: this.resolveAnonId(req),
+        props: { ...this.baseFunnelProps(req), reason: 'empty_deck' },
+      });
+      throw new EmptyDeckError();
+    }
+
+    const deckName = deckNameFromImageFilename(file.originalname);
+    let result: Awaited<ReturnType<PhotoToFlashcardsUseCase['execute']>>;
+    try {
+      result = await this.photoToFlashcardsUseCase!.execute({
+        imageBase64: decoded.imageBase64,
+        mediaType: decoded.mediaType,
+        deckName,
+        owner,
+        isPaying: paying,
+        imageDimensions: { width: decoded.width, height: decoded.height },
+        usageSurface: 'photo_to_deck_upload',
+      });
+    } catch (err) {
+      if (this.respondToImageConversionError(req, res, err)) {
+        return;
+      }
+      throw err;
+    }
+
+    const apkg = await fs.promises.readFile(result.apkgPath);
+    fs.promises.unlink(result.apkgPath).catch(() => undefined);
+
+    res.set('Content-Type', 'application/apkg');
+    res.set('Content-Length', Buffer.byteLength(apkg).toString());
+    res.set('X-Card-Count', result.cardCount.toString());
+    res.set('X-MCQ-Count', result.mcqCount.toString());
+    res.set('X-MCQ-Skipped-Count', result.mcqSkippedCount.toString());
+    res.set(
+      'Access-Control-Expose-Headers',
+      'File-Name, X-Card-Count, X-MCQ-Count, X-MCQ-Skipped-Count'
+    );
+    try {
+      res.set('File-Name', encodeURIComponent(deckName));
+    } catch (err) {
+      console.info(`failed to set name ${deckName}`);
+      console.error(err);
+    }
+    res.attachment(`/${deckName}`);
+    track('conversion_succeeded', {
+      userId: Number(owner),
+      anonymousId: this.resolveAnonId(req),
+      props: {
+        ...this.baseFunnelProps(req),
+        card_count_bucket: toCardCountBucket(result.cardCount),
+      },
+    });
+    return res.status(200).send(apkg);
+  }
+
+  private respondToImageConversionError(
+    req: express.Request,
+    res: express.Response,
+    err: unknown
+  ): boolean {
+    const status = imageConversionErrorStatus(err);
+    if (status == null) {
+      return false;
+    }
+    const e = err as Error & {
+      code?: string;
+      used?: number;
+      limit?: number;
+    };
+    const owner = getOwner(res);
+    track('conversion_failed', {
+      userId: owner != null ? Number(owner) : null,
+      anonymousId: this.resolveAnonId(req),
+      props: {
+        ...this.baseFunnelProps(req),
+        reason: `image_${e.code ?? status}`,
+      },
+    });
+    const body: Record<string, unknown> = {
+      code: 'image_conversion_failed',
+      message: e.message,
+    };
+    if (e.used != null) {
+      body.used = e.used;
+    }
+    if (e.limit != null) {
+      body.limit = e.limit;
+    }
+    res.status(status).json(body);
+    return true;
   }
 
   private async buildBatchResponse(

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-21-image-uploads.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-21-image-uploads.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-21-image-uploads",
+  "date": "2026-08-21",
+  "type": "fix",
+  "title": "Drop a photo on the uploader and it now converts into cards instead of failing"
+}


### PR DESCRIPTION
## What
A single-image (jpg/png/webp/gif) upload on the main `/upload` file converter now converts through the existing Photo to Deck vision pipeline and returns a real `.apkg`, instead of failing with an empty deck. Backend-only change plus a changelog entry.

## Why
Closes #4062. Instrumentation from #4088 read: over the last 8 days, **14 image uploads → 0 successes → 14 `conversion_failed`** (100% failure) on the file converter, while a working vision pipeline already existed on a different surface (Photo to Deck). The image path died at the parser (an image has no toggle/Q&A structure → zero cards → `EmptyDeckError`), so every photo dropped on the uploader was a dead end.

## How
`UploadService.handleUpload` now intercepts an image-only upload from a signed-in user (`files.length === 1 && isImageOnlyUpload`) and routes it to a new `handleImageUpload`, which decodes the bytes (`decodeUploadImage`: `detectFileMime` + `image-size`) and calls the **existing** `PhotoToFlashcardsUseCase.execute` — no logic duplication, same use case Photo to Deck and the MCP tool already use. The apkg streams back exactly like any other single-deck conversion and fires `conversion_succeeded`.

Gates are reused unchanged: the use case owns the 5-per-month free quota and unlimited-for-paying rule, so no new gate is introduced. A gated-out (over-quota) user gets the quota error via `respondToImageConversionError` (413/422/429 mapped to a coded `image_conversion_failed` JSON body with the use case's own actionable message), never a silent fail. Anonymous uploads, multi-file uploads, and unreadable images (svg/bmp/corrupt) fall through to the existing `image_only_no_text` guidance floor untouched.

## LLM / cost envelope
Reuses `PhotoToFlashcardsUseCase` **as-is** — no model change, no budget re-tuning. Per image upload: one `claude-sonnet-5` vision call at `VISION_MAX_TOKENS` 8192 (retry 16384 on truncation), identical to a Photo to Deck conversion today. Latency: 2–30s on the sync request (same profile as the existing surface). Cost delta: one photo-to-deck-equivalent call per image upload where the prior cost was $0 (the upload failed) — bounded to **single-image** uploads (`files.length === 1`), so there is no multi-call fan-out on the hot path. Prompt caching: N/A (vision image inputs aren't cached; unchanged from today). Cost attribution is tagged `usageSurface: 'photo_to_deck_upload'` so day-1/2 spend can be split out from the Photo to Deck surface.

## Measuring success
`conversion_succeeded` with `input_format` in (`png`,`jpg`,`jpeg`,`webp`,`gif`) at `/api/ops/metrics` should go from ~0 to non-zero, and `conversion_failed` for those formats should drop toward 0 (baseline: 14/0/14 over 8 days). `ai_usage_recorded` / `recordClaudeUsage` rows with `surface = photo_to_deck_upload` confirm the vision path is firing and isolate its spend.

## Testing
- Unit: `src/lib/upload/decodeUploadImage.test.ts` (PNG decode; null for empty/non-image/PDF).
- Boundary: `UploadService.test.ts` — a single-image signed-in upload routes through a stubbed vision use case and streams the apkg + fires `conversion_succeeded`; a vision quota error surfaces with its 429 status + `conversion_failed`; an anonymous image upload never calls vision and keeps `image_only_no_text`.
- Full server suite: 6529 passed / 74 failed — every failure is the documented worktree env class (Python `create_deck` venv absent → `PythonExitError`, and `getPageCount`), none in touched code.
- Full web suite: 374 files / 3335 tests green (changelog + events parity).
- `tsc -p . --noEmit` clean; `pnpm format:check` clean; `pnpm arch` 0 errors.
- Sonar: not run locally; PR decoration will report.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px

Notes: Backend-only behaviour change; the only `web/src` file is a changelog JSON (data, renders in the existing What's New list). Success reuses the shipped single-deck apkg-download flow; the error path reuses the shipped `extractErrorMessage` → error-state rendering. No new web component or string. No dev server run — the honest limitation is stated here per CLAUDE.md; recommend a manual drop-a-photo check on the uploader before merge.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-08-21-image-uploads.json` — "Drop a photo on the uploader and it now converts into cards instead of failing"

## Decisions made
- **Shipped the PREFERRED path, not the FLOOR.** The floor the issue describes — a coded `image_only_no_text` error rendering "Photos convert best through photo-to-deck" with a localized link — is **already shipped end-to-end** (backend `image_only_no_text` + `photoToDeckUrl`, web `renderImageOnlyState` in 10 locales, `image_only_photo_deck_shown/_clicked`). Re-shipping it would be a false artifact. The real gap is the 100% failure, so images now actually convert.
- **Single-image only.** The dominant real case (14 uploads) is a single photo drop, and one vision call per upload cleanly bounds cost/latency on the sync path. Multi-image uploads (a cost multiplier + a per-request quota race) keep the floor guidance for now.
- **Reused the use case's own gate rather than adding `CheckMonthlyCardLimitUseCase`/`incrementCardUsage`.** Photo to Deck gates on its 5/month vision quota (free) / unlimited (paying), not the monthly *card* limit. Matching it avoids double-gating and keeps the two surfaces identical.
- **No new event names or i18n keys.** Only reused events (`conversion_started/succeeded/failed`) with new prop values (`mode: 'image'`, `reason: 'image_<status>'`, `usageSurface`), so no allowlist parity change. Over-quota/unreadable responses reuse the use case's existing English messages via the existing `extractErrorMessage` rendering.

## Risks
- Vision cost now flows from the file converter too. Mitigated by single-image-only scoping and the reused 5/month free quota; monitor `surface = photo_to_deck_upload` spend on day 1/2.
- A signed-in user who previously saw the "try Photo to Deck" nudge now gets a real conversion instead — intended. The nudge still shows for anonymous and multi-file image uploads.
- Rollback is a clean revert (behaviour is additive behind `photoToFlashcardsUseCase != null`; unset the wiring and the floor returns).

## Goal alignment
Directly attacks first-conversion friction (the acquisition lane): a photo dropped on the uploader was a guaranteed dead end and now yields a deck. Funnel metric to move: `conversion_succeeded` for image `input_format` (0 → non-zero) and the image-format `conversion_failed` rate (→ 0), read at `/api/ops/metrics`, first check at day 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbQZzLbjr2apKHQC7orhhw
