### PR TITLE
fix: keep the note types page alive when previewData is missing

### DIFF
--- a/web/src/pages/TemplatesPage/renderNoteTypePreview.test.ts
+++ b/web/src/pages/TemplatesPage/renderNoteTypePreview.test.ts
@@ -40,6 +40,24 @@ const cloze: AnkiNoteType = {
 };
 
 describe('renderCardSide', () => {
+  it('renders with empty values when previewData is missing entirely', () => {
+    const result = renderCardSide(
+      basic,
+      undefined as unknown as Record<string, string>,
+      'front'
+    );
+    expect(result).toBe('');
+  });
+
+  it('builds a document for a starter with no previewData', () => {
+    const doc = buildPreviewDocument(
+      basic,
+      undefined as unknown as Record<string, string>,
+      'back'
+    );
+    expect(doc).toContain('<div class="card">');
+  });
+
   it('substitutes simple {{Field}} placeholders on the front', () => {
     const result = renderCardSide(
       basic,

--- a/web/src/pages/TemplatesPage/renderNoteTypePreview.ts
+++ b/web/src/pages/TemplatesPage/renderNoteTypePreview.ts
@@ -51,22 +51,23 @@ function substituteFields(
 
 export function renderCardSide(
   noteType: AnkiNoteType,
-  previewData: PreviewData,
+  previewData: PreviewData | undefined,
   side: 'front' | 'back'
 ): string {
   const template = noteType.tmpls[0];
   if (!template) return '';
+  const data = previewData ?? {};
   if (side === 'front') {
-    return substituteFields(template.qfmt, previewData, 'front');
+    return substituteFields(template.qfmt, data, 'front');
   }
-  const frontHtml = substituteFields(template.qfmt, previewData, 'front');
+  const frontHtml = substituteFields(template.qfmt, data, 'front');
   const backWithFront = template.afmt.replaceAll('{{FrontSide}}', frontHtml);
-  return substituteFields(backWithFront, previewData, 'back');
+  return substituteFields(backWithFront, data, 'back');
 }
 
 export function buildPreviewDocument(
   noteType: AnkiNoteType,
-  previewData: PreviewData,
+  previewData: PreviewData | undefined,
   side: 'front' | 'back'
 ): string {
   const body = renderCardSide(noteType, previewData, side);

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-21-templates-preview-guard.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-21-templates-preview-guard.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-21-templates-preview-guard",
+  "date": "2026-08-21",
+  "type": "fix",
+  "title": "The note types page no longer goes blank when one saved template is missing its preview example"
+}


### PR DESCRIPTION
## What

`renderCardSide` and `buildPreviewDocument` accept a missing `previewData` and default it to an empty record — the template skeleton renders with blank field values instead of throwing.

## Why

Reported live from prod today: https://2anki.net/templates/ went to the root error boundary with `TypeError: Cannot read properties of undefined (reading 'Front')` in the field-substitution replace callback. Every access inside the renderer is `data[field] ?? ''`, which is only safe when `data` exists — a single starter arriving without `previewData` bricked the whole page.

Diagnosis per first-time-fix: pinned the entry point (SPA render of /templates, three starter sources) and read the data — the reporter's stored template row is valid, and the live `/api/templates/defaults` + `/official` responses all carry `previewData` (checked entry by entry). The malformed starter was transient — most plausibly the mid-deploy asset/chunk race (three deploys landed today; the same console showed a font 404 that timestamps to the exact minute the build dir was swapped, and both fonts serve 200 now). Root defect regardless: one bad entry must not take down the page.

## Testing

Two new tests reproduce the exact prod TypeError against the unguarded code (watched them fail with the identical message), then pass with the guard. Full TemplatesPage suites 58/58 green, web typecheck clean, `pnpm format:check` clean.

## Risks

None beyond rendering a blank-field preview for a malformed entry — strictly better than the error boundary.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: machine-backed via `pnpm --filter 2anki-web test:golden-path`. The crash itself is unit-reproduced with the exact prod error; live /templates verified serving clean data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbQZzLbjr2apKHQC7orhhw
