### PR TITLE
fix: keep the boot sweep off Notion jobs so interrupted marking works

### DIFF
--- a/src/data_layer/JobRepository.test.ts
+++ b/src/data_layer/JobRepository.test.ts
@@ -634,3 +634,84 @@ describe('JobRepository.updateJobStatus — terminal transitions', () => {
     expect(row.job_reason_failure).toBe('real failure');
   });
 });
+
+describe('JobRepository boot-time stranded-job handling', () => {
+  let db: Knex;
+  let repo: JobRepository;
+
+  beforeEach(async () => {
+    db = await makeDb();
+    repo = new JobRepository(db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it('leaves in-flight Notion jobs for markInterruptedNotionJobs', async () => {
+    await insertJob(db, {
+      owner: '1',
+      object_id: 'notion-1',
+      status: 'step1_started',
+      type: 'page',
+    });
+
+    await repo.failStrandedLegacyJobs();
+    await repo.markInterruptedNotionJobs();
+
+    const row = await db('jobs').where({ object_id: 'notion-1' }).first();
+    expect(row.status).toBe('interrupted');
+  });
+
+  it('leaves in-flight claude jobs for markInterruptedClaudeJobs', async () => {
+    await insertJob(db, {
+      owner: '1',
+      object_id: 'claude-1',
+      status: 'step1_started',
+      type: 'claude',
+    });
+
+    await repo.failStrandedLegacyJobs();
+
+    const row = await db('jobs').where({ object_id: 'claude-1' }).first();
+    expect(row.status).toBe('step1_started');
+  });
+
+  it('fails an in-flight job of unknown or missing type', async () => {
+    await insertJob(db, {
+      owner: '1',
+      object_id: 'legacy-1',
+      status: 'step1_started',
+      type: 'apkg_import',
+    });
+    await db('jobs').insert({
+      owner: '1',
+      object_id: 'legacy-2',
+      status: 'step1_started',
+      title: 'Deck',
+      type: null,
+      last_edited_time: new Date(),
+    });
+
+    await repo.failStrandedLegacyJobs();
+
+    const one = await db('jobs').where({ object_id: 'legacy-1' }).first();
+    const two = await db('jobs').where({ object_id: 'legacy-2' }).first();
+    expect(one.status).toBe('failed');
+    expect(two.status).toBe('failed');
+  });
+
+  it('never touches terminal rows', async () => {
+    await insertJob(db, {
+      owner: '1',
+      object_id: 'done-1',
+      status: 'done',
+      type: 'apkg_import',
+    });
+
+    await repo.failStrandedLegacyJobs();
+
+    const row = await db('jobs').where({ object_id: 'done-1' }).first();
+    expect(row.status).toBe('done');
+  });
+});

--- a/src/data_layer/JobRepository.ts
+++ b/src/data_layer/JobRepository.ts
@@ -124,6 +124,22 @@ class JobRepository {
       .update({ status: 'interrupted', last_edited_time: new Date() });
   }
 
+  // Boot-time sweep for job types with no interrupted-marking of their own.
+  // Claude and Notion types are excluded: their markInterrupted* methods above
+  // own those rows, and this sweep used to run first and convert every
+  // in-flight Notion job to 'failed' with no reason, making
+  // markInterruptedNotionJobs dead code (#4176).
+  failStrandedLegacyJobs() {
+    return this.database(this.tableName)
+      .whereNotIn('status', ['done', 'failed', 'cancelled', 'interrupted'])
+      .where((qb) =>
+        qb
+          .whereNull('type')
+          .orWhereNotIn('type', ['claude', 'page', 'database', 'conversion'])
+      )
+      .update({ status: 'failed' });
+  }
+
   static readonly TERMINAL_STATUSES = [
     'done',
     'failed',

--- a/src/data_layer/index.ts
+++ b/src/data_layer/index.ts
@@ -229,10 +229,10 @@ export const setupDatabase = async (database: Knex) => {
     }
 
     // Completed jobs become uploads. Any left during startup means they failed.
-    // Claude jobs are handled separately by markInterruptedClaudeJobs to preserve restart capability.
-    await database.raw(
-      "UPDATE jobs SET status = 'failed' WHERE status NOT IN ('done', 'failed', 'cancelled', 'interrupted') AND type IS DISTINCT FROM 'claude';"
-    );
+    // Claude AND Notion job types are excluded — their markInterrupted* methods
+    // in server.ts own those rows so they surface as restartable 'interrupted',
+    // not 'failed' with no reason (#4176).
+    await new JobRepository(database).failStrandedLegacyJobs();
   } catch (error) {
     console.error(error);
     process.exit(1);

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-22-interrupted-status.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-22-interrupted-status.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-22-interrupted-status",
+  "date": "2026-08-22",
+  "type": "fix",
+  "title": "Notion conversions caught mid-update show as interrupted with a restart, not failed with no reason"
+}


### PR DESCRIPTION
Fixes #4176

## What

`setupDatabase()` runs a stranded-job sweep at boot — `UPDATE jobs SET status='failed' WHERE … type IS DISTINCT FROM 'claude'` — **before** `markInterruptedNotionJobs()` runs in `server.ts`. The sweep matched every non-claude type, so every in-flight Notion page/database/conversion job killed by a deploy force-exit (≈2/week, see #4177) landed as **"Failed"** with a NULL failure reason, and the interrupted-marking has been dead code on every prod boot. Claude jobs were unaffected (their exclusion already existed).

The fix: the sweep now excludes the job types whose `markInterrupted*` methods own them — `claude`, `page`, `database`, `conversion` — and moved from a raw SQL string in `data_layer/index.ts` to `JobRepository.failStrandedLegacyJobs()`, where it is testable next to the methods it must stay consistent with. NULL-type and unknown-type rows keep the old behavior (swept to failed). With the exclusion in place, boot ordering no longer matters.

User-visible effect: a conversion caught by a deploy restart now shows "Interrupted" with the restart affordance, instead of "Failed" with no reason.

## Tests

New `JobRepository` cases (all failed before the fix where applicable):
- in-flight `page` job survives the sweep and becomes `interrupted` via `markInterruptedNotionJobs`
- in-flight `claude` job untouched by the sweep
- in-flight unknown-type and NULL-type jobs still swept to `failed`
- terminal rows never touched

Full server suite 6568 passed (only the documented environmental `getPageCount` pdfinfo failures). tsc + `pnpm format:check` clean.

Changelog entry included. Browser check: not applicable — only `web/src/` file is the changelog JSON. Sonar: not run locally; PR decoration will report.
