### PR TITLE
fix: start anonymous pass clock at first use, not purchase

### DIFF
--- a/migrations/20261010000000_add_activated_at_to_anonymous_passes.js
+++ b/migrations/20261010000000_add_activated_at_to_anonymous_passes.js
@@ -9,6 +9,9 @@ exports.up = async (knex) => {
   });
 };
 
+// Rolling back after any pass has activated loses data: activation overwrites
+// expires_at in place (no backup of the purchase-stamped value), and dropping
+// activated_at erases which rows were touched. Treat down as pre-traffic only.
 exports.down = async (knex) => {
   await knex.schema.alterTable('anonymous_passes', (table) => {
     table.dropColumn('activated_at');

--- a/migrations/20261010000000_add_activated_at_to_anonymous_passes.js
+++ b/migrations/20261010000000_add_activated_at_to_anonymous_passes.js
@@ -1,0 +1,16 @@
+// An anonymous pass used to have expires_at stamped purchase + duration, so any
+// claim delay burned the window the buyer paid for. expires_at now holds the
+// 30-day claim/use deadline until the pass is first attached; activated_at
+// records when the usable countdown actually started (first x-pass-token use or
+// account claim), after which expires_at is reset to activation + duration.
+exports.up = async (knex) => {
+  await knex.schema.alterTable('anonymous_passes', (table) => {
+    table.timestamp('activated_at', { useTz: true }).nullable();
+  });
+};
+
+exports.down = async (knex) => {
+  await knex.schema.alterTable('anonymous_passes', (table) => {
+    table.dropColumn('activated_at');
+  });
+};

--- a/src/data_layer/AnonymousPassRepository.ts
+++ b/src/data_layer/AnonymousPassRepository.ts
@@ -9,6 +9,7 @@ export interface AnonymousPass {
   payment_intent_id: string;
   claimed_by_user_id: number | null;
   buyer_email_hash: string | null;
+  activated_at: Date | null;
 }
 
 export interface AnonymousPassWindowRow {
@@ -38,6 +39,11 @@ export interface IAnonymousPassRepository {
   setBuyerEmailHash(id: number, buyerEmailHash: string): Promise<void>;
   claim(id: number, userId: number): Promise<boolean>;
   unclaim(id: number): Promise<void>;
+  activate(
+    id: number,
+    activatedAt: Date,
+    expiresAt: Date
+  ): Promise<AnonymousPass | null>;
 }
 
 interface AnonymousPassRow {
@@ -48,6 +54,12 @@ interface AnonymousPassRow {
   payment_intent_id: string;
   claimed_by_user_id: number | null;
   buyer_email_hash: string | null;
+  activated_at: Date | null;
+}
+
+function toDate(value: Date | string | null): Date | null {
+  if (value == null) return null;
+  return value instanceof Date ? value : new Date(value);
 }
 
 function toAnonymousPass(row: AnonymousPassRow): AnonymousPass {
@@ -62,6 +74,7 @@ function toAnonymousPass(row: AnonymousPassRow): AnonymousPass {
     payment_intent_id: row.payment_intent_id,
     claimed_by_user_id: row.claimed_by_user_id ?? null,
     buyer_email_hash: row.buyer_email_hash ?? null,
+    activated_at: toDate(row.activated_at ?? null),
   };
 }
 
@@ -194,6 +207,18 @@ export class AnonymousPassRepository implements IAnonymousPassRepository {
       .update({ claimed_by_user_id: null });
   }
 
+  async activate(
+    id: number,
+    activatedAt: Date,
+    expiresAt: Date
+  ): Promise<AnonymousPass | null> {
+    await this.database(this.table)
+      .where({ id })
+      .whereNull('activated_at')
+      .update({ activated_at: activatedAt, expires_at: expiresAt });
+    return this.findById(id);
+  }
+
   async findById(id: number): Promise<AnonymousPass | null> {
     const row = await this.database<AnonymousPassRow>(this.table)
       .where({ id })
@@ -247,6 +272,7 @@ export class InMemoryAnonymousPassRepository implements IAnonymousPassRepository
       payment_intent_id: params.paymentIntentId,
       claimed_by_user_id: null,
       buyer_email_hash: params.buyerEmailHash ?? null,
+      activated_at: null,
     };
     this.rows.push(entry);
     return entry;
@@ -290,6 +316,20 @@ export class InMemoryAnonymousPassRepository implements IAnonymousPassRepository
   async unclaim(id: number): Promise<void> {
     const row = this.rows.find((r) => r.id === id);
     if (row) row.claimed_by_user_id = null;
+  }
+
+  async activate(
+    id: number,
+    activatedAt: Date,
+    expiresAt: Date
+  ): Promise<AnonymousPass | null> {
+    const row = this.rows.find((r) => r.id === id);
+    if (row == null) return null;
+    if (row.activated_at == null) {
+      row.activated_at = activatedAt;
+      row.expires_at = expiresAt;
+    }
+    return row;
   }
 
   async findById(id: number): Promise<AnonymousPass | null> {

--- a/src/data_layer/public/AnonymousPasses.ts
+++ b/src/data_layer/public/AnonymousPasses.ts
@@ -23,6 +23,8 @@ export default interface AnonymousPasses {
   claimed_by_user_id: UsersId | null;
 
   buyer_email_hash: string | null;
+
+  activated_at: Date | null;
 }
 
 /** Represents the initializer for the table public.anonymous_passes */
@@ -44,6 +46,8 @@ export interface AnonymousPassesInitializer {
   claimed_by_user_id?: UsersId | null;
 
   buyer_email_hash?: string | null;
+
+  activated_at?: Date | null;
 }
 
 /** Represents the mutator for the table public.anonymous_passes */
@@ -63,4 +67,6 @@ export interface AnonymousPassesMutator {
   claimed_by_user_id?: UsersId | null;
 
   buyer_email_hash?: string | null;
+
+  activated_at?: Date | null;
 }

--- a/src/routes/WebhookRouter.test.ts
+++ b/src/routes/WebhookRouter.test.ts
@@ -362,9 +362,11 @@ describe('WebhookRouter — pass grant', () => {
         buyerEmailHash: emailHash('buyer@example.com'),
       })
     );
-    const insertedExpiry = (mockAnonInsert.mock.calls[0][0] as {
-      expiresAt: Date;
-    }).expiresAt;
+    const insertedExpiry = (
+      mockAnonInsert.mock.calls[0][0] as {
+        expiresAt: Date;
+      }
+    ).expiresAt;
     const daysOut =
       (insertedExpiry.getTime() - Date.now()) / (24 * 60 * 60 * 1000);
     expect(daysOut).toBeGreaterThan(29);

--- a/src/routes/WebhookRouter.test.ts
+++ b/src/routes/WebhookRouter.test.ts
@@ -362,6 +362,13 @@ describe('WebhookRouter — pass grant', () => {
         buyerEmailHash: emailHash('buyer@example.com'),
       })
     );
+    const insertedExpiry = (mockAnonInsert.mock.calls[0][0] as {
+      expiresAt: Date;
+    }).expiresAt;
+    const daysOut =
+      (insertedExpiry.getTime() - Date.now()) / (24 * 60 * 60 * 1000);
+    expect(daysOut).toBeGreaterThan(29);
+    expect(daysOut).toBeLessThanOrEqual(30);
   });
 
   it('emails a claim link to the buyer when a newly granted anonymous pass has an email', async () => {

--- a/src/routes/WebhookRouter.ts
+++ b/src/routes/WebhookRouter.ts
@@ -19,6 +19,7 @@ import UserPassRepository, {
 import AnonymousPassRepository from '../data_layer/AnonymousPassRepository';
 import PassClaimTokensRepository from '../data_layer/PassClaimTokensRepository';
 import { SendAnonymousPassClaimEmailUseCase } from '../usecases/passes/SendAnonymousPassClaimEmailUseCase';
+import { PASS_CLAIM_WINDOW_MS } from '../usecases/passes/passDurations';
 import TokenRepository from '../data_layer/TokenRepository';
 import AuthenticationService from '../services/AuthenticationService';
 import UsersService from '../services/UsersService';
@@ -391,7 +392,9 @@ const WebhooksRouter = () => {
               }
               try {
                 const anonRepo = new AnonymousPassRepository(getDatabase());
-                const expiresAt = new Date(now.getTime() + durationMs);
+                const expiresAt = new Date(
+                  now.getTime() + PASS_CLAIM_WINDOW_MS
+                );
                 const buyerEmail =
                   session.customer_details?.email ??
                   session.customer_email ??

--- a/src/usecases/checkout/ValidateAnonymousPassUseCase.test.ts
+++ b/src/usecases/checkout/ValidateAnonymousPassUseCase.test.ts
@@ -71,6 +71,47 @@ describe('ValidateAnonymousPassUseCase', () => {
     expect(result.valid).toBe(false);
   });
 
+  it('activates an unused pass on first validation, starting the clock from now', async () => {
+    const claimDeadline = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
+    await repo.insert({
+      stripeSessionId: 'cs_fresh',
+      kind: '24h',
+      expiresAt: claimDeadline,
+      paymentIntentId: 'pi_f',
+    });
+
+    const result = await useCase.execute('cs_fresh', now);
+
+    expect(result.valid).toBe(true);
+    const stored = await repo.findBySessionId('cs_fresh');
+    expect(stored?.activated_at).toEqual(now);
+    expect(stored?.expires_at).toEqual(
+      new Date(now.getTime() + 24 * 60 * 60 * 1000)
+    );
+  });
+
+  it('does not restart the window for an already-activated pass', async () => {
+    const pass = await repo.insert({
+      stripeSessionId: 'cs_used',
+      kind: '24h',
+      expiresAt: new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000),
+      paymentIntentId: 'pi_u',
+    });
+    const activatedExpiry = new Date(now.getTime() + 2 * 60 * 60 * 1000);
+    await repo.activate(
+      pass.id,
+      new Date(now.getTime() - 22 * 60 * 60 * 1000),
+      activatedExpiry
+    );
+
+    const result = await useCase.execute('cs_used', now);
+
+    expect(result.valid).toBe(true);
+    expect(result.pass?.expires_at).toEqual(activatedExpiry);
+    const stored = await repo.findBySessionId('cs_used');
+    expect(stored?.expires_at).toEqual(activatedExpiry);
+  });
+
   describe('Stripe reconciliation when the webhook has not landed yet', () => {
     const paidSession = {
       payment_status: 'paid',
@@ -96,6 +137,19 @@ describe('ValidateAnonymousPassUseCase', () => {
         kind: '24h',
       });
       expect(await repo.findBySessionId('cs_new')).not.toBeNull();
+    });
+
+    it('activates a reconciled pass to the duration window, not the 30-day deadline', async () => {
+      const retrieve = jest.fn().mockResolvedValue(paidSession);
+
+      const result = await useCaseWith(retrieve).execute('cs_new2', now);
+
+      expect(result.valid).toBe(true);
+      const stored = await repo.findBySessionId('cs_new2');
+      expect(stored?.activated_at).toEqual(now);
+      expect(stored?.expires_at).toEqual(
+        new Date(now.getTime() + 24 * 60 * 60 * 1000)
+      );
     });
 
     it('returns valid=false for an unpaid session', async () => {

--- a/src/usecases/checkout/ValidateAnonymousPassUseCase.ts
+++ b/src/usecases/checkout/ValidateAnonymousPassUseCase.ts
@@ -4,11 +4,11 @@ import type {
   AnonymousPass,
 } from '../../data_layer/AnonymousPassRepository';
 import type { PassKind } from '../../data_layer/UserPassRepository';
-
-const DURATION_MS: Record<Extract<PassKind, '24h' | '7d'>, number> = {
-  '24h': 24 * 60 * 60 * 1000,
-  '7d': 7 * 24 * 60 * 60 * 1000,
-};
+import {
+  PASS_CLAIM_WINDOW_MS,
+  PASS_DURATION_MS,
+  isAnonymousPassKind,
+} from '../passes/passDurations';
 
 export interface ValidateAnonymousPassResult {
   valid: boolean;
@@ -31,7 +31,7 @@ export class ValidateAnonymousPassUseCase {
 
     const active = await this.anonPassRepo.findActive(stripeSessionId, now);
     if (active != null) {
-      return { valid: true, pass: active };
+      return { valid: true, pass: await this.ensureActivated(active, now) };
     }
 
     const existing = await this.anonPassRepo.findBySessionId(stripeSessionId);
@@ -40,6 +40,18 @@ export class ValidateAnonymousPassUseCase {
     }
 
     return this.reconcileFromStripe(stripeSessionId, now);
+  }
+
+  private async ensureActivated(
+    pass: AnonymousPass,
+    now: Date
+  ): Promise<AnonymousPass> {
+    if (pass.activated_at != null || !isAnonymousPassKind(pass.kind)) {
+      return pass;
+    }
+    const expiresAt = new Date(now.getTime() + PASS_DURATION_MS[pass.kind]);
+    const activated = await this.anonPassRepo.activate(pass.id, now, expiresAt);
+    return activated ?? pass;
   }
 
   private async reconcileFromStripe(
@@ -73,7 +85,7 @@ export class ValidateAnonymousPassUseCase {
 
       const createdMs =
         session.created != null ? session.created * 1000 : now.getTime();
-      const expiresAt = new Date(createdMs + DURATION_MS[passKind]);
+      const expiresAt = new Date(createdMs + PASS_CLAIM_WINDOW_MS);
       if (expiresAt <= now) {
         return { valid: false };
       }
@@ -84,7 +96,7 @@ export class ValidateAnonymousPassUseCase {
         expiresAt,
         paymentIntentId,
       });
-      return { valid: true, pass };
+      return { valid: true, pass: await this.ensureActivated(pass, now) };
     } catch {
       return { valid: false };
     }

--- a/src/usecases/passes/ConfirmPassClaimUseCase.test.ts
+++ b/src/usecases/passes/ConfirmPassClaimUseCase.test.ts
@@ -74,9 +74,18 @@ async function seedPass(anonRepo: InMemoryAnonymousPassRepository) {
 }
 
 describe('ConfirmPassClaimUseCase', () => {
-  it('attaches the pass with its original expiry and marks the anon row claimed', async () => {
+  it('starts the pass window at claim when it was never used, and marks the anon row claimed', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-09-01T00:00:00.000Z'));
+    const now = Date.now();
     const anonRepo = new InMemoryAnonymousPassRepository();
-    await seedPass(anonRepo);
+    await anonRepo.insert({
+      stripeSessionId: 'cs_1',
+      kind: '7d',
+      expiresAt: new Date(now + 30 * 24 * 60 * 60 * 1000),
+      paymentIntentId: 'pi_1',
+      buyerEmailHash: 'hash',
+    });
     const tokensRepo = makeTokensRepo();
     const userPassRepo = makeUserPassRepo();
     const useCase = new ConfirmPassClaimUseCase(
@@ -89,20 +98,67 @@ describe('ConfirmPassClaimUseCase', () => {
 
     const outcome = await useCase.execute(42, RAW_TOKEN, 'ip', 'eh');
 
+    const expected = new Date(now + 7 * 24 * 60 * 60 * 1000);
     expect(outcome).toEqual({
       success: true,
       passKind: '7d',
-      expiresAt: FUTURE,
+      expiresAt: expected,
     });
     expect(userPassRepo.upsertWithAbsoluteExpiry).toHaveBeenCalledWith(
       42,
       '7d',
-      FUTURE,
+      expected,
       'pi_1'
     );
     const row = await anonRepo.findById(1);
     expect(row?.claimed_by_user_id).toBe(42);
+    expect(row?.activated_at).toEqual(new Date(now));
+    expect(row?.expires_at).toEqual(expected);
     expect(tokensRepo.markConsumed).toHaveBeenCalledWith(10, expect.anything());
+    jest.useRealTimers();
+  });
+
+  it('carries the remaining window when the pass was already used anonymously', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-09-01T00:00:00.000Z'));
+    const now = Date.now();
+    const anonRepo = new InMemoryAnonymousPassRepository();
+    const pass = await anonRepo.insert({
+      stripeSessionId: 'cs_2',
+      kind: '7d',
+      expiresAt: new Date(now + 30 * 24 * 60 * 60 * 1000),
+      paymentIntentId: 'pi_1',
+      buyerEmailHash: 'hash',
+    });
+    const remaining = new Date(now + 6 * 24 * 60 * 60 * 1000);
+    await anonRepo.activate(
+      pass.id,
+      new Date(now - 24 * 60 * 60 * 1000),
+      remaining
+    );
+    const userPassRepo = makeUserPassRepo();
+    const useCase = new ConfirmPassClaimUseCase(
+      makeDb(),
+      makeTokensRepo(),
+      anonRepo,
+      userPassRepo,
+      makeAuditRepo()
+    );
+
+    const outcome = await useCase.execute(42, RAW_TOKEN, 'ip', 'eh');
+
+    expect(outcome).toEqual({
+      success: true,
+      passKind: '7d',
+      expiresAt: remaining,
+    });
+    expect(userPassRepo.upsertWithAbsoluteExpiry).toHaveBeenCalledWith(
+      42,
+      '7d',
+      remaining,
+      'pi_1'
+    );
+    jest.useRealTimers();
   });
 
   it('rejects an unknown or expired token', async () => {

--- a/src/usecases/passes/ConfirmPassClaimUseCase.ts
+++ b/src/usecases/passes/ConfirmPassClaimUseCase.ts
@@ -1,12 +1,16 @@
 import type { Knex } from 'knex';
 import type { UsersId } from '../../data_layer/public/Users';
 import hmacToken from '../../lib/misc/hmacToken';
-import type { IAnonymousPassRepository } from '../../data_layer/AnonymousPassRepository';
+import type {
+  AnonymousPass,
+  IAnonymousPassRepository,
+} from '../../data_layer/AnonymousPassRepository';
 import type { IPassClaimTokensRepository } from '../../data_layer/PassClaimTokensRepository';
 import type { ISubscriptionClaimAuditRepository } from '../../data_layer/SubscriptionClaimAuditRepository';
-import type { IUserPassRepository } from '../../data_layer/UserPassRepository';
-import type { PassKind } from '../../data_layer/UserPassRepository';
-import type { AnonymousPass } from '../../data_layer/AnonymousPassRepository';
+import type {
+  IUserPassRepository,
+  PassKind,
+} from '../../data_layer/UserPassRepository';
 import { PASS_DURATION_MS, isAnonymousPassKind } from './passDurations';
 
 export type ConfirmPassOutcome =

--- a/src/usecases/passes/ConfirmPassClaimUseCase.ts
+++ b/src/usecases/passes/ConfirmPassClaimUseCase.ts
@@ -6,6 +6,8 @@ import type { IPassClaimTokensRepository } from '../../data_layer/PassClaimToken
 import type { ISubscriptionClaimAuditRepository } from '../../data_layer/SubscriptionClaimAuditRepository';
 import type { IUserPassRepository } from '../../data_layer/UserPassRepository';
 import type { PassKind } from '../../data_layer/UserPassRepository';
+import type { AnonymousPass } from '../../data_layer/AnonymousPassRepository';
+import { PASS_DURATION_MS, isAnonymousPassKind } from './passDurations';
 
 export type ConfirmPassOutcome =
   | { success: true; passKind: PassKind; expiresAt: Date }
@@ -77,11 +79,13 @@ export class ConfirmPassClaimUseCase {
       return { success: false, reason: 'already_claimed' };
     }
 
+    const grantExpiry = await this.resolveGrantExpiry(pass);
+
     try {
       await this.userPassRepo.upsertWithAbsoluteExpiry(
         userId,
         pass.kind,
-        pass.expires_at,
+        grantExpiry,
         pass.payment_intent_id
       );
     } catch (error) {
@@ -94,6 +98,16 @@ export class ConfirmPassClaimUseCase {
     });
     await audit('pass_confirm_success');
 
-    return { success: true, passKind: pass.kind, expiresAt: pass.expires_at };
+    return { success: true, passKind: pass.kind, expiresAt: grantExpiry };
+  }
+
+  private async resolveGrantExpiry(pass: AnonymousPass): Promise<Date> {
+    if (pass.activated_at != null || !isAnonymousPassKind(pass.kind)) {
+      return pass.expires_at;
+    }
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + PASS_DURATION_MS[pass.kind]);
+    const activated = await this.anonPassRepo.activate(pass.id, now, expiresAt);
+    return activated?.expires_at ?? expiresAt;
   }
 }

--- a/src/usecases/passes/passDurations.ts
+++ b/src/usecases/passes/passDurations.ts
@@ -1,0 +1,12 @@
+export type AnonymousPassKind = '24h' | '7d';
+
+export const PASS_DURATION_MS: Record<AnonymousPassKind, number> = {
+  '24h': 24 * 60 * 60 * 1000,
+  '7d': 7 * 24 * 60 * 60 * 1000,
+};
+
+export const PASS_CLAIM_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+export function isAnonymousPassKind(kind: string): kind is AnonymousPassKind {
+  return kind === '24h' || kind === '7d';
+}

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-21-pass-clock-at-claim.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-21-pass-clock-at-claim.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-21-pass-clock-at-claim",
+  "date": "2026-08-21",
+  "type": "fix",
+  "title": "Day and Week pass time starts when you first use the pass, not when you pay — claim within 30 days"
+}


### PR DESCRIPTION
## What
Anonymous Day/Week passes now start their usable countdown when the buyer first uses or claims the pass, not at purchase. `anonymous_passes.expires_at` holds a 30-day claim/use deadline at purchase; a new `activated_at` column records when the real window started, after which `expires_at` is reset to activation + kind duration.

## Why
Closes #4142. `expires_at` was stamped `purchase + duration` at webhook time, so any claim delay — a broken checkout redirect (see #4141), or just buying tonight to study tomorrow — burned the window the buyer paid for. This week's buyer lost the full 24 hours without ever seeing them. The semantics only shift in the buyer's favour.

## How
- Migration `20261010000000` adds `activated_at TIMESTAMPTZ NULL`; kanel regenerated `AnonymousPasses.ts` in the same PR.
- New `AnonymousPassRepository.activate(id, activatedAt, expiresAt)` — idempotent (`WHERE activated_at IS NULL`), returns the resulting row.
- Purchase-time stamp (webhook anonymous branch + `ValidateAnonymousPassUseCase.reconcileFromStripe`) now uses a shared `PASS_CLAIM_WINDOW_MS` (30 days) instead of the kind duration.
- Activation on first attach: `ValidateAnonymousPassUseCase` activates on the first `x-pass-token` validation; `ConfirmPassClaimUseCase` activates on account claim. Claiming an already-activated pass carries the remaining window instead of restarting it.
- Shared durations in `src/usecases/passes/passDurations.ts` (used by the webhook, validate, and confirm paths).

## Verification of the signed-in path (issue asked)
The signed-in `user_passes` purchase path is **unchanged** and is **not a defect**: the webhook grants via `upsertWithExtension(userId, kind, durationMs, …)` for a buyer who is signed in and lands back with the pass immediately usable, so purchase equals activation there.

## Measuring success
- No new event; correctness is observable via `/api/ops/passes/unlock-monitor` and `/api/ops/value-monitor` (a claimed pass now shows an `expires_at` in the future relative to its claim, not its purchase). A spot check: `anonymous_passes` rows should carry `activated_at IS NULL` until first use, then `expires_at = activated_at + duration`.

## Testing
- `ConfirmPassClaimUseCase`: window starts at claim when never used (asserts `activated_at`, reset `expires_at`, and the granted `user_pass` expiry under a frozen clock); carries the remaining window when already used anonymously.
- `ValidateAnonymousPassUseCase`: activates an unused pass on first validation to now + duration; does not restart an already-activated pass; a reconciled pass activates to the duration window, not the 30-day deadline.
- `WebhookRouter`: anonymous pass is stamped ~30 days out at purchase.
- `tsc -p . --noEmit` clean. Full server suite: 684 suites / 6531 tests pass; the 9 failing suites are the documented environmental class only (8 `PythonExitError` — no venv — plus `getPageCount`). `pnpm format:check` clean tree-wide; changelog loader test green.
- Sonar: not run locally; PR decoration will report.

## Browser check
No web UI change (changelog JSON only). The behavioral change is server-side pass timing.

## Migration + kanel
Includes migration `20261010000000_add_activated_at_to_anonymous_passes.js`; applied to local Postgres and `src/data_layer/public/AnonymousPasses.ts` regenerated with kanel in this PR. Requesting **migration-reviewer**. Note: this migration and #4159's `20261009000000` are independent (different tables); merge in timestamp order for tidiness.

## Payments surface
Touches the Stripe webhook and the pass claim/use flow — **/security-review will run before merge.**

## Risks
- The `x-pass-token` validation now performs one write (activation) the first time a pass is seen; it is a bounded, once-per-pass `UPDATE … WHERE activated_at IS NULL` on a low-traffic path (anonymous pass holders only).
- Win-back and monitors that read `expires_at` will see an unclaimed pass as active for up to 30 days (the claim deadline) rather than 24h/7d; this is intended — the pass genuinely stays claimable.
- Additive, buyer-favourable; down migration drops the column.

## Goal alignment
Protects pass revenue (~9% of total; Day Pass is the current landing CTA) by giving buyers the full duration they paid for regardless of when they claim — fewer refunds and less trust loss. Moves claimed-pass value (usable time actually delivered), read at `/api/ops/value-monitor`, from the week after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbQZzLbjr2apKHQC7orhhw
