### PR TITLE
fix: bound server.close so the conversion pool keeps its drain window

### DIFF
--- a/src/lib/gracefulShutdown.test.ts
+++ b/src/lib/gracefulShutdown.test.ts
@@ -10,6 +10,7 @@ import type { Knex } from 'knex';
 import { shutdownConversionPool } from './conversionPool';
 import {
   gracefulShutdown,
+  HTTP_CLOSE_BUDGET_MS,
   POOL_DRAIN_TIMEOUT_MS,
   SHUTDOWN_TIMEOUT_MS,
   PM2_KILL_TIMEOUT_MS,
@@ -140,6 +141,51 @@ describe('gracefulShutdown', () => {
   it('orders the timeouts so drain finishes before the hard exit and pm2 SIGKILL', () => {
     expect(POOL_DRAIN_TIMEOUT_MS).toBeLessThan(SHUTDOWN_TIMEOUT_MS);
     expect(SHUTDOWN_TIMEOUT_MS).toBeLessThan(PM2_KILL_TIMEOUT_MS);
+  });
+
+  it('bounds the HTTP close so piscina keeps its full self-managed window', () => {
+    const POOL_CLOSE_TIMEOUT_MS =
+      jest.requireActual<typeof import('./conversionPool')>(
+        './conversionPool'
+      ).POOL_CLOSE_TIMEOUT_MS;
+    expect(HTTP_CLOSE_BUDGET_MS + POOL_CLOSE_TIMEOUT_MS).toBeLessThan(
+      SHUTDOWN_TIMEOUT_MS
+    );
+  });
+
+  it('severs hung connections after the close budget so the drain still runs', async () => {
+    jest.useFakeTimers();
+    const warnSpy = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    let closeCb: (() => void) | undefined;
+    const calls = { closeAll: 0 };
+    // An open SSE stream is an in-flight request: closeIdleConnections cannot
+    // reap it and server.close waits for it forever.
+    const server = {
+      close: (cb?: () => void) => {
+        closeCb = cb;
+        return server;
+      },
+      closeIdleConnections: () => undefined,
+      closeAllConnections: () => {
+        calls.closeAll += 1;
+        closeCb?.();
+      },
+    } as unknown as http.Server;
+    const { db, destroyCalls } = fakeDatabase();
+
+    const done = gracefulShutdown('SIGINT', server, db);
+    await Promise.resolve();
+    jest.advanceTimersByTime(HTTP_CLOSE_BUDGET_MS + 1);
+    await done;
+
+    expect(calls.closeAll).toBe(1);
+    expect(drainMock).toHaveBeenCalledTimes(1);
+    expect(destroyCalls.count).toBe(1);
+    expect(exitSpy).toHaveBeenCalledWith(0);
+    warnSpy.mockRestore();
+    jest.useRealTimers();
   });
 
   it('gives in-flight conversions room past the old 23s window that force-killed large decks', () => {

--- a/src/lib/gracefulShutdown.ts
+++ b/src/lib/gracefulShutdown.ts
@@ -20,6 +20,13 @@ export const SHUTDOWN_TIMEOUT_MS = 85_000;
 // 80s pool budget lets it finish, and the 5s reserve below SHUTDOWN_TIMEOUT_MS
 // covers the trailing database.destroy() before the hard exit.
 export const POOL_DRAIN_TIMEOUT_MS = POOL_CLOSE_TIMEOUT_MS + 3_000;
+// server.close() waits for every in-flight request, and an open SSE stream or
+// a slow client transfer is one closeIdleConnections cannot reap — unbounded,
+// this phase ate the whole 85s clock and starved the pool of its drain window
+// (~2 force-exits/week, #4177). After this budget the remaining connections
+// are severed; the retiring color is already off the load balancer, so the
+// only requests cut are ones that would die at the hard exit anyway.
+export const HTTP_CLOSE_BUDGET_MS = 2_000;
 
 let shuttingDown = false;
 
@@ -45,7 +52,16 @@ export async function gracefulShutdown(
   hardExit.unref();
 
   server.closeIdleConnections?.();
-  await new Promise<void>((resolve) => server.close(() => resolve()));
+  const closed = new Promise<void>((resolve) => server.close(() => resolve()));
+  const closeBudget = setTimeout(() => {
+    console.warn(
+      `HTTP close exceeded ${HTTP_CLOSE_BUDGET_MS}ms — severing remaining connections`
+    );
+    server.closeAllConnections?.();
+  }, HTTP_CLOSE_BUDGET_MS);
+  closeBudget.unref();
+  await closed;
+  clearTimeout(closeBudget);
 
   try {
     await shutdownConversionPool({ timeoutMs: POOL_DRAIN_TIMEOUT_MS });


### PR DESCRIPTION
Fixes #4177

## What

`Graceful shutdown exceeded 85000ms — forcing exit` fires on ~a quarter of blue-green retirements (25 times in 11 weeks, most recently Aug 18 and Aug 20). Cause: `gracefulShutdown` awaits `server.close()` **unbounded** before the conversion pool's 80s drain window, under the same 85s hard-exit clock. An open SSE stream (chat) or a slow client transfer is an in-flight request `closeIdleConnections` cannot reap — when one lingers, the close phase eats the clock and the hard exit kills conversions mid-flight (the Aug 20 retirement's last log line was a Notion conversion mid-retry).

The close now runs under a 2s budget (`HTTP_CLOSE_BUDGET_MS`); on expiry the remaining connections are severed with `server.closeAllConnections()` and the drain proceeds. Severing is safe here: blue-green puts the new color live before the old one drains, so the retiring process is already off the load balancer and those connections would die at the hard exit anyway — this just converts "conversion killed at 85s" into "idle-ish socket severed at 2s, conversion saved."

Budget arithmetic: 2s close + piscina's 80s self-managed window + margin for `database.destroy()` fits inside the 85s clock (asserted by a new invariant test). The outer 83s pool race stays as the backstop for a hung `close()` itself.

## Also noted during the investigation (no code change here)

- The "25000ms" line that triggered the issue turned out to be a **May-era orphan log line** inherited through pm2 process-id reuse — pm2 appends to leftover per-id log files. Ops suggestion for the deploy script (not in this PR): remove stale `~/.pm2/logs/server-{blue,green}-*-<id>.log` files when creating a color app, so log archaeology stops producing ghosts.
- The companion boot-marking fix (#4176 / PR #4185) makes the jobs a force-exit does kill surface as restartable "Interrupted" rather than "Failed".

## Tests

- New: hung-connection scenario — close callback only fires when `closeAllConnections` severs; asserts the pool drain and DB teardown still run and the process exits 0. Fails on the old code (hangs past the close await).
- New invariant: `HTTP_CLOSE_BUDGET_MS + POOL_CLOSE_TIMEOUT_MS < SHUTDOWN_TIMEOUT_MS`.
- Existing 6 shutdown tests unchanged and green (8/8 total). Full server suite 6566 passed (only the documented environmental `getPageCount` pdfinfo failures). tsc + `pnpm format:check` clean.

No changelog entry — deploy-time reliability, no user-visible surface change. Sonar: not run locally; PR decoration will report.
