### PR TITLE
fix: gate mindmap image uploads on magic bytes, not claimed type

### DIFF
--- a/src/controllers/MindmapController.ts
+++ b/src/controllers/MindmapController.ts
@@ -208,7 +208,7 @@ export class MindmapController {
       const result = await useCase.execute({
         userId,
         mapId,
-        file: { buffer: file.buffer, mimetype: file.mimetype, size: file.size },
+        file: { buffer: file.buffer, size: file.size },
       });
       res.status(201).json({
         url: result.presignedUrl,

--- a/src/usecases/mindmaps/UploadMindmapImageUseCase.test.ts
+++ b/src/usecases/mindmaps/UploadMindmapImageUseCase.test.ts
@@ -36,7 +36,7 @@ describe('UploadMindmapImageUseCase', () => {
     const result = await useCase.execute({
       userId: '42',
       mapId: 'map-1',
-      file: { buffer: TINY_PNG, mimetype: 'image/png', size: TINY_PNG.length },
+      file: { buffer: TINY_PNG, size: TINY_PNG.length },
     });
 
     expect(result.s3Key).toMatch(/^mindmaps\/42\/map-1\/.+\.png$/);
@@ -57,11 +57,7 @@ describe('UploadMindmapImageUseCase', () => {
       useCase.execute({
         userId: '42',
         mapId: 'map-1',
-        file: {
-          buffer: svgBuf,
-          mimetype: 'image/svg+xml',
-          size: svgBuf.length,
-        },
+        file: { buffer: svgBuf, size: svgBuf.length },
       })
     ).rejects.toBeInstanceOf(MindmapImageTypeError);
 
@@ -77,7 +73,7 @@ describe('UploadMindmapImageUseCase', () => {
       useCase.execute({
         userId: '42',
         mapId: 'map-1',
-        file: { buffer: big, mimetype: 'image/png', size: big.length },
+        file: { buffer: big, size: big.length },
       })
     ).rejects.toBeInstanceOf(MindmapImageTooLargeError);
 
@@ -91,9 +87,38 @@ describe('UploadMindmapImageUseCase', () => {
     const result = await useCase.execute({
       userId: '7',
       mapId: 'abc',
-      file: { buffer: TINY_PNG, mimetype: 'image/jpeg', size: TINY_PNG.length },
+      file: { buffer: TINY_PNG, size: TINY_PNG.length },
     });
 
-    expect(result.s3Key).toMatch(/^mindmaps\/7\/abc\/.+\.jpg$/);
+    expect(result.s3Key).toMatch(/^mindmaps\/7\/abc\/.+\.png$/);
+  });
+
+  it('rejects a non-image payload regardless of the declared content type', async () => {
+    const storage = makeStorage();
+    const useCase = new UploadMindmapImageUseCase(storage);
+    const icns = Buffer.concat([Buffer.from('icns'), Buffer.alloc(64, 0x01)]);
+
+    await expect(
+      useCase.execute({
+        userId: '42',
+        mapId: 'map-1',
+        file: { buffer: icns, size: icns.length },
+      })
+    ).rejects.toBeInstanceOf(MindmapImageTypeError);
+
+    expect(storage.uploadFile).not.toHaveBeenCalled();
+  });
+
+  it('derives the stored extension from the detected type, not a claim', async () => {
+    const storage = makeStorage();
+    const useCase = new UploadMindmapImageUseCase(storage);
+
+    const result = await useCase.execute({
+      userId: '42',
+      mapId: 'map-1',
+      file: { buffer: TINY_PNG, size: TINY_PNG.length },
+    });
+
+    expect(result.s3Key).toMatch(/\.png$/);
   });
 });

--- a/src/usecases/mindmaps/UploadMindmapImageUseCase.ts
+++ b/src/usecases/mindmaps/UploadMindmapImageUseCase.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import imageSize from 'image-size';
 
 import StorageHandler from '../../lib/storage/StorageHandler';
+import { detectFileMime } from '../../lib/detectFileMime';
 
 const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
 const ALLOWED_MIME_TYPES = new Set([
@@ -31,7 +32,6 @@ interface UploadInput {
   mapId: string;
   file: {
     buffer: Buffer;
-    mimetype: string;
     size: number;
   };
 }
@@ -49,15 +49,16 @@ export class UploadMindmapImageUseCase {
   async execute(input: UploadInput): Promise<MindmapImageResult> {
     const { userId, mapId, file } = input;
 
-    if (!ALLOWED_MIME_TYPES.has(file.mimetype)) {
-      throw new MindmapImageTypeError();
-    }
-
     if (file.size > MAX_IMAGE_BYTES) {
       throw new MindmapImageTooLargeError();
     }
 
-    const ext = this.extensionFor(file.mimetype);
+    const detectedType = detectFileMime(file.buffer);
+    if (detectedType == null || !ALLOWED_MIME_TYPES.has(detectedType)) {
+      throw new MindmapImageTypeError();
+    }
+
+    const ext = this.extensionFor(detectedType);
     const s3Key = `mindmaps/${userId}/${mapId}/${randomUUID()}${ext}`;
 
     await this.storage.uploadFile(s3Key, file.buffer);

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-22-mindmap-image-check.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-22-mindmap-image-check.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-22-mindmap-image-check",
+  "date": "2026-08-22",
+  "type": "fix",
+  "title": "Mindmap image uploads verify the file is really a PNG, JPEG, GIF, or WebP before saving"
+}


### PR DESCRIPTION
## What

Closes the one `image-size` exposure left open by the dependency sweep (https://github.com/2anki/server/pull/4190). Dependabot alerts 404/405 report infinite-loop DoS in image-size's ICNS/JXL/HEIF parsers with **no patched release** — so the fix is a gate, not a bump.

Three call sites use `imageSize()` on user bytes. Two already detect the type from the buffer (`detectFileMime` magic bytes) before parsing. The third — `UploadMindmapImageUseCase` — trusted the client-declared `file.mimetype`, so a crafted non-image buffer sent with `Content-Type: image/png` passed the allowlist and reached the vulnerable parser: an event-loop hang on the main server process, triggerable by any authenticated user.

Now:
- Type is detected from the buffer (same `detectFileMime` gate as the other two sites); anything outside png/jpeg/gif/webp gets the existing 415.
- The stored S3 extension derives from the detected type, not the claim.
- The 5 MB size cap runs before any content inspection.
- `mimetype` is gone from the use-case input — the claim is no longer consulted at all.

One prior test codified the spoof (PNG bytes claimed as `image/jpeg`, asserted a `.jpg` key); replaced with the detected-type contract per the testing rules.

User-visible side effect (changelog entry included): a renamed or mislabeled file (e.g. an iPhone HEIC posing as .png) now gets the clear "Only PNG, JPEG, GIF, and WebP images are accepted" error instead of an opaque failure.

## Tests

- `UploadMindmapImageUseCase.test.ts` 6/6 — new failing-first cases: non-image payload rejected regardless of declared type (ICNS magic bytes), extension follows detected type; existing accept/SVG-reject/size-cap cases updated to the mimetype-free input.
- Full server suite: 6602 passed (only the documented `getPageCount` pdfinfo environmental failures). `tsc -p . --noEmit` clean, `pnpm format:check` clean, `pnpm arch` 0 errors.

Sonar: not run locally; PR decoration will report.

No web/src source change (changelog JSON only) — no browser check applicable.
