### PR TITLE
fix: skip the upload-bytes snapshot when the request is already dead

### DIFF
--- a/src/lib/misc/GetUploadHandler.test.ts
+++ b/src/lib/misc/GetUploadHandler.test.ts
@@ -77,6 +77,41 @@ describe('withNormalizedFilenames', () => {
     expect(file.buffer).toEqual(Buffer.from('disk-bytes'));
   });
 
+  it('skips the snapshot entirely when the request already aborted', () => {
+    fs.rmSync(tmpPath); // multer 2.x removes temp files when the client aborts
+    const file = makeDiskFile(tmpPath);
+    const req = {
+      files: [file],
+      aborted: true,
+    } as unknown as express.Request;
+    const res = {} as express.Response;
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const wrapped = withNormalizedFilenames((_req, _res, next) => next());
+
+    const callback = jest.fn();
+    wrapped(req, res, callback);
+
+    expect(callback).toHaveBeenCalledWith();
+    expect(file.buffer).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('skips the snapshot when the response is already finished', () => {
+    fs.rmSync(tmpPath);
+    const file = makeDiskFile(tmpPath);
+    const { req } = makeReqRes([file]);
+    const res = { writableEnded: true } as unknown as express.Response;
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const wrapped = withNormalizedFilenames((_req, _res, next) => next());
+
+    wrapped(req, res, jest.fn());
+
+    expect(file.buffer).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
   it('forwards multer errors without snapshotting', () => {
     const file = makeDiskFile(tmpPath);
     const { req, res } = makeReqRes([file]);

--- a/src/lib/misc/GetUploadHandler.ts
+++ b/src/lib/misc/GetUploadHandler.ts
@@ -28,16 +28,25 @@ export function withNormalizedFilenames(
         callback(error);
         return;
       }
+      // A dead request has nothing to convert, and multer 2.x has already
+      // removed its temp files — snapshotting would only ENOENT-spam the log
+      // once per file (#4173).
+      const requestDead =
+        req.aborted || req.destroyed || res.writableEnded || res.destroyed;
       const files = req.files as UploadedFile[] | undefined;
       if (files) {
         for (const file of files) {
           file.originalname = decodeMultipartFilename(file.originalname);
         }
-        ensureUploadBytes(files);
+        if (!requestDead) {
+          ensureUploadBytes(files);
+        }
       }
       if (req.file) {
         req.file.originalname = decodeMultipartFilename(req.file.originalname);
-        ensureUploadBytes([req.file as UploadedFile]);
+        if (!requestDead) {
+          ensureUploadBytes([req.file as UploadedFile]);
+        }
       }
       callback();
     });

--- a/src/usecases/uploads/ensureUploadBytes.test.ts
+++ b/src/usecases/uploads/ensureUploadBytes.test.ts
@@ -72,4 +72,26 @@ describe('ensureUploadBytes', () => {
     expect(() => ensureUploadBytes([file])).not.toThrow();
     expect(file.buffer).toBeUndefined();
   });
+
+  it('collapses a batch of unreadable files into a single warn', () => {
+    fs.rmSync(tmpPath);
+    const gone = path.join(path.dirname(tmpPath), 'gone-too.bin');
+    const files = [
+      makeFile({ path: tmpPath }),
+      makeFile({ path: gone, originalname: 'other.html' }),
+    ];
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    ensureUploadBytes(files);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      '[upload] could not snapshot upload bytes',
+      expect.objectContaining({
+        count: 2,
+        firstFile: path.basename(tmpPath),
+      })
+    );
+    warn.mockRestore();
+  });
 });

--- a/src/usecases/uploads/ensureUploadBytes.ts
+++ b/src/usecases/uploads/ensureUploadBytes.ts
@@ -21,19 +21,26 @@ import { UploadedFile } from '../../lib/storage/types';
 export const SNAPSHOT_MAX_BYTES = 64 * 1024 * 1024;
 
 export function ensureUploadBytes(files: UploadedFile[]): void {
+  const unreadable: { file: string; error: string }[] = [];
   for (const file of files) {
     if (file.buffer != null || !file.path) continue;
     if (file.size > SNAPSHOT_MAX_BYTES) continue;
     try {
       file.buffer = fs.readFileSync(file.path);
     } catch (error) {
-      // The file is already gone or unreadable at request time (rare). Leave the
+      // The file is already gone or unreadable at request time. Leave the
       // buffer unset; the worker surfaces its own clear error if the disk read
       // also fails by the time it runs.
-      console.warn('[upload] could not snapshot upload bytes', {
-        file: path.basename(file.path),
-        error: String(error),
-      });
+      unreadable.push({ file: path.basename(file.path), error: String(error) });
     }
+  }
+  if (unreadable.length > 0) {
+    // One line per request, not per file: an aborted multi-file upload used to
+    // dump 4 log lines for each of its dozens of vanished temp files (#4173).
+    console.warn('[upload] could not snapshot upload bytes', {
+      count: unreadable.length,
+      firstFile: unreadable[0].file,
+      firstError: unreadable[0].error,
+    });
   }
 }


### PR DESCRIPTION
Fixes #4173

## What

On 2026-08-21 the prod error log carried 63 `[upload] could not snapshot upload bytes` ENOENT warns in two tight bursts (21 + 42 unique multer temp names) with no surrounding conversion activity and no user-facing failure. Best-supported explanation: multer 2.x removes its temp files when a request aborts, but leaves `req.files` populated — `withNormalizedFilenames` then snapshots N corpses and warns once per file.

Two changes:

- `withNormalizedFilenames` skips `ensureUploadBytes` when the request is already dead (`req.aborted || req.destroyed || res.writableEnded || res.destroyed`) — there is nothing to convert, and the snapshot exists only to insure a conversion.
- `ensureUploadBytes` collapses whatever unreadable files remain into **one** warn per call (`{ count, firstFile, firstError }`) instead of four log lines per file.

No behavior change for live requests: filename decoding still runs, successful snapshots are untouched, and a genuinely missing file still leaves `buffer` unset for the worker's own clear error.

## Tests

- `GetUploadHandler.test.ts`: aborted request → no snapshot, no warn; finished response → same. Both failed on the old code.
- `ensureUploadBytes.test.ts`: two missing files → exactly one warn with `count: 2`. Failed on the old code (two warns).
- Full server suite: 6567 passed; only failures are the documented environmental `getPageCount` pdfinfo cases on this machine. `pnpm format:check` clean, server tsc clean.

## Notes

- The abort-cleanup explanation is the hypothesis best supported by the log evidence (see #4173); this change is correct under every explanation — a dead request never benefits from the snapshot.
- No changelog entry — log-noise fix, no user-visible behavior change.
- Sonar: not run locally; PR decoration will report.
