### PR TITLE
fix: stop reporting self-healed stale-chunk reloads as errors

### DIFF
--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -9,8 +9,11 @@ import { SkeletonPage } from './components/Skeleton/Skeleton';
 import { RootErrorBoundary } from './components/RootErrorBoundary/RootErrorBoundary';
 import { initTheme } from './lib/theme';
 import { initI18n } from './lib/i18n';
-import { recoverFromChunkError } from './lib/chunkReload';
-import { reportClientError } from './lib/reportClientError';
+import { isChunkLoadError, recoverFromChunkError } from './lib/chunkReload';
+import {
+  reportClientError,
+  reportDeclinedChunkRecovery,
+} from './lib/reportClientError';
 
 window.addEventListener('error', (event) => {
   recoverFromChunkError(event.error);
@@ -37,11 +40,14 @@ function main() {
     <React.StrictMode>
       <Suspense fallback={<SkeletonPage />}>
         <RootErrorBoundary
-          onError={(error, errorInfo) =>
-            reportClientError(error, {
-              componentStack: errorInfo.componentStack,
-            })
-          }
+          onError={(error, errorInfo) => {
+            const context = { componentStack: errorInfo.componentStack };
+            if (isChunkLoadError(error)) {
+              reportDeclinedChunkRecovery(error, context);
+              return;
+            }
+            reportClientError(error, context);
+          }}
         >
           <App />
         </RootErrorBoundary>

--- a/web/src/lib/reportClientError.test.ts
+++ b/web/src/lib/reportClientError.test.ts
@@ -237,4 +237,25 @@ describe('reportClientError', () => {
     );
     expect(fetchSpy).not.toHaveBeenCalled();
   });
+
+  it('skips the WebKit stale-chunk import failure', () => {
+    reportClientError(new Error('Importing a module script failed.'));
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('skips the Chromium stale-chunk import failure', () => {
+    reportClientError(
+      new Error(
+        'Failed to fetch dynamically imported module: https://2anki.net/assets/DownloadsPage-abc123.js'
+      )
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('skips an error named ChunkLoadError regardless of message', () => {
+    const chunkError = new Error('Loading chunk 42 failed.');
+    chunkError.name = 'ChunkLoadError';
+    reportClientError(chunkError);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
 });

--- a/web/src/lib/reportClientError.test.ts
+++ b/web/src/lib/reportClientError.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { reportClientError } from './reportClientError';
+import {
+  reportClientError,
+  reportDeclinedChunkRecovery,
+} from './reportClientError';
 import { UserNotice } from './errors/UserNotice';
 import { getClientRelease } from './release';
 
@@ -243,5 +246,26 @@ describe('reportClientError', () => {
     chunkError.name = 'ChunkLoadError';
     reportClientError(chunkError);
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('reportDeclinedChunkRecovery', () => {
+  it('reports the declined recovery with a message the chunk skip cannot match', () => {
+    reportDeclinedChunkRecovery(
+      new Error('Importing a module script failed.'),
+      { componentStack: 'at LazyRoute' }
+    );
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const [, init] = getLastCall();
+    const body = JSON.parse(init.body as string) as {
+      message: string;
+      context: Record<string, unknown>;
+    };
+    expect(body.message).toBe('Stale chunk failed again within cooldown');
+    expect(body.context).toMatchObject({
+      originalMessage: 'Importing a module script failed.',
+      componentStack: 'at LazyRoute',
+    });
   });
 });

--- a/web/src/lib/reportClientError.test.ts
+++ b/web/src/lib/reportClientError.test.ts
@@ -229,26 +229,12 @@ describe('reportClientError', () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it('skips an Unable to preload CSS chunk error', () => {
-    reportClientError(
-      new Error(
-        'Unable to preload CSS for https://cdn.2anki.net/assets/index-abc123.css'
-      )
-    );
-    expect(fetchSpy).not.toHaveBeenCalled();
-  });
-
-  it('skips the WebKit stale-chunk import failure', () => {
-    reportClientError(new Error('Importing a module script failed.'));
-    expect(fetchSpy).not.toHaveBeenCalled();
-  });
-
-  it('skips the Chromium stale-chunk import failure', () => {
-    reportClientError(
-      new Error(
-        'Failed to fetch dynamically imported module: https://2anki.net/assets/DownloadsPage-abc123.js'
-      )
-    );
+  it.each([
+    'Unable to preload CSS for https://cdn.2anki.net/assets/index-abc123.css',
+    'Importing a module script failed.',
+    'Failed to fetch dynamically imported module: https://2anki.net/assets/DownloadsPage-abc123.js',
+  ])('skips the stale-chunk failure message %s', (message) => {
+    reportClientError(new Error(message));
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 

--- a/web/src/lib/reportClientError.ts
+++ b/web/src/lib/reportClientError.ts
@@ -1,4 +1,5 @@
 import { UserNotice } from './errors/UserNotice';
+import { isChunkLoadError } from './chunkReload';
 import { isDomManipulationError } from './isDomManipulationError';
 import { getClientRelease } from './release';
 
@@ -64,6 +65,7 @@ export function reportClientError(
 ): void {
   if (error instanceof UserNotice) return;
   if (isAbortError(error)) return;
+  if (isChunkLoadError(error)) return;
   if (isDomManipulationError(error)) return;
   if (isExpectedClientFault(error)) return;
   if (isTransientGatewayGetError(error)) return;

--- a/web/src/lib/reportClientError.ts
+++ b/web/src/lib/reportClientError.ts
@@ -59,6 +59,25 @@ function isTransientGatewayGetError(error: unknown): boolean {
   );
 }
 
+/**
+ * The one chunk-failure state ops still needs to see: the reload guard
+ * declined to recover (second failure inside the cooldown) and the user is
+ * looking at the fallback UI. Reported under a distinct message that the
+ * chunk-error skip cannot match; the original browser wording rides in
+ * context.
+ */
+export function reportDeclinedChunkRecovery(
+  error: unknown,
+  context?: Record<string, unknown>
+): void {
+  const originalMessage =
+    error instanceof Error ? error.message : String(error);
+  reportClientError(new Error('Stale chunk failed again within cooldown'), {
+    ...context,
+    originalMessage,
+  });
+}
+
 export function reportClientError(
   error: unknown,
   context?: Record<string, unknown>


### PR DESCRIPTION
## What

Triage outcome for the `/ops/errors` top group: **"Importing a module script failed." (12 occurrences, 6 releases) is noise from successfully self-healed stale-chunk reloads** — a user has a tab open across a deploy, the next lazy navigation requests a hashed chunk that no longer exists, the reload guard (`chunkReload.ts`) recognizes the message and reloads, the user recovers. But `reportClientError` had no matching skip (only `'Unable to preload'` was filtered), so `RouteRecoveryBoundary` / the App error handler filed an error event for every recovery. That's why the group re-surfaced **8 times after being marked resolved on Jul 31** — it can never stay resolved while deploys keep happening.

Fix: `reportClientError` now skips anything `isChunkLoadError` classifies as recoverable — the same single source of truth the reload guard uses. No diagnostic signal lost: the repeated-failure case (cooldown active) still shows the user the fallback UI, and its report carried the identical message hash anyway.

## The rest of the triage (no code needed)

| Group | Verdict |
|---|---|
| `connect ECONNREFUSED 127.0.0.1:5432` (2×, one minute on Aug 21) | Transient Postgres restart — likely unattended-upgrades applying a PG patch; the box carried 105 days of staged updates until yesterday's reboot. Mark resolved; #4187's connection-retry already covers job-failure persistence. |
| `Cannot read properties of undefined (reading 'Front')` (1×, /templates, Aug 21 13:52) | **Already fixed** — #4163 ("keep the note types page alive when previewData is missing") merged 21:20 the same day; the event predates the fix. Mark resolved. |
| `MulterError: Field value too long` (1×, /api/chat/message) | A >1 MB text field hit multer's default `fieldSize`; surfaces as an unhandled 500 instead of a clean 413. Filed as a follow-up (see PR comment) — one occurrence, not urgent. |

## Tests

- 3 new cases in `reportClientError.test.ts` (WebKit + Chromium stale-chunk messages, `ChunkLoadError` name), failing-first.
- Full web suite 3318 passed; web typecheck clean; `pnpm format:check` clean.

No changelog entry — internal error-reporting hygiene, no user-visible behavior change.

Browser check: not applicable — removes a fire-and-forget error-report POST on a recovery path that ends in a full page reload; no visible UI change, covered by unit tests on the reporter skip contract.

Sonar: not run locally; PR decoration will report.

