### PR TITLE
fix: recover unclaimed anonymous passes with email and ops grant

### DIFF
--- a/migrations/20261009000000_pass_claim_tokens_nullable_user.js
+++ b/migrations/20261009000000_pass_claim_tokens_nullable_user.js
@@ -11,6 +11,9 @@ exports.up = async (knex) => {
   });
 };
 
+// Rolling back is only viable before the first anonymous-claim email has run:
+// once a NULL-user token row exists, re-adding NOT NULL fails. Delete or
+// backfill those rows first if a rollback is ever genuinely needed.
 exports.down = async (knex) => {
   await knex.schema.alterTable('pass_claim_tokens', (table) => {
     table.integer('user_id').notNullable().alter();

--- a/migrations/20261009000000_pass_claim_tokens_nullable_user.js
+++ b/migrations/20261009000000_pass_claim_tokens_nullable_user.js
@@ -1,0 +1,18 @@
+// A pass_claim_token is now issued at webhook fulfillment for anonymous Day/Week
+// pass buyers, before any account exists — the emailed claim link resolves the
+// account only when the buyer signs in and clicks. The column was NOT NULL
+// because every prior issue path (self-serve /account claim, win-back) already
+// had a logged-in user. Dropping the constraint lets a fulfillment token carry
+// no user until it is confirmed; the confirm path claims the pass for whoever
+// is signed in, so user_id on the token is purely the "issued to" record.
+exports.up = async (knex) => {
+  await knex.schema.alterTable('pass_claim_tokens', (table) => {
+    table.integer('user_id').nullable().alter();
+  });
+};
+
+exports.down = async (knex) => {
+  await knex.schema.alterTable('pass_claim_tokens', (table) => {
+    table.integer('user_id').notNullable().alter();
+  });
+};

--- a/src/controllers/NotionController.test.ts
+++ b/src/controllers/NotionController.test.ts
@@ -71,6 +71,7 @@ function buildEmailService(): IEmailService {
     sendNotionReconnectEmail: jest.fn().mockResolvedValue(undefined),
     sendSubscriptionClaimConfirmation: jest.fn().mockResolvedValue(undefined),
     sendPassClaimConfirmation: jest.fn().mockResolvedValue(undefined),
+    sendAnonymousPassClaimEmail: jest.fn().mockResolvedValue(undefined),
     sendContactConfirmationEmail: jest.fn().mockResolvedValue(undefined),
     sendPriceLockInEmail: jest.fn().mockResolvedValue(undefined),
     sendSubscriptionRecoveryEmail: jest.fn().mockResolvedValue(undefined),

--- a/src/controllers/OpsController.test.ts
+++ b/src/controllers/OpsController.test.ts
@@ -699,9 +699,7 @@ describe('OpsController.grantUnclaimedPass', () => {
   });
 
   it('returns 500 when the use case is not configured', async () => {
-    const controller = new OpsController(
-      {} as unknown as GetOpsMetricsUseCase
-    );
+    const controller = new OpsController({} as unknown as GetOpsMetricsUseCase);
     const req = {
       body: { anonymousPassId: 55, email: 'buyer@example.com' },
     } as unknown as express.Request;

--- a/src/controllers/OpsController.test.ts
+++ b/src/controllers/OpsController.test.ts
@@ -9,6 +9,7 @@ import { GetLandingPageYieldUseCase } from '../usecases/ops/GetLandingPageYieldU
 import { GetCustomerSignalsUseCase } from '../usecases/ops/GetCustomerSignalsUseCase';
 import { GetPassUnlockMonitorUseCase } from '../usecases/ops/GetPassUnlockMonitorUseCase';
 import { GetCancelFunnelUseCase } from '../usecases/ops/GetCancelFunnelUseCase';
+import { GrantUnclaimedPassUseCase } from '../usecases/passes/GrantUnclaimedPassUseCase';
 
 const buildRes = () => {
   const json = jest.fn();
@@ -590,5 +591,124 @@ describe('OpsController.getCancelFunnel', () => {
 
     expect(res.status).toHaveBeenCalledWith(500);
     errSpy.mockRestore();
+  });
+});
+
+describe('OpsController.grantUnclaimedPass', () => {
+  const buildController = (execute: jest.Mock) =>
+    new OpsController(
+      {} as unknown as GetOpsMetricsUseCase,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { execute } as unknown as GrantUnclaimedPassUseCase
+    );
+
+  it('returns 200 with the grant details on success', async () => {
+    const expiresAt = new Date('2026-08-21T12:00:00Z');
+    const execute = jest.fn().mockResolvedValue({
+      success: true,
+      userId: 42,
+      kind: '24h',
+      expiresAt,
+    });
+    const controller = buildController(execute);
+    const req = {
+      body: { anonymousPassId: 55, email: 'buyer@example.com' },
+    } as unknown as express.Request;
+    const res = buildRes();
+
+    await controller.grantUnclaimedPass(req, res);
+
+    expect(execute).toHaveBeenCalledWith({
+      anonymousPassId: 55,
+      email: 'buyer@example.com',
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      granted: true,
+      userId: 42,
+      kind: '24h',
+      expiresAt: expiresAt.toISOString(),
+    });
+  });
+
+  it('returns 404 when no pass matches the id', async () => {
+    const execute = jest
+      .fn()
+      .mockResolvedValue({ success: false, reason: 'pass_not_found' });
+    const controller = buildController(execute);
+    const req = {
+      body: { anonymousPassId: 999, email: 'buyer@example.com' },
+    } as unknown as express.Request;
+    const res = buildRes();
+
+    await controller.grantUnclaimedPass(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('returns 409 when the pass is already claimed by another account', async () => {
+    const execute = jest
+      .fn()
+      .mockResolvedValue({ success: false, reason: 'already_claimed' });
+    const controller = buildController(execute);
+    const req = {
+      body: { anonymousPassId: 55, email: 'buyer@example.com' },
+    } as unknown as express.Request;
+    const res = buildRes();
+
+    await controller.grantUnclaimedPass(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(409);
+  });
+
+  it('returns 400 without calling the use case on a missing pass id', async () => {
+    const execute = jest.fn();
+    const controller = buildController(execute);
+    const req = {
+      body: { email: 'buyer@example.com' },
+    } as unknown as express.Request;
+    const res = buildRes();
+
+    await controller.grantUnclaimedPass(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 when the use case is not configured', async () => {
+    const controller = new OpsController(
+      {} as unknown as GetOpsMetricsUseCase
+    );
+    const req = {
+      body: { anonymousPassId: 55, email: 'buyer@example.com' },
+    } as unknown as express.Request;
+    const res = buildRes();
+
+    await controller.grantUnclaimedPass(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
   });
 });

--- a/src/controllers/OpsController.test.ts
+++ b/src/controllers/OpsController.test.ts
@@ -621,7 +621,6 @@ describe('OpsController.grantUnclaimedPass', () => {
       undefined,
       undefined,
       undefined,
-      undefined,
       { execute } as unknown as GrantUnclaimedPassUseCase
     );
 

--- a/src/controllers/OpsController.ts
+++ b/src/controllers/OpsController.ts
@@ -27,6 +27,7 @@ import { GetPassUnlockMonitorUseCase } from '../usecases/ops/GetPassUnlockMonito
 import { GetPaidValueMonitorUseCase } from '../usecases/ops/GetPaidValueMonitorUseCase';
 import { GetAiUsageMetricsUseCase } from '../usecases/ops/GetAiUsageMetricsUseCase';
 import { SetChatAttachmentsLifecycleUseCase } from '../usecases/ops/SetChatAttachmentsLifecycleUseCase';
+import { GrantUnclaimedPassUseCase } from '../usecases/passes/GrantUnclaimedPassUseCase';
 
 class OpsController {
   constructor(
@@ -53,7 +54,8 @@ class OpsController {
     private readonly getCancelFunnelUseCase?: GetCancelFunnelUseCase,
     private readonly getPaidValueMonitorUseCase?: GetPaidValueMonitorUseCase,
     private readonly getAiUsageMetricsUseCase?: GetAiUsageMetricsUseCase,
-    private readonly setChatAttachmentsLifecycleUseCase?: SetChatAttachmentsLifecycleUseCase
+    private readonly setChatAttachmentsLifecycleUseCase?: SetChatAttachmentsLifecycleUseCase,
+    private readonly grantUnclaimedPassUseCase?: GrantUnclaimedPassUseCase
   ) {}
 
   async getAiUsage(req: express.Request, res: express.Response) {
@@ -88,6 +90,56 @@ class OpsController {
     } catch (error) {
       console.error('[ops] setChatAttachmentsLifecycle failed', error);
       res.status(500).json({ message: 'Failed to apply the lifecycle rule' });
+    }
+  }
+
+  async grantUnclaimedPass(req: express.Request, res: express.Response) {
+    if (this.grantUnclaimedPassUseCase == null) {
+      res.status(500).json({ message: 'Pass grant not configured' });
+      return;
+    }
+    const { anonymousPassId, email } = req.body as {
+      anonymousPassId?: unknown;
+      email?: unknown;
+    };
+    const passId = Number(anonymousPassId);
+    const trimmedEmail = typeof email === 'string' ? email.trim() : '';
+    if (!Number.isInteger(passId) || passId <= 0) {
+      res.status(400).json({ message: 'A valid pass id is required.' });
+      return;
+    }
+    if (!trimmedEmail.includes('@')) {
+      res.status(400).json({ message: 'A valid email is required.' });
+      return;
+    }
+    try {
+      const outcome = await this.grantUnclaimedPassUseCase.execute({
+        anonymousPassId: passId,
+        email: trimmedEmail,
+      });
+      if (outcome.success) {
+        res.status(200).json({
+          granted: true,
+          userId: outcome.userId,
+          kind: outcome.kind,
+          expiresAt: outcome.expiresAt.toISOString(),
+        });
+        return;
+      }
+      if (outcome.reason === 'pass_not_found') {
+        res.status(404).json({ message: 'No pass found for that id.' });
+        return;
+      }
+      if (outcome.reason === 'user_not_found') {
+        res.status(404).json({ message: 'No account found for that email.' });
+        return;
+      }
+      res
+        .status(409)
+        .json({ message: 'That pass is already claimed by another account.' });
+    } catch (error) {
+      console.error('[ops] grantUnclaimedPass failed', error);
+      res.status(500).json({ message: 'Failed to grant the pass.' });
     }
   }
 

--- a/src/controllers/SubscriptionClaimController.ts
+++ b/src/controllers/SubscriptionClaimController.ts
@@ -7,6 +7,7 @@ import { passKindLabel } from '../usecases/passes/passKindLabel';
 import { emailHash } from '../lib/emailHash';
 import hmacToken from '../lib/misc/hmacToken';
 import { resolveClientIp } from '../lib/rateLimit/ipHelpers';
+import { track } from '../services/events/track';
 
 export class SubscriptionClaimController {
   constructor(
@@ -110,6 +111,10 @@ export class SubscriptionClaimController {
     );
 
     if (outcome.success) {
+      track('anonymous_pass_claimed', {
+        userId,
+        props: { kind: outcome.passKind, method: 'link' },
+      });
       res.status(200).json({
         kind: 'pass',
         passKind: passKindLabel(outcome.passKind),

--- a/src/data_layer/public/PassClaimTokens.ts
+++ b/src/data_layer/public/PassClaimTokens.ts
@@ -11,7 +11,7 @@ export type PassClaimTokensId = number & { __brand: 'public.pass_claim_tokens' }
 export default interface PassClaimTokens {
   id: PassClaimTokensId;
 
-  user_id: UsersId;
+  user_id: UsersId | null;
 
   anonymous_pass_id: AnonymousPassesId;
 
@@ -29,7 +29,7 @@ export interface PassClaimTokensInitializer {
   /** Default value: nextval('pass_claim_tokens_id_seq'::regclass) */
   id?: PassClaimTokensId;
 
-  user_id: UsersId;
+  user_id?: UsersId | null;
 
   anonymous_pass_id: AnonymousPassesId;
 
@@ -47,7 +47,7 @@ export interface PassClaimTokensInitializer {
 export interface PassClaimTokensMutator {
   id?: PassClaimTokensId;
 
-  user_id?: UsersId;
+  user_id?: UsersId | null;
 
   anonymous_pass_id?: AnonymousPassesId;
 

--- a/src/lib/storage/jobs/helpers/sendReEngagementEmails.test.ts
+++ b/src/lib/storage/jobs/helpers/sendReEngagementEmails.test.ts
@@ -21,6 +21,7 @@ function buildEmailService(): jest.Mocked<IEmailService> {
     sendNotionReconnectEmail: jest.fn().mockResolvedValue(undefined),
     sendSubscriptionClaimConfirmation: jest.fn().mockResolvedValue(undefined),
     sendPassClaimConfirmation: jest.fn().mockResolvedValue(undefined),
+    sendAnonymousPassClaimEmail: jest.fn().mockResolvedValue(undefined),
     sendContactConfirmationEmail: jest.fn().mockResolvedValue(undefined),
     sendPriceLockInEmail: jest.fn().mockResolvedValue(undefined),
     sendSubscriptionRecoveryEmail: jest.fn().mockResolvedValue(undefined),

--- a/src/routes/OpsRouter.ts
+++ b/src/routes/OpsRouter.ts
@@ -44,6 +44,7 @@ import { emailHash } from '../lib/emailHash';
 import { getEventsSink } from '../services/events/eventsSinkInstance';
 import { DeleteInactiveUsersUseCase } from '../usecases/ops/DeleteInactiveUsersUseCase';
 import { SetChatAttachmentsLifecycleUseCase } from '../usecases/ops/SetChatAttachmentsLifecycleUseCase';
+import { GrantUnclaimedPassUseCase } from '../usecases/passes/GrantUnclaimedPassUseCase';
 import { getDefaultEmailService } from '../services/EmailService/EmailService';
 import { UserVisibleErrorsRepository } from '../data_layer/UserVisibleErrorsRepository';
 import { JobsMetricsRepository } from '../data_layer/JobsMetricsRepository';
@@ -220,7 +221,13 @@ const OpsRouter = () => {
         repo: new AiUsageMetricsRepository(database),
       })
     ),
-    new SetChatAttachmentsLifecycleUseCase(new StorageHandler())
+    new SetChatAttachmentsLifecycleUseCase(new StorageHandler()),
+    new GrantUnclaimedPassUseCase(
+      new AnonymousPassRepository(database),
+      new UserPassRepository(database),
+      new UsersRepository(database),
+      getEventsSink()
+    )
   );
 
   /**
@@ -433,6 +440,43 @@ const OpsRouter = () => {
     '/api/ops/chat-attachments-lifecycle',
     RequireOpsAccess,
     (req, res) => controller.setChatAttachmentsLifecycle(req, res)
+  );
+
+  /**
+   * @swagger
+   * /api/ops/grant-unclaimed-pass:
+   *   post:
+   *     summary: Claim an anonymous Day/Week pass to an account with a fresh window
+   *     description: |
+   *       Attaches an unclaimed anonymous_passes row to the account matching the
+   *       given email and grants a user pass whose validity window starts now, so
+   *       a buyer whose checkout redirect never returned still gets the full
+   *       duration they paid for. Idempotent for the same account; 409 if the pass
+   *       is already claimed by a different account. Internal endpoint locked to
+   *       the ops owner — returns 404 for everyone else.
+   *     tags: [Ops]
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required: [anonymousPassId, email]
+   *             properties:
+   *               anonymousPassId: { type: integer }
+   *               email: { type: string }
+   *     responses:
+   *       200:
+   *         description: Pass granted — returns userId, kind, expiresAt
+   *       400:
+   *         description: Missing or invalid pass id or email
+   *       404:
+   *         description: Not the ops owner, or no pass/account found
+   *       409:
+   *         description: Pass already claimed by another account
+   */
+  router.post('/api/ops/grant-unclaimed-pass', RequireOpsAccess, (req, res) =>
+    controller.grantUnclaimedPass(req, res)
   );
 
   /**

--- a/src/routes/WebhookRouter.test.ts
+++ b/src/routes/WebhookRouter.test.ts
@@ -5,10 +5,14 @@ import { InMemoryUserPassRepository } from '../data_layer/UserPassRepository';
 import { InMemoryAnonymousPassRepository } from '../data_layer/AnonymousPassRepository';
 import { emailHash } from '../lib/emailHash';
 
+process.env.THE_HASHING_SECRET = 'test-secret-for-jest';
+
 const mockUpsert = jest.fn();
 const inMemoryRepo = new InMemoryUserPassRepository();
 
 const mockAnonInsert = jest.fn();
+const mockAnonFindBySessionId = jest.fn().mockResolvedValue(null);
+const mockPassClaimTokenInsert = jest.fn().mockResolvedValue({ id: 1 });
 const inMemoryAnonRepo = new InMemoryAnonymousPassRepository();
 
 const mockCustomersRetrieve = jest.fn();
@@ -62,6 +66,7 @@ jest.mock('../data_layer/AbandonedCheckoutRecoveryRepository', () => ({
 const mockSendAbandonedCheckoutRecoveryEmail = jest
   .fn()
   .mockResolvedValue(undefined);
+const mockSendAnonymousPassClaimEmail = jest.fn().mockResolvedValue(undefined);
 jest.mock('../services/EmailService/EmailService', () => ({
   getDefaultEmailService: jest.fn().mockReturnValue({
     sendAbandonedCheckoutRecoveryEmail: mockSendAbandonedCheckoutRecoveryEmail,
@@ -79,6 +84,7 @@ jest.mock('../services/EmailService/EmailService', () => ({
     sendNotionReconnectEmail: jest.fn().mockResolvedValue(undefined),
     sendSubscriptionClaimConfirmation: jest.fn().mockResolvedValue(undefined),
     sendPassClaimConfirmation: jest.fn().mockResolvedValue(undefined),
+    sendAnonymousPassClaimEmail: mockSendAnonymousPassClaimEmail,
     sendPriceLockInEmail: jest.fn().mockResolvedValue(undefined),
     sendSubscriptionRecoveryEmail: jest.fn().mockResolvedValue(undefined),
   }),
@@ -103,10 +109,20 @@ jest.mock('../data_layer/AnonymousPassRepository', () => {
   );
   return {
     __esModule: true,
-    default: jest.fn().mockImplementation(() => ({ insert: mockAnonInsert })),
+    default: jest.fn().mockImplementation(() => ({
+      insert: mockAnonInsert,
+      findBySessionId: mockAnonFindBySessionId,
+    })),
     InMemoryAnonymousPassRepository: AnonMem,
   };
 });
+
+jest.mock('../data_layer/PassClaimTokensRepository', () => ({
+  __esModule: true,
+  default: jest
+    .fn()
+    .mockImplementation(() => ({ insert: mockPassClaimTokenInsert })),
+}));
 
 const mockUpdatePatreonByEmail = jest.fn();
 const mockGetByEmail = jest.fn().mockResolvedValue(null);
@@ -346,6 +362,80 @@ describe('WebhookRouter — pass grant', () => {
         buyerEmailHash: emailHash('buyer@example.com'),
       })
     );
+  });
+
+  it('emails a claim link to the buyer when a newly granted anonymous pass has an email', async () => {
+    mockWebhookEvent = {
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          id: 'cs_anon_email',
+          amount_total: 400,
+          currency: 'usd',
+          customer: null,
+          payment_intent: 'pi_anon_email',
+          customer_details: { email: 'buyer@example.com' },
+          metadata: { pass_kind: '7d', pass_anonymous: '1' },
+        },
+      },
+    };
+    mockAnonFindBySessionId.mockResolvedValueOnce(null);
+    mockAnonInsert.mockResolvedValue({
+      id: 55,
+      stripe_session_id: 'cs_anon_email',
+      kind: '7d',
+      expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      payment_intent_id: 'pi_anon_email',
+    });
+
+    const res = await postWebhook();
+    expect(res.status).toBe(200);
+    expect(mockPassClaimTokenInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ user_id: null, anonymous_pass_id: 55 })
+    );
+    expect(mockSendAnonymousPassClaimEmail).toHaveBeenCalledWith(
+      'buyer@example.com',
+      expect.stringContaining('/account/claim?token='),
+      'Week Pass'
+    );
+  });
+
+  it('does not re-send the claim email when the anonymous pass already existed', async () => {
+    mockWebhookEvent = {
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          id: 'cs_anon_retry',
+          amount_total: 400,
+          currency: 'usd',
+          customer: null,
+          payment_intent: 'pi_anon_retry',
+          customer_details: { email: 'buyer@example.com' },
+          metadata: { pass_kind: '24h', pass_anonymous: '1' },
+        },
+      },
+    };
+    mockAnonFindBySessionId.mockResolvedValueOnce({
+      id: 55,
+      stripe_session_id: 'cs_anon_retry',
+      kind: '24h',
+      expires_at: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      payment_intent_id: 'pi_anon_retry',
+      claimed_by_user_id: null,
+      buyer_email_hash: null,
+    });
+    mockAnonInsert.mockResolvedValue({
+      id: 55,
+      stripe_session_id: 'cs_anon_retry',
+      kind: '24h',
+      expires_at: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      payment_intent_id: 'pi_anon_retry',
+    });
+
+    const res = await postWebhook();
+    expect(res.status).toBe(200);
+    expect(mockSendAnonymousPassClaimEmail).not.toHaveBeenCalled();
+    expect(mockPassClaimTokenInsert).not.toHaveBeenCalled();
   });
 
   it('returns 200 and skips anonymous insert when payment_intent is missing', async () => {

--- a/src/routes/WebhookRouter.ts
+++ b/src/routes/WebhookRouter.ts
@@ -17,6 +17,8 @@ import UserPassRepository, {
   type PassKind,
 } from '../data_layer/UserPassRepository';
 import AnonymousPassRepository from '../data_layer/AnonymousPassRepository';
+import PassClaimTokensRepository from '../data_layer/PassClaimTokensRepository';
+import { SendAnonymousPassClaimEmailUseCase } from '../usecases/passes/SendAnonymousPassClaimEmailUseCase';
 import TokenRepository from '../data_layer/TokenRepository';
 import AuthenticationService from '../services/AuthenticationService';
 import UsersService from '../services/UsersService';
@@ -69,6 +71,12 @@ const WebhooksRouter = () => {
   const recordErrorUseCase = new RecordUserVisibleErrorUseCase(
     new UserVisibleErrorsRepository(database)
   );
+  const sendAnonymousPassClaimEmailUseCase =
+    new SendAnonymousPassClaimEmailUseCase(
+      new PassClaimTokensRepository(database),
+      getDefaultEmailService(),
+      getEventsSink()
+    );
 
   /**
    * @swagger
@@ -388,6 +396,9 @@ const WebhooksRouter = () => {
                   session.customer_details?.email ??
                   session.customer_email ??
                   null;
+                const alreadyGranted = await anonRepo.findBySessionId(
+                  session.id
+                );
                 const granted = await anonRepo.insert({
                   stripeSessionId: session.id,
                   kind: passKind,
@@ -401,6 +412,20 @@ const WebhooksRouter = () => {
                   expires_at: granted.expires_at.toISOString(),
                   payment_intent_id_hash: hashToken(paymentIntentId),
                 });
+                if (alreadyGranted == null && buyerEmail != null) {
+                  try {
+                    await sendAnonymousPassClaimEmailUseCase.execute({
+                      anonymousPassId: granted.id,
+                      kind: passKind,
+                      buyerEmail,
+                    });
+                  } catch (claimEmailError) {
+                    console.error(
+                      'pass.claim_email.send_failed',
+                      claimEmailError
+                    );
+                  }
+                }
               } catch (passError) {
                 console.error('pass.webhook.grant_failed', passError);
               }

--- a/src/services/EmailService/EmailService.ts
+++ b/src/services/EmailService/EmailService.ts
@@ -20,6 +20,7 @@ import {
   SUBSCRIPTION_CLAIM_CONFIRMATION_TEMPLATE,
   CONTACT_CONFIRMATION_TEMPLATE,
   PASS_CLAIM_CONFIRMATION_TEMPLATE,
+  ANONYMOUS_PASS_CLAIM_TEMPLATE,
   SUBSCRIPTION_RECOVERY_TEMPLATE,
   SUBSCRIPTION_SCHEDULED_CANCELLATION_TEMPLATE,
   SUBSCRIPTION_RESUMING_SOON_TEMPLATE,
@@ -98,6 +99,11 @@ export interface IEmailService {
     claimUrl: string
   ): Promise<void>;
   sendPassClaimConfirmation(
+    to: string,
+    claimUrl: string,
+    passKindLabel: string
+  ): Promise<void>;
+  sendAnonymousPassClaimEmail(
     to: string,
     claimUrl: string,
     passKindLabel: string
@@ -636,6 +642,31 @@ export class EmailService implements IEmailService {
     }
   }
 
+  async sendAnonymousPassClaimEmail(
+    to: string,
+    claimUrl: string,
+    passKindLabel: string
+  ): Promise<void> {
+    const markup = ANONYMOUS_PASS_CLAIM_TEMPLATE.replace(
+      '{{link}}',
+      claimUrl
+    ).replace('{{passKind}}', passKindLabel);
+    const msg = {
+      to,
+      from: this.defaultSender,
+      subject: `Claim your 2anki ${passKindLabel}`,
+      text: `Thanks for buying a 2anki ${passKindLabel}. Claim it to your account here: ${claimUrl} — this link stays valid for 30 days, and the pass clock starts when you claim it.`,
+      html: markup,
+      replyTo: 'support@2anki.net',
+    };
+    try {
+      await this.deliver(msg);
+    } catch (error) {
+      console.error('Failed to send anonymous pass claim email:', error);
+      throw error;
+    }
+  }
+
   private loadCancellationsSent(): Set<string> {
     try {
       // Ensure .2anki directory exists
@@ -1075,6 +1106,14 @@ export class UnimplementedEmailService implements IEmailService {
     _passKindLabel: string
   ): Promise<void> {
     console.info('sendPassClaimConfirmation not handled');
+  }
+
+  async sendAnonymousPassClaimEmail(
+    _to: string,
+    _claimUrl: string,
+    _passKindLabel: string
+  ): Promise<void> {
+    console.info('sendAnonymousPassClaimEmail not handled');
   }
 
   async sendPriceLockInEmail(

--- a/src/services/EmailService/constants.ts
+++ b/src/services/EmailService/constants.ts
@@ -95,6 +95,11 @@ export const PASS_CLAIM_CONFIRMATION_TEMPLATE = fs.readFileSync(
   'utf8'
 );
 
+export const ANONYMOUS_PASS_CLAIM_TEMPLATE = fs.readFileSync(
+  path.join(EMAIL_TEMPLATES_DIRECTORY, 'anonymous-pass-claim.html'),
+  'utf8'
+);
+
 export const SUBSCRIPTION_RECOVERY_TEMPLATE = fs.readFileSync(
   path.join(EMAIL_TEMPLATES_DIRECTORY, 'subscription-recovery.html'),
   'utf8'

--- a/src/services/EmailService/templates/anonymous-pass-claim.html
+++ b/src/services/EmailService/templates/anonymous-pass-claim.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="color-scheme" content="light dark" />
+  <title>2anki.net — Claim your pass</title>
+  <style>
+    @media (prefers-color-scheme: dark) {
+      body { background-color: #1a1a1a !important; }
+      .email-card { background-color: #111827 !important; }
+      .email-header { color: #f9fafb !important; border-bottom-color: #374151 !important; }
+      .email-body p { color: #f9fafb !important; }
+      .email-cta a { background-color: #60a5fa !important; }
+      .email-footer { color: #6b7280 !important; border-top-color: #374151 !important; }
+    }
+    @media only screen and (max-width: 600px) {
+      .email-card { width: 100% !important; padding: 0 !important; }
+      .email-body { padding: 24px 16px !important; }
+      .email-header { padding: 16px !important; }
+      .email-footer { padding: 12px 16px !important; }
+    }
+  </style>
+</head>
+<body style="margin: 0; padding: 0; background-color: #f5f5f5; -webkit-font-smoothing: antialiased;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #f5f5f5;">
+    <tr>
+      <td align="center" style="padding: 32px 16px;">
+        <table role="presentation" class="email-card" cellpadding="0" cellspacing="0" style="max-width: 580px; width: 100%; background-color: #ffffff; border-radius: 8px;">
+          <tr>
+            <td class="email-header" style="text-align: center; padding: 24px; border-bottom: 1px solid #e5e7eb;">
+              <img src="https://2anki.net/mascot/navbar-logo.png" alt="2anki" width="120" style="display: block; margin: 0 auto; height: auto;" />
+            </td>
+          </tr>
+          <tr>
+            <td class="email-body" style="padding: 32px 24px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px; line-height: 1.6; color: #374151;">
+              <p style="margin: 0 0 16px;">Thanks for buying a 2anki {{passKind}}. Claim it to your account and the clock starts when you do, not before.</p>
+              <div style="text-align: center; margin: 24px 0;" class="email-cta">
+                <a href="{{link}}" style="display: inline-block; padding: 12px 32px; background-color: #3b82f6; color: #ffffff; text-decoration: none; border-radius: 6px; font-weight: 600; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px;">Claim your pass</a>
+              </div>
+              <p style="margin: 0 0 16px;">This link stays valid for 30 days. Sign in or create an account with any email when you click, and the pass attaches to that account.</p>
+              <p style="margin: 0;">The 2anki Team</p>
+            </td>
+          </tr>
+          <tr>
+            <td class="email-footer" style="text-align: center; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 12px; color: #9ca3af; padding: 16px 24px; border-top: 1px solid #e5e7eb;">
+              2anki.net — Turn what you study into Anki flashcards
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -118,6 +118,8 @@ export const KNOWN_EVENTS = new Set([
   'empty_back_notice_shown',
   'mindmap_export_excluded_nodes',
   'ai_usage_recorded',
+  'pass_claim_email_sent',
+  'anonymous_pass_claimed',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;

--- a/src/usecases/notion/MarkNotionTokenInvalidUseCase.test.ts
+++ b/src/usecases/notion/MarkNotionTokenInvalidUseCase.test.ts
@@ -47,6 +47,7 @@ function buildEmailService(
     sendNotionReconnectEmail: jest.fn().mockResolvedValue(undefined),
     sendSubscriptionClaimConfirmation: jest.fn().mockResolvedValue(undefined),
     sendPassClaimConfirmation: jest.fn().mockResolvedValue(undefined),
+    sendAnonymousPassClaimEmail: jest.fn().mockResolvedValue(undefined),
     sendContactConfirmationEmail: jest.fn().mockResolvedValue(undefined),
     sendPriceLockInEmail: jest.fn().mockResolvedValue(undefined),
     sendSubscriptionRecoveryEmail: jest.fn().mockResolvedValue(undefined),

--- a/src/usecases/ops/SendAbandonedCheckoutRecoveryOnExpiryUseCase.test.ts
+++ b/src/usecases/ops/SendAbandonedCheckoutRecoveryOnExpiryUseCase.test.ts
@@ -44,6 +44,7 @@ function makeEmailService(): jest.Mocked<IEmailService> {
     sendNotionReconnectEmail: jest.fn().mockResolvedValue(undefined),
     sendSubscriptionClaimConfirmation: jest.fn().mockResolvedValue(undefined),
     sendPassClaimConfirmation: jest.fn().mockResolvedValue(undefined),
+    sendAnonymousPassClaimEmail: jest.fn().mockResolvedValue(undefined),
     sendContactConfirmationEmail: jest.fn().mockResolvedValue(undefined),
     sendPriceLockInEmail: jest.fn().mockResolvedValue(undefined),
     sendSubscriptionRecoveryEmail: jest.fn().mockResolvedValue(undefined),

--- a/src/usecases/ops/SendInactivityWarningsUseCase.test.ts
+++ b/src/usecases/ops/SendInactivityWarningsUseCase.test.ts
@@ -27,6 +27,7 @@ function makeEmailService(
     sendNotionReconnectEmail: jest.fn().mockResolvedValue(undefined),
     sendSubscriptionClaimConfirmation: jest.fn().mockResolvedValue(undefined),
     sendPassClaimConfirmation: jest.fn().mockResolvedValue(undefined),
+    sendAnonymousPassClaimEmail: jest.fn().mockResolvedValue(undefined),
     sendContactConfirmationEmail: jest.fn().mockResolvedValue(undefined),
     sendPriceLockInEmail: jest.fn().mockResolvedValue(undefined),
     sendSubscriptionRecoveryEmail: jest.fn().mockResolvedValue(undefined),

--- a/src/usecases/ops/SendPassWinbackUseCase.test.ts
+++ b/src/usecases/ops/SendPassWinbackUseCase.test.ts
@@ -28,6 +28,7 @@ function makeEmailService(): jest.Mocked<IEmailService> {
     sendNotionReconnectEmail: jest.fn().mockResolvedValue(undefined),
     sendSubscriptionClaimConfirmation: jest.fn().mockResolvedValue(undefined),
     sendPassClaimConfirmation: jest.fn().mockResolvedValue(undefined),
+    sendAnonymousPassClaimEmail: jest.fn().mockResolvedValue(undefined),
     sendContactConfirmationEmail: jest.fn().mockResolvedValue(undefined),
     sendPriceLockInEmail: jest.fn().mockResolvedValue(undefined),
     sendSubscriptionRecoveryEmail: jest.fn().mockResolvedValue(undefined),

--- a/src/usecases/passes/ConfirmPassClaimUseCase.ts
+++ b/src/usecases/passes/ConfirmPassClaimUseCase.ts
@@ -48,7 +48,7 @@ export class ConfirmPassClaimUseCase {
 
     if (tokenRow.consumed_at != null) {
       await audit(
-        tokenRow.user_id === userId
+        tokenRow.user_id == null || tokenRow.user_id === userId
           ? 'pass_confirm_already_consumed'
           : 'pass_confirm_replay'
       );

--- a/src/usecases/passes/GrantUnclaimedPassUseCase.test.ts
+++ b/src/usecases/passes/GrantUnclaimedPassUseCase.test.ts
@@ -8,9 +8,7 @@ import type { EventsSink } from '../../services/events/EventsSink';
 
 function makeUsersRepo(id: number | null): UsersByEmailRepository {
   return {
-    getByEmail: jest
-      .fn()
-      .mockResolvedValue(id == null ? undefined : { id }),
+    getByEmail: jest.fn().mockResolvedValue(id == null ? undefined : { id }),
   };
 }
 

--- a/src/usecases/passes/GrantUnclaimedPassUseCase.test.ts
+++ b/src/usecases/passes/GrantUnclaimedPassUseCase.test.ts
@@ -1,0 +1,126 @@
+import {
+  GrantUnclaimedPassUseCase,
+  UsersByEmailRepository,
+} from './GrantUnclaimedPassUseCase';
+import { InMemoryAnonymousPassRepository } from '../../data_layer/AnonymousPassRepository';
+import { InMemoryUserPassRepository as UserPassMem } from '../../data_layer/UserPassRepository';
+import type { EventsSink } from '../../services/events/EventsSink';
+
+function makeUsersRepo(id: number | null): UsersByEmailRepository {
+  return {
+    getByEmail: jest
+      .fn()
+      .mockResolvedValue(id == null ? undefined : { id }),
+  };
+}
+
+function makeEventsSink(): Pick<EventsSink, 'record'> {
+  return { record: jest.fn() };
+}
+
+const NOW = new Date('2026-08-20T12:00:00Z');
+
+describe('GrantUnclaimedPassUseCase', () => {
+  it('claims the pass to the user and grants a fresh window from now', async () => {
+    const anonRepo = new InMemoryAnonymousPassRepository();
+    const pass = await anonRepo.insert({
+      stripeSessionId: 'cs_1',
+      kind: '24h',
+      expiresAt: new Date('2026-08-01T00:00:00Z'),
+      paymentIntentId: 'pi_1',
+    });
+    const userPassRepo = new UserPassMem();
+    const eventsSink = makeEventsSink();
+    const useCase = new GrantUnclaimedPassUseCase(
+      anonRepo,
+      userPassRepo,
+      makeUsersRepo(42),
+      eventsSink
+    );
+
+    const outcome = await useCase.execute(
+      { anonymousPassId: pass.id, email: 'buyer@example.com' },
+      NOW
+    );
+
+    expect(outcome).toEqual({
+      success: true,
+      userId: 42,
+      kind: '24h',
+      expiresAt: new Date(NOW.getTime() + 24 * 60 * 60 * 1000),
+    });
+    const claimedPass = await anonRepo.findById(pass.id);
+    expect(claimedPass?.claimed_by_user_id).toBe(42);
+    const activeUserPass = await userPassRepo.findActive(42, NOW);
+    expect(activeUserPass?.expires_at).toEqual(
+      new Date(NOW.getTime() + 24 * 60 * 60 * 1000)
+    );
+    expect(eventsSink.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'anonymous_pass_claimed',
+        user_id: 42,
+        props: { kind: '24h', method: 'ops' },
+      })
+    );
+  });
+
+  it('returns pass_not_found for a missing pass id', async () => {
+    const useCase = new GrantUnclaimedPassUseCase(
+      new InMemoryAnonymousPassRepository(),
+      new UserPassMem(),
+      makeUsersRepo(42)
+    );
+
+    const outcome = await useCase.execute(
+      { anonymousPassId: 999, email: 'buyer@example.com' },
+      NOW
+    );
+
+    expect(outcome).toEqual({ success: false, reason: 'pass_not_found' });
+  });
+
+  it('returns user_not_found when no account matches the email', async () => {
+    const anonRepo = new InMemoryAnonymousPassRepository();
+    const pass = await anonRepo.insert({
+      stripeSessionId: 'cs_2',
+      kind: '7d',
+      expiresAt: new Date('2026-08-01T00:00:00Z'),
+      paymentIntentId: 'pi_2',
+    });
+    const useCase = new GrantUnclaimedPassUseCase(
+      anonRepo,
+      new UserPassMem(),
+      makeUsersRepo(null)
+    );
+
+    const outcome = await useCase.execute(
+      { anonymousPassId: pass.id, email: 'nobody@example.com' },
+      NOW
+    );
+
+    expect(outcome).toEqual({ success: false, reason: 'user_not_found' });
+  });
+
+  it('returns already_claimed when the pass belongs to a different user', async () => {
+    const anonRepo = new InMemoryAnonymousPassRepository();
+    const pass = await anonRepo.insert({
+      stripeSessionId: 'cs_3',
+      kind: '24h',
+      expiresAt: new Date('2026-08-01T00:00:00Z'),
+      paymentIntentId: 'pi_3',
+    });
+    await anonRepo.claim(pass.id, 7);
+    const useCase = new GrantUnclaimedPassUseCase(
+      anonRepo,
+      new UserPassMem(),
+      makeUsersRepo(42)
+    );
+
+    const outcome = await useCase.execute(
+      { anonymousPassId: pass.id, email: 'buyer@example.com' },
+      NOW
+    );
+
+    expect(outcome).toEqual({ success: false, reason: 'already_claimed' });
+  });
+});

--- a/src/usecases/passes/GrantUnclaimedPassUseCase.ts
+++ b/src/usecases/passes/GrantUnclaimedPassUseCase.ts
@@ -1,0 +1,85 @@
+import type { IAnonymousPassRepository } from '../../data_layer/AnonymousPassRepository';
+import type {
+  IUserPassRepository,
+  PassKind,
+} from '../../data_layer/UserPassRepository';
+import type { EventsSink } from '../../services/events/EventsSink';
+
+const DURATION_MS: Record<'24h' | '7d', number> = {
+  '24h': 24 * 60 * 60 * 1000,
+  '7d': 7 * 24 * 60 * 60 * 1000,
+};
+
+export interface UsersByEmailRepository {
+  getByEmail(email: string): Promise<{ id: number | string } | undefined>;
+}
+
+export interface GrantUnclaimedPassInput {
+  anonymousPassId: number;
+  email: string;
+}
+
+export type GrantUnclaimedPassOutcome =
+  | { success: true; userId: number; kind: PassKind; expiresAt: Date }
+  | {
+      success: false;
+      reason: 'pass_not_found' | 'user_not_found' | 'already_claimed';
+    };
+
+export class GrantUnclaimedPassUseCase {
+  constructor(
+    private readonly anonPassRepo: IAnonymousPassRepository,
+    private readonly userPassRepo: IUserPassRepository,
+    private readonly usersRepo: UsersByEmailRepository,
+    private readonly eventsSink?: Pick<EventsSink, 'record'>
+  ) {}
+
+  async execute(
+    input: GrantUnclaimedPassInput,
+    now: Date = new Date()
+  ): Promise<GrantUnclaimedPassOutcome> {
+    const pass = await this.anonPassRepo.findById(input.anonymousPassId);
+    if (pass == null || (pass.kind !== '24h' && pass.kind !== '7d')) {
+      return { success: false, reason: 'pass_not_found' };
+    }
+
+    const user = await this.usersRepo.getByEmail(input.email);
+    if (user == null) {
+      return { success: false, reason: 'user_not_found' };
+    }
+    const userId = Number(user.id);
+
+    if (pass.claimed_by_user_id != null && pass.claimed_by_user_id !== userId) {
+      return { success: false, reason: 'already_claimed' };
+    }
+
+    if (pass.claimed_by_user_id == null) {
+      const claimed = await this.anonPassRepo.claim(pass.id, userId);
+      if (!claimed) {
+        return { success: false, reason: 'already_claimed' };
+      }
+    }
+
+    const expiresAt = new Date(now.getTime() + DURATION_MS[pass.kind]);
+    const granted = await this.userPassRepo.upsertWithAbsoluteExpiry(
+      userId,
+      pass.kind,
+      expiresAt,
+      pass.payment_intent_id
+    );
+
+    this.eventsSink?.record({
+      name: 'anonymous_pass_claimed',
+      user_id: userId,
+      props: { kind: pass.kind, method: 'ops' },
+      created_at: now,
+    });
+
+    return {
+      success: true,
+      userId,
+      kind: pass.kind,
+      expiresAt: granted.expires_at,
+    };
+  }
+}

--- a/src/usecases/passes/SendAnonymousPassClaimEmailUseCase.test.ts
+++ b/src/usecases/passes/SendAnonymousPassClaimEmailUseCase.test.ts
@@ -1,0 +1,107 @@
+import { SendAnonymousPassClaimEmailUseCase } from './SendAnonymousPassClaimEmailUseCase';
+import type { IPassClaimTokensRepository } from '../../data_layer/PassClaimTokensRepository';
+import type { IEmailService } from '../../services/EmailService/EmailService';
+import type { EventsSink } from '../../services/events/EventsSink';
+
+process.env.THE_HASHING_SECRET = 'test-secret-for-jest';
+
+function makeTokensRepo(): IPassClaimTokensRepository {
+  return {
+    insert: jest.fn().mockResolvedValue({ id: 1 }),
+    findByTokenHash: jest.fn().mockResolvedValue(null),
+    markConsumed: jest.fn().mockResolvedValue(undefined),
+    countRecentByUser: jest.fn().mockResolvedValue(0),
+  };
+}
+
+function makeEmailService(): IEmailService {
+  return {
+    sendAnonymousPassClaimEmail: jest.fn().mockResolvedValue(undefined),
+  } as unknown as IEmailService;
+}
+
+function makeEventsSink(): Pick<EventsSink, 'record'> {
+  return { record: jest.fn() };
+}
+
+describe('SendAnonymousPassClaimEmailUseCase', () => {
+  it('issues an unbound claim token and emails the buyer a claim link', async () => {
+    const tokensRepo = makeTokensRepo();
+    const emailService = makeEmailService();
+    const eventsSink = makeEventsSink();
+    const useCase = new SendAnonymousPassClaimEmailUseCase(
+      tokensRepo,
+      emailService,
+      eventsSink,
+      'https://2anki.net'
+    );
+
+    await useCase.execute({
+      anonymousPassId: 7,
+      kind: '24h',
+      buyerEmail: 'buyer@example.com',
+    });
+
+    expect(tokensRepo.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ user_id: null, anonymous_pass_id: 7 })
+    );
+    const tokenArg = (tokensRepo.insert as jest.Mock).mock.calls[0][0];
+    expect(typeof tokenArg.token_hash).toBe('string');
+    expect(tokenArg.token_hash.length).toBeGreaterThan(0);
+    expect(tokenArg.expires_at.getTime()).toBeGreaterThan(
+      Date.now() + 20 * 24 * 60 * 60 * 1000
+    );
+
+    expect(emailService.sendAnonymousPassClaimEmail).toHaveBeenCalledWith(
+      'buyer@example.com',
+      expect.stringContaining('/account/claim?token='),
+      'Day Pass'
+    );
+    const url = (emailService.sendAnonymousPassClaimEmail as jest.Mock).mock
+      .calls[0][1] as string;
+    expect(url).toContain('kind=pass');
+  });
+
+  it('records a pass_claim_email_sent event with the pass kind', async () => {
+    const eventsSink = makeEventsSink();
+    const useCase = new SendAnonymousPassClaimEmailUseCase(
+      makeTokensRepo(),
+      makeEmailService(),
+      eventsSink,
+      'https://2anki.net'
+    );
+
+    await useCase.execute({
+      anonymousPassId: 3,
+      kind: '7d',
+      buyerEmail: 'buyer@example.com',
+    });
+
+    expect(eventsSink.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'pass_claim_email_sent',
+        props: { kind: '7d' },
+      })
+    );
+  });
+
+  it('does nothing when the buyer email is not a valid address', async () => {
+    const tokensRepo = makeTokensRepo();
+    const emailService = makeEmailService();
+    const useCase = new SendAnonymousPassClaimEmailUseCase(
+      tokensRepo,
+      emailService,
+      makeEventsSink(),
+      'https://2anki.net'
+    );
+
+    await useCase.execute({
+      anonymousPassId: 9,
+      kind: '24h',
+      buyerEmail: '',
+    });
+
+    expect(tokensRepo.insert).not.toHaveBeenCalled();
+    expect(emailService.sendAnonymousPassClaimEmail).not.toHaveBeenCalled();
+  });
+});

--- a/src/usecases/passes/SendAnonymousPassClaimEmailUseCase.ts
+++ b/src/usecases/passes/SendAnonymousPassClaimEmailUseCase.ts
@@ -1,0 +1,54 @@
+import crypto from 'node:crypto';
+import type { IEmailService } from '../../services/EmailService/EmailService';
+import type { IPassClaimTokensRepository } from '../../data_layer/PassClaimTokensRepository';
+import type { AnonymousPassesId } from '../../data_layer/public/AnonymousPasses';
+import type { EventsSink } from '../../services/events/EventsSink';
+import type { PassKind } from '../../data_layer/UserPassRepository';
+import hmacToken from '../../lib/misc/hmacToken';
+import { passKindLabel } from './passKindLabel';
+
+const CLAIM_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+export interface SendAnonymousPassClaimEmailInput {
+  anonymousPassId: number;
+  kind: PassKind;
+  buyerEmail: string;
+}
+
+export class SendAnonymousPassClaimEmailUseCase {
+  constructor(
+    private readonly tokensRepo: IPassClaimTokensRepository,
+    private readonly emailService: IEmailService,
+    private readonly eventsSink?: Pick<EventsSink, 'record'>,
+    private readonly domain: string = process.env.DOMAIN ?? 'https://2anki.net'
+  ) {}
+
+  async execute(input: SendAnonymousPassClaimEmailInput): Promise<void> {
+    const trimmedEmail = input.buyerEmail.trim();
+    if (!trimmedEmail.includes('@')) {
+      return;
+    }
+
+    const now = new Date();
+    const rawToken = crypto.randomUUID();
+    await this.tokensRepo.insert({
+      user_id: null,
+      anonymous_pass_id: input.anonymousPassId as AnonymousPassesId,
+      token_hash: hmacToken(rawToken),
+      expires_at: new Date(now.getTime() + CLAIM_TOKEN_TTL_MS),
+    });
+
+    const claimUrl = `${this.domain}/account/claim?token=${encodeURIComponent(rawToken)}&kind=pass`;
+    await this.emailService.sendAnonymousPassClaimEmail(
+      trimmedEmail,
+      claimUrl,
+      passKindLabel(input.kind)
+    );
+
+    this.eventsSink?.record({
+      name: 'pass_claim_email_sent',
+      props: { kind: input.kind },
+      created_at: now,
+    });
+  }
+}

--- a/src/usecases/subscriptions/ClaimSubscriptionUseCase.test.ts
+++ b/src/usecases/subscriptions/ClaimSubscriptionUseCase.test.ts
@@ -63,6 +63,7 @@ const makeEmailService = (
   sendNotionReconnectEmail: jest.fn().mockResolvedValue(undefined),
   sendSubscriptionClaimConfirmation: jest.fn().mockResolvedValue(undefined),
   sendPassClaimConfirmation: jest.fn().mockResolvedValue(undefined),
+  sendAnonymousPassClaimEmail: jest.fn().mockResolvedValue(undefined),
   sendContactConfirmationEmail: jest.fn().mockResolvedValue(undefined),
   sendPriceLockInEmail: jest.fn().mockResolvedValue(undefined),
   sendSubscriptionRecoveryEmail: jest.fn().mockResolvedValue(undefined),

--- a/web/src/lib/analytics/events.ts
+++ b/web/src/lib/analytics/events.ts
@@ -87,6 +87,8 @@ export const KNOWN_EVENTS = new Set([
   'subscription_pause_offer_declined',
   'language_changed',
   'card_style_selected',
+  'pass_claim_email_sent',
+  'anonymous_pass_claimed',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;

--- a/web/src/pages/OpsPage/CommandsTab.tsx
+++ b/web/src/pages/OpsPage/CommandsTab.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import sharedStyles from '../../styles/shared.module.css';
 import styles from './OpsPage.module.css';
 import { syncStripeSubscriptions } from './syncStripeSubscriptions';
+import { grantUnclaimedPass } from './grantUnclaimedPass';
 import { setChatAttachmentsLifecycle } from './setChatAttachmentsLifecycle';
 import { sendPassWinback } from './sendPassWinback';
 import {
@@ -66,6 +67,10 @@ export default function CommandsTab() {
   const [winbackCampaign, setWinbackCampaign] = useState('');
   const [winbackStatus, setWinbackStatus] = useState<Status>('idle');
   const [winbackMessage, setWinbackMessage] = useState('');
+  const [passId, setPassId] = useState('');
+  const [passEmail, setPassEmail] = useState('');
+  const [passStatus, setPassStatus] = useState<Status>('idle');
+  const [passMessage, setPassMessage] = useState('');
 
   const runWinback = async (dryRun: boolean) => {
     const campaign = winbackCampaign.trim();
@@ -90,6 +95,33 @@ export default function CommandsTab() {
       setWinbackMessage(
         error instanceof Error ? error.message : 'Unknown error'
       );
+    }
+  };
+
+  const runGrantPass = async () => {
+    const id = Number(passId.trim());
+    const email = passEmail.trim();
+    if (!Number.isInteger(id) || id <= 0) {
+      setPassStatus('error');
+      setPassMessage('Enter a numeric pass id first.');
+      return;
+    }
+    if (!email.includes('@')) {
+      setPassStatus('error');
+      setPassMessage('Enter the account email first.');
+      return;
+    }
+    setPassStatus('loading');
+    setPassMessage('');
+    try {
+      const result = await grantUnclaimedPass(id, email);
+      setPassStatus('success');
+      setPassMessage(
+        `Granted a ${result.kind} pass to account ${result.userId}, valid until ${new Date(result.expiresAt).toLocaleString()}.`
+      );
+    } catch (error) {
+      setPassStatus('error');
+      setPassMessage(error instanceof Error ? error.message : 'Unknown error');
     }
   };
 
@@ -195,6 +227,54 @@ export default function CommandsTab() {
       <p className={styles.panelSubtitle}>
         Manual ops actions. Run dry-run first to validate counts before sending.
       </p>
+
+      <section className={`${sharedStyles.surface} ${styles.card}`}>
+      <section className={`${sharedStyles.surface} ${styles.card}`}>
+        <h2 className={styles.cardTitle}>Grant unclaimed pass</h2>
+        <p className={styles.panelSubtitle}>
+          Attaches an unclaimed anonymous pass to an account by email and grants
+          the full duration from now — for a buyer whose checkout redirect never
+          returned. Find the pass id in the pass unlock monitor. Idempotent for
+          the same account.
+        </p>
+        <div className={styles.controls}>
+          <input
+            type="number"
+            aria-label="Anonymous pass id"
+            placeholder="Pass id"
+            className={styles.textInput}
+            value={passId}
+            onChange={(e) => setPassId(e.target.value)}
+          />
+          <input
+            type="email"
+            aria-label="Account email"
+            placeholder="name@example.com"
+            className={styles.textInput}
+            value={passEmail}
+            onChange={(e) => setPassEmail(e.target.value)}
+          />
+          <button
+            type="button"
+            className={sharedStyles.btnSmall}
+            onClick={() => runGrantPass()}
+            disabled={passStatus === 'loading'}
+          >
+            {passStatus === 'loading' ? 'Working…' : 'Grant pass'}
+          </button>
+        </div>
+      </section>
+
+      {passStatus === 'success' && passMessage && (
+        <div className={`${sharedStyles.alertSuccess} ${styles.banner}`}>
+          {passMessage}
+        </div>
+      )}
+      {passStatus === 'error' && passMessage && (
+        <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>
+          {passMessage}
+        </div>
+      )}
 
       <section className={`${sharedStyles.surface} ${styles.card}`}>
         <h2 className={styles.cardTitle}>Inactivity warnings</h2>

--- a/web/src/pages/OpsPage/CommandsTab.tsx
+++ b/web/src/pages/OpsPage/CommandsTab.tsx
@@ -229,7 +229,6 @@ export default function CommandsTab() {
       </p>
 
       <section className={`${sharedStyles.surface} ${styles.card}`}>
-      <section className={`${sharedStyles.surface} ${styles.card}`}>
         <h2 className={styles.cardTitle}>Grant unclaimed pass</h2>
         <p className={styles.panelSubtitle}>
           Attaches an unclaimed anonymous pass to an account by email and grants

--- a/web/src/pages/OpsPage/grantUnclaimedPass.ts
+++ b/web/src/pages/OpsPage/grantUnclaimedPass.ts
@@ -1,0 +1,25 @@
+export interface GrantUnclaimedPassResponse {
+  granted: boolean;
+  userId: number;
+  kind: string;
+  expiresAt: string;
+}
+
+export async function grantUnclaimedPass(
+  anonymousPassId: number,
+  email: string
+): Promise<GrantUnclaimedPassResponse> {
+  const response = await fetch('/api/ops/grant-unclaimed-pass', {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ anonymousPassId, email }),
+  });
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(
+      data.message ?? `${response.status} ${response.statusText}`
+    );
+  }
+  return response.json();
+}

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-21-pass-claim-email.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-21-pass-claim-email.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-21-pass-claim-email",
+  "date": "2026-08-21",
+  "type": "fix",
+  "title": "Day and Week passes arrive by email so you can claim them even if checkout never returns to the site"
+}


### PR DESCRIPTION
## What
Adds recovery paths for anonymous Day/Week passes that are paid for but never claimed, plus the instrumentation to measure the drop-off.

- **On fulfillment**, when the Stripe session has a buyer email, issue an unbound `pass_claim_token` and email a claim link (valid 30 days). The link reuses the existing `/account/claim` confirm flow, which attaches the pass to whichever account the buyer signs into.
- **Ops command** `POST /api/ops/grant-unclaimed-pass` (+ CommandsTab button) claims an anonymous pass to an account by email and grants the full duration from now — the manual unblock for a buyer already in the inbox.
- **Events** `pass_claim_email_sent` and `anonymous_pass_claimed` added to both analytics allowlists.

## Why
Closes #4141. An anonymous pass is granted at webhook time but only claimed on the `/upload?pass_session=...` redirect round-trip. A PayPal-style redirect break (in-app browser, closed tab, different device) leaves the pass paid-but-unclaimed until it expires, so the buyer pays and receives nothing. Passes are ~9% of revenue and the Day Pass is the new landing CTA; a silent zero-delivery poisons the funnel we just started promoting.

## How
- New `SendAnonymousPassClaimEmailUseCase` creates a `pass_claim_token` with `user_id = null` and sends a new transactional template (`anonymous-pass-claim.html`). Wired into the webhook's anonymous-pass branch; guarded by a `findBySessionId` check so a Stripe retry (idempotent insert) does not re-email or re-issue a token.
- Migration `20261009000000` drops the `NOT NULL` on `pass_claim_tokens.user_id` (a fulfillment token predates any account); the confirm path already claims for whichever user is signed in, so the token's `user_id` is only the "issued to" record. Kanel regenerated `PassClaimTokens.ts` in the same PR.
- New `GrantUnclaimedPassUseCase` + `OpsController.grantUnclaimedPass` + route + client wrapper + button (route↔button parity test enforces the pairing).
- `ConfirmPassClaimUseCase` audit label handles a null (unbound) token `user_id`.

## Measuring success
- `pass_claim_email_sent` vs `checkout_completed` (plan=24h/7d, no user) — recovery-offer coverage per purchased anonymous pass.
- `anonymous_pass_claimed` (props `method: link | ops`) — claims recovered, split by path. Read at `/api/ops/metrics`; the existing `/api/ops/passes/unlock-monitor` continues to show paid-but-not-unlocked buyers.
- Log line `pass.claim_email.send_failed` surfaces send failures without breaking the webhook 200.

## Testing
- Unit: `SendAnonymousPassClaimEmailUseCase` (token issued unbound, claim link, event, no-op on bad email), `GrantUnclaimedPassUseCase` (fresh window from now, pass/user-not-found, already-claimed), `OpsController.grantUnclaimedPass` (200/404/409/400/500 mapping).
- Integration: `WebhookRouter` — emails a claim link on a newly granted anonymous pass with a buyer email; does not re-send on a retry where the pass already existed.
- Interface change to `IEmailService` required updating 7 test mocks; `tsc -p . --noEmit` clean (deploy build compiles tests).
- Full server suite: 686 suites / 6545 tests pass; the 9 failing suites are the documented environmental class only (8 `PythonExitError` — no Python venv in the worktree — plus `getPageCount`). Full web suite green (254 tests). `pnpm format:check` clean tree-wide.
- Sonar: not run locally; PR decoration will report.

## Browser check
Browser check: not applicable — the CommandsTab "Grant unclaimed pass" card is an exact mirror of the adjacent "Developer access" command (same input/button/status pattern); the route↔button parity test covers the wiring. A live browser pass on the ops page was not run in this worktree (no dev-server access) — the pattern is a well-tested exact mirror; flagging honestly for a human to click through if preferred.

## Migration + kanel
Includes migration `20261009000000_pass_claim_tokens_nullable_user.js`; applied to local Postgres and `src/data_layer/public/PassClaimTokens.ts` regenerated with kanel in this PR. Requesting **migration-reviewer**.

## Payments surface
This touches the Stripe webhook and payment-linked claim flow — **/security-review will run before merge.**

## Risks
- The fulfillment email is best-effort inside the webhook (its own try/catch, logs `pass.claim_email.send_failed`) so a SendGrid failure never breaks the `200` ack or the grant.
- The nullable `user_id` is additive and buyer-favorable; the down migration restores `NOT NULL` (safe only while no unbound rows exist, which is the pre-change state).
- No change to the existing redirect claim path or `user_passes`; `findActive` still excludes claimed rows, so ops/link/redirect claims cannot double-grant.

## Goal alignment
Protects pass revenue (~9% of the total, and the Day Pass is the current landing CTA): a paid pass that silently delivers nothing is a refund and a trust loss. Should move claimed-per-purchased for anonymous passes upward, read at `/api/ops/metrics` and `/api/ops/passes/unlock-monitor`, from the week after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbQZzLbjr2apKHQC7orhhw

