### PR TITLE
refactor: clear deferred Sonar findings from #3935

### DIFF
--- a/src/services/EmailService/EmailService.test.ts
+++ b/src/services/EmailService/EmailService.test.ts
@@ -5,7 +5,10 @@ jest.mock('@sendgrid/mail', () => ({
   send,
 }));
 
-import { getDefaultEmailService } from './EmailService';
+import {
+  getDefaultEmailService,
+  UnimplementedEmailService,
+} from './EmailService';
 import {
   NOTION_RECONNECT_TEMPLATE,
   CONTACT_CONFIRMATION_TEMPLATE,
@@ -354,5 +357,48 @@ describe('EmailService.sendContactConfirmationEmail', () => {
     expect(msg.subject).toBe('We got your message');
     expect(msg.replyTo).toBe('support@2anki.net');
     expect(msg.html).toContain('Your message reached us');
+  });
+});
+
+describe('EmailService.sendConversionLinkEmail delivery contract', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.SENDGRID_API_KEY = 'test-key';
+    process.env.DOMAIN = 'https://2anki.net';
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('returns an awaitable promise whose resolution follows delivery', async () => {
+    const service = getDefaultEmailService();
+
+    const returned = service.sendConversionLinkEmail(
+      'learner@example.com',
+      'Anatomy',
+      'https://2anki.net/api/download/u/key-9',
+      2
+    );
+
+    expect(returned).toBeInstanceOf(Promise);
+    await returned;
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets the unimplemented service be awaited without delivering', async () => {
+    const service = new UnimplementedEmailService();
+
+    const returned = service.sendConversionLinkEmail(
+      'learner@example.com',
+      'Anatomy',
+      'https://2anki.net/api/download/u/key-9',
+      2
+    );
+
+    await returned;
+    expect(send).not.toHaveBeenCalled();
   });
 });

--- a/src/services/EmailService/EmailService.ts
+++ b/src/services/EmailService/EmailService.ts
@@ -53,7 +53,7 @@ export interface IEmailService {
     filename: string,
     link: string,
     cardCount?: number
-  ): void;
+  ): Promise<void>;
   sendContactEmail(
     name: string,
     email: string,
@@ -968,12 +968,12 @@ export class UnimplementedEmailService implements IEmailService {
     );
   }
 
-  sendConversionLinkEmail(
+  async sendConversionLinkEmail(
     email: string,
     filename: string,
     link: string,
     cardCount?: number
-  ): void {
+  ): Promise<void> {
     console.info(
       'sendConversionLinkEmail not handled',
       email,

--- a/src/services/NotionService/NotionService.getAccessData.test.ts
+++ b/src/services/NotionService/NotionService.getAccessData.test.ts
@@ -57,3 +57,38 @@ test('throws when NOTION_REDIRECT_URI is missing rather than POSTing an invalid 
   );
   expect(mockedAxios.post).not.toHaveBeenCalled();
 });
+
+describe('NotionService.getAccessData settles per the OAuth response', () => {
+  test('resolves with the token payload Notion returns', async () => {
+    mockedAxios.post.mockResolvedValue({
+      data: { access_token: 'tok-abc', workspace_id: 'ws-1' },
+    } as Awaited<ReturnType<typeof mockedAxios.post>>);
+
+    const result = await makeService().getAccessData('auth-code-123');
+
+    expect(result).toEqual({ access_token: 'tok-abc', workspace_id: 'ws-1' });
+  });
+
+  test('rejects with the underlying error when the token request fails', async () => {
+    const failure = new Error('notion oauth request failed');
+    mockedAxios.post.mockRejectedValue(failure);
+
+    await expect(makeService().getAccessData('auth-code-123')).rejects.toBe(
+      failure
+    );
+  });
+
+  test('stays pending when Notion responds without an access_token', async () => {
+    mockedAxios.post.mockResolvedValue({
+      data: {},
+    } as Awaited<ReturnType<typeof mockedAxios.post>>);
+
+    const settled = jest.fn();
+    void makeService().getAccessData('auth-code-123').then(settled, settled);
+
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(settled).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/NotionService/NotionService.ts
+++ b/src/services/NotionService/NotionService.ts
@@ -263,7 +263,7 @@ export class NotionService {
       throw new Error('Notion Connection Handler not configured');
     }
 
-    return new Promise(async (resolve, reject) => {
+    return new Promise((resolve, reject) => {
       const url = 'https://api.notion.com/v1/oauth/token';
       const data = {
         grant_type: 'authorization_code',
@@ -278,21 +278,18 @@ export class NotionService {
         headers: { 'Content-Type': 'application/json' },
       };
 
-      try {
-        const res = await instrumentedAxios.post<{ access_token?: string }>(
-          'notion',
-          url,
-          data,
-          options
-        );
-        if (res.data.access_token) {
-          resolve(res.data as { [key: string]: string });
-        }
-      } catch (err) {
-        console.info('Get access data failed');
-        console.error(err);
-        reject(err);
-      }
+      instrumentedAxios
+        .post<{ access_token?: string }>('notion', url, data, options)
+        .then((res) => {
+          if (res.data.access_token) {
+            resolve(res.data as { [key: string]: string });
+          }
+        })
+        .catch((err) => {
+          console.info('Get access data failed');
+          console.error(err);
+          reject(err);
+        });
     });
   }
 

--- a/src/services/NotionService/helpers/renderTextChildren.test.tsx
+++ b/src/services/NotionService/helpers/renderTextChildren.test.tsx
@@ -172,3 +172,29 @@ describe('renderTextChildren — inline colors', () => {
     expect(result).toContain('<strong>');
   });
 });
+
+describe('renderTextChildren — multi-item concatenation', () => {
+  it('joins plain text and an inline equation in order with no separator', () => {
+    const result = renderTextChildren(
+      [makeText('alpha'), makeEquation('E = mc^2'), makeText('omega')],
+      defaultSettings
+    );
+
+    expect(result).toBe('alpha\\(E = mc^2\\)omega');
+    expect(result).not.toContain('[object Object]');
+  });
+
+  it('joins a markup-rendered annotated item with plain items as strings', () => {
+    const result = renderTextChildren(
+      [
+        makeText('before '),
+        makeText('bold', { bold: true }),
+        makeText(' after'),
+      ],
+      defaultSettings
+    );
+
+    expect(result).toBe('before <strong>bold</strong> after');
+    expect(result).not.toContain('[object Object]');
+  });
+});

--- a/src/services/NotionService/helpers/renderTextChildren.tsx
+++ b/src/services/NotionService/helpers/renderTextChildren.tsx
@@ -43,6 +43,6 @@ export default function renderTextChildren(
 
       return `unsupported type: ${t.type}\n${JSON.stringify(t, null, 2)}`;
     })
-    .reduce((acc, curr) => acc + curr);
+    .reduce((acc, curr) => acc + curr, '');
   return preserveNewlinesIfApplicable(content, settings);
 }

--- a/src/services/SettingsService.test.ts
+++ b/src/services/SettingsService.test.ts
@@ -1,0 +1,26 @@
+import SettingsService from './SettingsService';
+import SettingsRepository from '../data_layer/SettingsRepository';
+
+function makeRepository(deleteImpl: jest.Mock): SettingsRepository {
+  return { delete: deleteImpl } as unknown as SettingsRepository;
+}
+
+describe('SettingsService.delete', () => {
+  it('resolves after delegating the deletion to the repository', async () => {
+    const del = jest.fn().mockResolvedValue(undefined);
+    const service = new SettingsService(makeRepository(del));
+
+    await expect(
+      service.delete('owner-1', 'object-9')
+    ).resolves.toBeUndefined();
+    expect(del).toHaveBeenCalledWith('owner-1', 'object-9');
+  });
+
+  it('rejects with the repository error when the deletion fails', async () => {
+    const failure = new Error('delete failed');
+    const del = jest.fn().mockRejectedValue(failure);
+    const service = new SettingsService(makeRepository(del));
+
+    await expect(service.delete('owner-1', 'object-9')).rejects.toBe(failure);
+  });
+});

--- a/src/services/SettingsService.ts
+++ b/src/services/SettingsService.ts
@@ -34,15 +34,8 @@ class SettingsService implements IServiceSettings {
     });
   }
 
-  delete(owner: string, id: string) {
-    return new Promise<void>(async (resolve, reject) => {
-      try {
-        await this.repository.delete(owner, id);
-        resolve();
-      } catch (error) {
-        reject(error);
-      }
-    });
+  async delete(owner: string, id: string): Promise<void> {
+    await this.repository.delete(owner, id);
   }
 
   getById(owner: string, id: string) {

--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
@@ -3419,5 +3419,50 @@ describe('SyncNotionPageToRacUseCase', () => {
       expect(result.created).toBe(1);
       expect(result.errors).toEqual([]);
     });
+
+    test('logs a rejected telemetry write once and keeps it out of the error feed', async () => {
+      const repos = makeRepos();
+      const ac = makeAnkiConnectStub();
+      const unsupportedRepo = makeUnsupportedRepo();
+      const failure = new Error('db down');
+      unsupportedRepo.record.mockRejectedValue(failure);
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const useCase = new SyncNotionPageToRacUseCase(
+        repos.clients,
+        repos.mappings,
+        repos.conflicts,
+        repos.subscriptions,
+        repos.logs,
+        repos.notionRepo,
+        () => ac,
+        () => async () => [],
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        unsupportedRepo
+      );
+
+      const result = expectSyncResult(
+        await useCase.execute({
+          owner: 42,
+          notionPageId: 'page-id',
+          trigger: 'polling',
+        })
+      );
+      await new Promise((resolve) => setImmediate(resolve));
+
+      const recordFailureLogs = errorSpy.mock.calls.filter(
+        (call) =>
+          call[0] === '[ankify-sync] failed to record unsupported blocks'
+      );
+      expect(result.errors).toEqual([]);
+      expect(recordFailureLogs).toHaveLength(1);
+      expect(recordFailureLogs[0][1]).toBe(failure);
+      errorSpy.mockRestore();
+    });
   });
 });

--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.ts
@@ -1127,16 +1127,9 @@ export class SyncNotionPageToRacUseCase {
     if (this.unsupportedBlockRepo == null || types.length === 0) {
       return;
     }
-    try {
-      void this.unsupportedBlockRepo.record(types).catch((error) => {
-        console.error(
-          '[ankify-sync] failed to record unsupported blocks',
-          error
-        );
-      });
-    } catch (error) {
+    void this.unsupportedBlockRepo.record(types).catch((error) => {
       console.error('[ankify-sync] failed to record unsupported blocks', error);
-    }
+    });
   }
 
   private async persistSyncLog(


### PR DESCRIPTION
## What

Closes the five behaviour-sensitive Sonar findings deliberately deferred from the #3930 sweep and recorded in the ledger issue #3935. Each finding is its own commit, each gated by a characterizing test written against the unchanged code first, then re-run after the minimal fix to prove the observable behaviour did not move.

## Why

Closes #3935. These were held because "adding await changes timing and error propagation" — the mechanical rule fix risked changing behaviour 6,080 tests would not catch. Pinning current behaviour before touching each one lets us clear the debt without that risk.

## How — per-finding outcomes

| Finding | Location | Outcome |
|---|---|---|
| `typescript:S6544` | `EmailService.ts` `sendConversionLinkEmail` | **Fixed.** `IEmailService` declared the method `: void` while the impl is `async` (returns `Promise<void>`). Aligned the interface to `Promise<void>` and made the `UnimplementedEmailService` stub `async`. Callers already `await` it, so runtime is unchanged. |
| `typescript:S6544` | `NotionService.ts` `getAccessData` | **Fixed.** De-async'd the `new Promise(async …)` executor into a `.then/.catch` chain. Preserves the sync throw on misconfig, resolve-on-token, reject-on-failure, **and** the pre-existing pending-forever edge when Notion returns no `access_token`. |
| `typescript:S6544` | `SettingsService.ts` `delete` | **Fixed.** The `new Promise(async …)` + try/catch only forwarded resolve/reject and every path settles, so it collapses to a plain `async` method awaiting the repository. Error propagation unchanged. |
| `typescript:S4822` | `SyncNotionPageToRacUseCase.ts` `recordUnsupportedBlocks` | **Fixed.** The outer try/catch around a voided, `.catch`-handled promise is dead code — `record()` is `async`, so it never throws synchronously. Removed it. The fence in the ledger (#3926, memory growth) is now **closed**, so the guard is lifted. |
| `typescript:S6959` | `renderTextChildren.tsx` reduce | **Fixed.** Seeded the reduce with `''`. The ledger's deferral reason ("mixed JSX/string array → `''` would stringify to `[object Object]`") does **not** hold for this code: every `map` branch returns a `string` (`renderInlineEquation` and `renderToStaticMarkup` both return `string`), so the array is homogeneous strings and the seed is a no-op for all reachable inputs; the empty-array case is already guarded upstream. Verified with a characterizing test. |

None stayed deferred; none was already gone. Line numbers had drifted since 2026-07-30 (each pattern was located by content). The `getAccessData` test file already existed on `main` — its two original tests are preserved and the three characterizations are appended.

## Measuring success

SonarCloud PR decoration should show these five findings (3× S6544, 1× S4822, 1× S6959) no longer open on the PR scan, and `main`'s next branch analysis drops them from the CRITICAL/MAJOR list. The characterizing tests stay green in CI.

## Testing

Full server suite: `pnpm test --maxWorkers=2` → 684 suites passed, 9 failed, 2 skipped; 6531 tests passed, 74 failed, 25 skipped, 7 todo. Every one of the 9 failing suites is a documented environmental failure — 8 Python-venv suites (`DeckParser.*`, `golden`, canaries → `PythonExitError`) and 1 `getPageCount` pdfinfo suite; verified each failure is `PythonExitError`/pdfinfo, zero content-assertion diffs. `npx tsc -p . --noEmit` clean (the interface change breaks no `jest.fn()` mock). `pnpm format:check` clean.

- Unit tests added/extended:
  - `EmailService.test.ts` — awaitable delivery contract + unimplemented stub resolves without delivering.
  - `NotionService.getAccessData.test.ts` — resolve payload, reject-with-error, stays-pending-without-token.
  - `SettingsService.test.ts` (new) — resolve-on-success, reject-with-repository-error.
  - `SyncNotionPageToRacUseCase.test.ts` — rejected telemetry write logged once and kept out of the error feed.
  - `renderTextChildren.test.tsx` — multi-item concatenation incl. a markup-rendered annotated item, no `[object Object]`.

Sonar: not run locally; PR decoration will report — it should show these findings closing.

## Browser check

Server-only refactors (no `web/src` changes; `renderTextChildren.tsx` is a server-side Notion render helper). No browser check applicable.

## Changelog

No entry — internal Sonar-debt refactors, no user-visible behavior change.

## Risks

Low. Each change is behaviour-preserving and pinned by a test that passed against the unchanged code first. The one path worth naming is the NotionService OAuth exchange — the de-async keeps the exact resolve/reject/throw semantics including the pre-existing pending-forever edge, which is now covered by a test.

## Residual items #3935 also tracked (NOT in this PR — surfaced so nothing vanishes on close)

- **UI-only** `tssecurity:S5144`/`S7044` on `instrumentedAxios.ts` — cannot be fixed or waived from the repo; Alexander marks them False Positive in the SonarCloud UI.
- **MINOR, arguably Won't Fix** — `S5332` (sendmail transport, local delivery), `S4036` (`execFileSync('git')` PATH search), `S4158` (empty array in a dev-only mock script).
- **Standing smell backlog** — 45× `S3776` cognitive complexity (ledger says leave alone), 5× `S1186` `setupTests.ts` stubs (needs an exclusion), 3× `S4123` `await`-on-non-Promise (ledger flags as "worth investigating" — not touched here; deserves its own read), 1× `S3735`, 1× `S2004`.

Closing #3935 per the task drops tracking for the above; recommend re-filing a trimmed ledger for the standing backlog if it should survive.

## Goal alignment

None — internal. Sonar-debt cleanup on the Notion OAuth, settings, ankify-sync, and conversion-render paths keeps those files easy to change; no funnel or revenue metric moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbQZzLbjr2apKHQC7orhhw
