### PR TITLE
fix: keep primary-button text white on hover for link buttons

### DIFF
--- a/web/src/styles/shared.module.css
+++ b/web/src/styles/shared.module.css
@@ -92,6 +92,7 @@
 
 .btnPrimary:hover {
   background: var(--color-primary-hover);
+  color: var(--color-bg-primary);
   box-shadow: var(--shadow-sm);
 }
 


### PR DESCRIPTION
## What

One line in `shared.module.css`: `.btnPrimary:hover` now sets `color: var(--color-bg-primary)` explicitly.

## Why

The global `a:hover { color: var(--color-text-link-hover) }` rule (specificity 0-1-1) beats `.btnPrimary` (0-1-0), and `.btnPrimary:hover` set background and shadow but not color. Result: every `<Link>` styled as a primary button flipped to dark link-blue text on the blue button while hovered — unreadable. Spotted on the chat paywall's "See plans" CTA (screenshot in session); the same defect was latent on every other Link-rendered primary button (e.g. the EmptyState CTA). `.btnSecondary:hover` already carries an explicit `color` for exactly this reason — this brings `.btnPrimary:hover` in line.

## Testing

`pnpm format:check` clean, web typecheck clean, ChatPanel suite green, golden-path spec green (2 passed at 375px, no console errors). CSS-only, one property.

No changelog entry — one-line hover-state contrast fix, no behavior change.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: machine-backed via `pnpm --filter 2anki-web test:golden-path`. Hover state itself verified by cascade analysis (mirrors the already-shipped btnSecondary:hover pattern); reported broken from a live-prod screenshot, fix is the known one-liner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbQZzLbjr2apKHQC7orhhw
