### PR TITLE
docs: route legacy csv-to-apkg sibling in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ This checkout (`2anki/server`) is the backend + web app. The **native iOS app is
 
 - **Native app / ASO / App Store listing / store metadata / StoreKit / Swift** → `2anki.app` repo and **its** agents (they have the app, the current listing, the screenshots, the feature set in front of them). Do NOT draft ASO or store copy from this server checkout — it's context-poor and the metadata PR lands over there.
 - **Backend, web app, conversion pipeline, Notion/Stripe/Claude integrations, funnel instrumentation** → here in `2anki/server`.
+- **Legacy sibling `2anki/csv-to-apkg`** (npm lib, local checkout at `../csv-to-apkg`): the server no longer uses it — CSV parses in-repo (`src/lib/parser/experimental/FallbackParser.ts`, `src/lib/csv/`) and apkg generation uses the vendored `create_deck/`. The `@2anki/csv-to-apkg` entry in `package.json` has zero imports and is safe to drop. The standalone lib still reads this repo's `src/templates/` at runtime when used on its own.
 
 A strategy issue may be *filed* in `2anki/server` for tracking (e.g. #3582 ASO, #3688 native) while the *work* executes in `2anki.app` — create/mirror the actionable issue in `2anki.app` and cross-link (`2anki/server#NNNN`). Open app issues with `gh issue create --repo Laer-Smart/2anki.app`.
 


### PR DESCRIPTION
## Why

The "Repos — route work to the right one" section covered only server vs the native app. Sessions had no pointer that the `../csv-to-apkg` sibling is legacy: the server declares `@2anki/csv-to-apkg` in package.json but has **zero imports** of it anywhere in `src/`, `web/src/`, or `scripts/` — CSV parses in-repo (`src/lib/parser/experimental/FallbackParser.ts`, `src/lib/csv/`) and apkg generation uses the vendored `create_deck/`.

## What

One bullet added to the repos section recording the legacy status, where CSV/apkg conversion actually lives, and that the standalone lib reads this repo's `src/templates/` only when used on its own.

Follow-up candidate (not in this PR): drop the dead `@2anki/csv-to-apkg` dependency.

Docs-only: no changelog (not user-visible), no web/src changes, Sonar not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVtT5QFtJBSqLv7raVM7Xr