### PR TITLE
fix: retry the conversion failure write through a database blip

### DIFF
--- a/src/lib/storage/jobs/helpers/performConversion.ts
+++ b/src/lib/storage/jobs/helpers/performConversion.ts
@@ -14,6 +14,7 @@ import {
 import { CreateJobWorkSpaceUseCase } from '../../../../usecases/jobs/CreateJobWorkSpaceUseCase';
 import { CreateFlashcardsForJobUseCase } from '../../../../usecases/jobs/CreateFlashcardsForJobUseCase';
 import { SetJobFailedUseCase } from '../../../../usecases/jobs/SetJobFailedUseCase';
+import { persistJobFailureWithRetry } from './persistJobFailureWithRetry';
 import { BuildDeckForJobUseCase } from '../../../../usecases/jobs/BuildDeckForJobUseCase';
 import { CompleteJobUseCase } from '../../../../usecases/jobs/CompleteJobUseCase';
 import { NotifyUserUseCase } from '../../../../usecases/jobs/NotifyUserUseCase';
@@ -428,7 +429,9 @@ export default async function performConversion(
       }
     }
     const failedJob = new SetJobFailedUseCase(jobRepository);
-    await failedJob.execute(id, owner, jobFailureReasonFromError(error, id));
+    await persistJobFailureWithRetry(() =>
+      failedJob.execute(id, owner, jobFailureReasonFromError(error, id))
+    );
     trackConversionFailed(owner, anonId, type, resolvedSignupOrigin, {
       reason: jobFailureReasonCode(error),
     });

--- a/src/lib/storage/jobs/helpers/persistJobFailureWithRetry.test.ts
+++ b/src/lib/storage/jobs/helpers/persistJobFailureWithRetry.test.ts
@@ -1,0 +1,80 @@
+import {
+  isConnectionClassError,
+  persistJobFailureWithRetry,
+} from './persistJobFailureWithRetry';
+
+function connectionError(code: string): Error {
+  return Object.assign(new Error(`connect ${code} 127.0.0.1:5432`), { code });
+}
+
+describe('isConnectionClassError', () => {
+  it('matches socket-level connection failures', () => {
+    expect(isConnectionClassError(connectionError('ECONNREFUSED'))).toBe(true);
+    expect(isConnectionClassError(connectionError('ECONNRESET'))).toBe(true);
+    expect(isConnectionClassError(connectionError('ETIMEDOUT'))).toBe(true);
+  });
+
+  it('matches postgres shutdown/startup SQLSTATEs', () => {
+    expect(isConnectionClassError(connectionError('57P01'))).toBe(true);
+    expect(isConnectionClassError(connectionError('57P03'))).toBe(true);
+  });
+
+  it('does not match ordinary errors', () => {
+    expect(isConnectionClassError(new Error('boom'))).toBe(false);
+    expect(
+      isConnectionClassError(
+        Object.assign(new Error('bad sql'), { code: '42601' })
+      )
+    ).toBe(false);
+    expect(isConnectionClassError(undefined)).toBe(false);
+  });
+});
+
+describe('persistJobFailureWithRetry', () => {
+  it('returns after the first attempt when the write succeeds', async () => {
+    const write = jest.fn().mockResolvedValue(undefined);
+    const sleepFn = jest.fn().mockResolvedValue(undefined);
+
+    await persistJobFailureWithRetry(write, { sleepFn });
+
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(sleepFn).not.toHaveBeenCalled();
+  });
+
+  it('retries a connection-class failure until the database is back', async () => {
+    const write = jest
+      .fn()
+      .mockRejectedValueOnce(connectionError('ECONNREFUSED'))
+      .mockRejectedValueOnce(connectionError('ECONNREFUSED'))
+      .mockResolvedValueOnce(undefined);
+    const sleepFn = jest.fn().mockResolvedValue(undefined);
+
+    await persistJobFailureWithRetry(write, { sleepFn });
+
+    expect(write).toHaveBeenCalledTimes(3);
+    expect(sleepFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry a non-connection failure', async () => {
+    const err = new Error('constraint violation');
+    const write = jest.fn().mockRejectedValue(err);
+    const sleepFn = jest.fn().mockResolvedValue(undefined);
+
+    await expect(persistJobFailureWithRetry(write, { sleepFn })).rejects.toBe(
+      err
+    );
+    expect(write).toHaveBeenCalledTimes(1);
+  });
+
+  it('rethrows the last error when attempts are exhausted', async () => {
+    const err = connectionError('ECONNREFUSED');
+    const write = jest.fn().mockRejectedValue(err);
+    const sleepFn = jest.fn().mockResolvedValue(undefined);
+
+    await expect(persistJobFailureWithRetry(write, { sleepFn })).rejects.toBe(
+      err
+    );
+    expect(write).toHaveBeenCalledTimes(4);
+    expect(sleepFn).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/lib/storage/jobs/helpers/persistJobFailureWithRetry.ts
+++ b/src/lib/storage/jobs/helpers/persistJobFailureWithRetry.ts
@@ -1,0 +1,57 @@
+// When a conversion dies because Postgres itself went away (the quarterly
+// unattended-upgrades restart is ~4 seconds of ECONNREFUSED), the failure
+// WRITE dies with it and the job strands in a non-terminal status — locked
+// behind the 15-minute staleness window with 409s on every retry click
+// (#4178). The database is back in seconds, so a short retry lands the job in
+// 'failed', which is immediately restartable with an honest reason.
+
+const CONNECTION_ERROR_CODES = new Set([
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'EAI_AGAIN',
+  'EPIPE',
+  // Postgres SQLSTATEs for a server going down / not yet accepting connections.
+  '57P01',
+  '57P02',
+  '57P03',
+]);
+
+export function isConnectionClassError(error: unknown): boolean {
+  if (error == null || typeof error !== 'object') return false;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === 'string' && CONNECTION_ERROR_CODES.has(code);
+}
+
+const RETRY_DELAYS_MS = [5_000, 10_000, 15_000];
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function persistJobFailureWithRetry(
+  write: () => Promise<unknown>,
+  options: { sleepFn?: (ms: number) => Promise<void> } = {}
+): Promise<void> {
+  const doSleep = options.sleepFn ?? sleep;
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt++) {
+    try {
+      await write();
+      return;
+    } catch (error) {
+      lastError = error;
+      if (
+        !isConnectionClassError(error) ||
+        attempt === RETRY_DELAYS_MS.length
+      ) {
+        throw error;
+      }
+      console.warn(
+        `[conversion] failure write hit a connection error; retrying in ${RETRY_DELAYS_MS[attempt]}ms`
+      );
+      await doSleep(RETRY_DELAYS_MS[attempt]);
+    }
+  }
+  throw lastError;
+}


### PR DESCRIPTION
Fixes #4178

## What

2026-08-21 06:07 UTC: unattended-upgrades installed the postgresql-14 security update and restarted the cluster — ~4 seconds of `ECONNREFUSED`. A Notion conversion in flight died on a DB call, and then the failure **write** died on the same outage: `performConversion`'s catch calls `SetJobFailedUseCase`, which needs the same unreachable database. The job stranded in a non-terminal `started` status — locked behind the 15-minute staleness window, returning 409 `already_in_progress` on every retry click. The affected user self-recovered 24 minutes after a 4-second outage. PG minor security releases land this way roughly quarterly, always in the same early-morning window.

Fix: the failure write now runs through `persistJobFailureWithRetry` — up to 3 retries over ~30s, **only** for connection-class errors (socket codes + the Postgres shutdown/startup SQLSTATEs `57P01/57P02/57P03`). The database is back in seconds, so the job lands in `failed` with its honest reason — immediately restartable — instead of a 15-minute lockout. Non-connection errors (constraint violations, bad SQL) still throw on the first attempt, and exhausted retries propagate exactly as before.

Deliberately NOT built (per the investigation): retrying the conversion itself — complexity not justified by a 4s/quarter exposure window — and any change to the upgrade window (a security update restarting PG is working as intended).

## Tests

- New `persistJobFailureWithRetry.test.ts`: succeeds first try without sleeping; retries `ECONNREFUSED` until the DB is back; does not retry non-connection errors; rethrows after exhausting attempts; `isConnectionClassError` classification incl. SQLSTATEs.
- `src/lib/storage/jobs/helpers` suite 123 passed; full server suite 6571 passed (only the documented environmental `getPageCount` pdfinfo failures). tsc + `pnpm format:check` clean.

No changelog entry — infra resilience, no user-visible surface change. Sonar: not run locally; PR decoration will report.

Ops observation from the same audit (no code change): the box has ~105 days uptime with six staged security kernels waiting on a reboot (`Automatic-Reboot` is off) — staged kernel fixes aren't active until a planned reboot happens.
