### PR TITLE
fix: stop serving internal error text as a 400 to the client

### DIFF
--- a/src/routes/middleware/ErrorHandler.test.ts
+++ b/src/routes/middleware/ErrorHandler.test.ts
@@ -323,4 +323,74 @@ describe('ErrorHandler', () => {
     expect(res.send).not.toHaveBeenCalled();
     expect(res.json).not.toHaveBeenCalled();
   });
+
+  test('a TypeError responds 500 with a generic body, not the internal message', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const res = makeResponse(false);
+    const req = makeRequest();
+
+    await ErrorHandler(
+      res as unknown as express.Response,
+      req,
+      new TypeError(
+        "Cannot destructure property 'name' of 'req.body' as it is undefined."
+      )
+    );
+
+    expect(res.statusCode).toBe(500);
+    const body = res.body as { code: string; message: string };
+    expect(body.code).toBe('unknown');
+    expect(body.message).not.toContain('req.body');
+    expect(body.message).toContain('support@2anki.net');
+    errorSpy.mockRestore();
+  });
+
+  test('a Knex pool error responds 500 with a generic body', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const res = makeResponse(false);
+    const req = makeRequest();
+
+    await ErrorHandler(
+      res as unknown as express.Response,
+      req,
+      new Error(
+        'Knex: Timeout acquiring a connection. The pool is probably full.'
+      )
+    );
+
+    expect(res.statusCode).toBe(500);
+    const body = res.body as { code: string; message: string };
+    expect(body.message).not.toContain('Knex');
+    errorSpy.mockRestore();
+  });
+
+  test('a SQLSTATE-coded database error responds 500 with a generic body', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const res = makeResponse(false);
+    const req = makeRequest();
+
+    const dbError = Object.assign(
+      new Error('null value in column "user_id" violates not-null constraint'),
+      { code: '23502' }
+    );
+    await ErrorHandler(res as unknown as express.Response, req, dbError);
+
+    expect(res.statusCode).toBe(500);
+    const body = res.body as { code: string; message: string };
+    expect(body.message).not.toContain('user_id');
+    errorSpy.mockRestore();
+  });
+
+  test('a malformed-JSON body error keeps its 400 and message', async () => {
+    const res = makeResponse(false);
+    const req = makeRequest();
+
+    const parseError = Object.assign(
+      new SyntaxError('Unexpected token < in JSON at position 0'),
+      { type: 'entity.parse.failed' }
+    );
+    await ErrorHandler(res as unknown as express.Response, req, parseError);
+
+    expect(res.statusCode).toBe(400);
+  });
 });

--- a/src/routes/middleware/ErrorHandler.tsx
+++ b/src/routes/middleware/ErrorHandler.tsx
@@ -126,10 +126,43 @@ export default async function ErrorHandler(
     return;
   }
 
+  if (!quietError && isInternalFault(err)) {
+    const body: UploadErrorBody = {
+      code: 'unknown',
+      message:
+        'Something broke on our end. Try again — if it keeps failing, email support@2anki.net.',
+    };
+    res.status(500).json(body);
+    return;
+  }
+
   const code: UploadErrorCode =
     err instanceof PythonExitError ? toUploadErrorCode(err.kind) : 'unknown';
   const body: UploadErrorBody = { code, message: err.message };
   res.status(400).json(body);
+}
+
+const SQLSTATE_RE = /^[0-9A-Z]{5}$/;
+
+/**
+ * Native JS error classes and database faults are never intentional
+ * user-facing messages — surfacing err.message for these leaks internals
+ * (CWE-209) and mislabels a server bug as a client fault. Deliberate throws
+ * (limit errors, upload-shape errors) are plain Error and keep the 400 path.
+ */
+function isInternalFault(err: Error): boolean {
+  if (
+    err instanceof TypeError ||
+    err instanceof RangeError ||
+    err instanceof ReferenceError
+  ) {
+    return true;
+  }
+  if (err.message.startsWith('Knex:') || err.name === 'KnexTimeoutError') {
+    return true;
+  }
+  const code = (err as { code?: unknown }).code;
+  return typeof code === 'string' && SQLSTATE_RE.test(code);
 }
 
 function toMulterErrorBody(err: multer.MulterError): {

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-22-plain-error-message.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-22-plain-error-message.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-22-plain-error-message",
+  "date": "2026-08-22",
+  "type": "fix",
+  "title": "Unexpected server errors now show a plain message with a way to reach support"
+}


### PR DESCRIPTION
First staged step of https://github.com/2anki/server/issues/4195 (the architecture review's error-funnel finding). Does **not** close the issue — the HttpCodedError base + real error middleware remain.

## What

`ErrorHandler`'s fallback mapped every unhandled error to **status 400 with `err.message` in the body** — server bugs masqueraded as client faults and internal text leaked to users (CWE-209, against our own security rules). Both recent prod error groups demonstrate it: `Cannot destructure property 'name' of 'req.body'` (a TypeError) and `Knex: Timeout acquiring a connection. The pool is probably full` were served to users verbatim as 400s.

Now: **provably-internal** error classes respond 500 with a generic message + support address —
- native `TypeError` / `RangeError` / `ReferenceError`
- `Knex:`-prefixed messages and `KnexTimeoutError`
- SQLSTATE-coded database errors (5-char code)

## Why the narrow allowlist (regression safety)

The quiet-error classifiers (`isLimitError`, `isExpectedClientFault`) are deliberately narrow, and the upload path intentionally throws plain `Error`s whose message **is** the UX (limit messages, upload-shape errors). Blanket-genericizing all unknowns would turn those into opaque 500s — a worse regression than the leak. So this ships only the classes that are never intentional user copy, and the full migration to coded errors stays staged in #4195. Deliberate throws, `entity.parse.failed`, multer, Notion, and PythonExitError paths are all untouched (pinned by tests).

Copy follows VOICE.md: "Something broke on our end. Try again — if it keeps failing, email support@2anki.net."

## Tests

- 4 new failing-first cases: TypeError → 500 generic (no internal text, support address present); Knex pool error → 500; SQLSTATE-coded DB error → 500; malformed-JSON body keeps its 400 + message.
- `ErrorHandler.test.ts` 20/20. Full server suite 6606 passed (only the documented `getPageCount` pdfinfo environmental failures). `tsc --noEmit` clean, `pnpm format:check` clean.

Changelog entry included (the response text is user-visible).

Sonar: not run locally; PR decoration will report.

No web/src source change (changelog JSON only) — no browser check applicable.
