### PR TITLE
fix: keep every PDF page when pairing pages into toggle cards

### DIFF
--- a/src/lib/pdf/combineIntoHTML.test.ts
+++ b/src/lib/pdf/combineIntoHTML.test.ts
@@ -1,0 +1,61 @@
+import * as cheerio from 'cheerio';
+import { combineIntoHTML } from './combineIntoHTML';
+
+const imgSrcs = (html: string): string[] => {
+  const $ = cheerio.load(html);
+  const srcs: string[] = [];
+  $('img[src]').each((_, el) => {
+    srcs.push($(el).attr('src') ?? '');
+  });
+  return srcs;
+};
+
+const toggleCount = (html: string): number =>
+  cheerio.load(html)('details').length;
+
+describe('combineIntoHTML', () => {
+  it('keeps the only page of a one-page document', () => {
+    const html = combineIntoHTML(['/ws/doc.pdf-page1-1.png'], 'doc.pdf', '/ws');
+
+    expect(imgSrcs(html)).toEqual(['doc.pdf-page1-1.png']);
+    expect(toggleCount(html)).toBe(1);
+  });
+
+  it('keeps the odd last page of a three-page document', () => {
+    const html = combineIntoHTML(
+      [
+        '/ws/doc.pdf-page1-1.png',
+        '/ws/doc.pdf-page2-2.png',
+        '/ws/doc.pdf-page3-3.png',
+      ],
+      'doc.pdf',
+      '/ws'
+    );
+
+    expect(imgSrcs(html)).toEqual([
+      'doc.pdf-page1-1.png',
+      'doc.pdf-page2-2.png',
+      'doc.pdf-page3-3.png',
+    ]);
+    expect(toggleCount(html)).toBe(2);
+  });
+
+  it('pairs an even page count into front/back toggles unchanged', () => {
+    const html = combineIntoHTML(
+      ['/ws/doc.pdf-page1-1.png', '/ws/doc.pdf-page2-2.png'],
+      'doc.pdf',
+      '/ws'
+    );
+
+    const $ = cheerio.load(html);
+    expect(toggleCount(html)).toBe(1);
+    expect($('summary img').attr('src')).toBe('doc.pdf-page1-1.png');
+    expect($('details > img').attr('src')).toBe('doc.pdf-page2-2.png');
+  });
+
+  it('falls back to basenames when no workspace location is given', () => {
+    const html = combineIntoHTML(['/elsewhere/doc.pdf-page1-1.png'], 'doc.pdf');
+
+    expect(imgSrcs(html)).toEqual(['doc.pdf-page1-1.png']);
+  });
+});

--- a/src/lib/pdf/combineIntoHTML.ts
+++ b/src/lib/pdf/combineIntoHTML.ts
@@ -14,16 +14,17 @@ export function combineIntoHTML(
 <html>
 <head><title>${title}</title></head>
 <body>
-  ${Array.from({ length: imagePaths.length / 2 }, (_, i) => {
+  ${Array.from({ length: Math.ceil(imagePaths.length / 2) }, (_, i) => {
     const front = toSrc(imagePaths[i * 2]);
-    const back = toSrc(imagePaths[i * 2 + 1]);
+    const backPath = imagePaths[i * 2 + 1];
+    const back =
+      backPath == null ? '' : `\n        <img src="${toSrc(backPath)}" />`;
     return `<ul class="toggle">
     <li>
       <details>
         <summary>
         <img src="${front}" />
-        </summary>
-        <img src="${back}" />
+        </summary>${back}
       </details>
     </li>
     </ul>`;

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-22-one-page-pdf.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-22-one-page-pdf.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-22-one-page-pdf",
+  "date": "2026-08-22",
+  "type": "fix",
+  "title": "One-page PDFs convert to a deck instead of failing, and PDFs with an odd page count keep their last page"
+}


### PR DESCRIPTION
Fixes #4170

## What

`combineIntoHTML` paired PDF page images into front/back toggles with `Array.from({ length: imagePaths.length / 2 })`. `ToLength` truncates, so a 1-page PDF produced HTML with **zero** `<img>` tags and any odd page count silently dropped the last page. Both consumers broke:

- **Claude vision fallback**: `resolvePageImages` found no images in the empty HTML and failed the whole conversion with the empty-content error — deterministically, for every 1-page PDF routed to the image fallback. This is the bug a paying user hit 33 restarts in a row on 2026-08-21.
- **Classic image-toggle flow**: 1-page PDF → 0 cards; odd count → last page missing from the deck.

The pair count is now `Math.ceil`, and the last odd page renders as a front-only toggle (no back `<img>`). The vision fallback parses whatever `<img>` tags exist, so it now sees every page.

## Tests

- New `combineIntoHTML.test.ts`: 1-page keeps its page, 3-page keeps the odd last page, 2-page pairing unchanged, basename fallback. Watched the 1-page and 3-page cases fail on the old code first.
- Full server suite: 6568 passed, 2 failed — both the documented environmental `getPageCount` pdfinfo failures on this machine, unrelated to the diff.
- `/check` green (web typecheck, 3311 vitest, lint warnings are pre-existing debt), `pnpm format:check` clean, server tsc + arch clean (0 errors).

## Notes

- A 1-page PDF in the classic (non-AI) flow now yields one card with the page as the front and an empty back — previously it yielded nothing at all. Empty backs are already a counted, supported state in the parser.
- Sonar: not run locally; PR decoration will report.
- Changelog entry included (user-visible fix).
