### PR TITLE
refactor: type block renderers against IBlockRenderer, not the class

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -42,10 +42,10 @@ module.exports = {
     {
       name: 'no-circular',
       comment:
-        'Circular dependency between modules. Break the cycle — extract the shared piece or invert one direction. 27 existing cycles cluster on the data_layer/index.ts barrel; surfaced as warn so the count cannot grow unnoticed.',
+        'Circular dependency between modules (runtime edges only — type-only imports are erased at compile time and cannot cycle at runtime). Break the cycle — extract the shared piece or invert one direction. Surfaced as warn so the count cannot grow unnoticed.',
       severity: 'warn',
       from: {},
-      to: { circular: true },
+      to: { circular: true, dependencyTypesNot: ['type-only'] },
     },
     {
       name: 'data-layer-is-leaf',

--- a/src/services/NotionService/BlockHandler/BlockHandler.ts
+++ b/src/services/NotionService/BlockHandler/BlockHandler.ts
@@ -30,6 +30,7 @@ import { withTextAlign } from '../../../lib/parser/withTextAlign';
 import get16DigitRandomId from '../../../shared/helpers/get16DigitRandomId';
 import { NOTION_STYLE, getCodeThemeCss } from '../../../templates/helper';
 import NotionAPIWrapper from '../NotionAPIWrapper';
+import type { IBlockRenderer } from './types';
 import BlockColumn from '../blocks/lists/BlockColumn';
 import { tableRowsToCards } from '../blocks/lists/BlockTable';
 import { blockToStaticMarkup } from '../helpers/blockToStaticMarkup';
@@ -209,7 +210,7 @@ function applyHierarchyFields(
   ankiNote.h3 = context?.h3 ?? '';
 }
 
-class BlockHandler {
+class BlockHandler implements IBlockRenderer {
   api: NotionAPIWrapper;
 
   exporter;

--- a/src/services/NotionService/BlockHandler/types.ts
+++ b/src/services/NotionService/BlockHandler/types.ts
@@ -1,0 +1,34 @@
+import type {
+  AudioBlockObjectResponse,
+  BlockObjectResponse,
+  FileBlockObjectResponse,
+  PdfBlockObjectResponse,
+} from '@notionhq/client/build/src/api-endpoints';
+
+import type CardOption from '../../../lib/parser/Settings';
+import type TagRegistry from '../../../lib/parser/TagRegistry';
+import type NotionAPIWrapper from '../NotionAPIWrapper';
+
+/**
+ * The surface block renderers and helpers need from BlockHandler. They
+ * receive the instance by parameter; typing against this interface instead of
+ * the class keeps blocks/ and helpers/ out of BlockHandler's module cycle.
+ */
+export interface IBlockRenderer {
+  api: NotionAPIWrapper;
+  settings: CardOption;
+  skip: string[];
+  useAll: boolean;
+  tagRegistry: TagRegistry;
+  readonly unsupportedBlockTypes: string[];
+  recordUnsupportedBlockType(type: string): void;
+  getBackSide(
+    block: BlockObjectResponse,
+    handleChildren?: boolean
+  ): Promise<string | null>;
+  embedImage(c: BlockObjectResponse): Promise<string>;
+  embedAudioFile(c: AudioBlockObjectResponse): Promise<string>;
+  embedFile(
+    block: FileBlockObjectResponse | PdfBlockObjectResponse
+  ): Promise<string>;
+}

--- a/src/services/NotionService/blocks/BlockCallout.tsx
+++ b/src/services/NotionService/blocks/BlockCallout.tsx
@@ -3,7 +3,7 @@ import {
   RichTextItemResponse,
 } from '@notionhq/client/build/src/api-endpoints';
 import ReactDOMServer from 'react-dom/server';
-import BlockHandler from '../BlockHandler/BlockHandler';
+import type { IBlockRenderer } from '../BlockHandler/types';
 import getChildren from '../helpers/getChildren';
 import getPlainText from '../helpers/getPlainText';
 import { styleWithColors } from '../NotionColors';
@@ -11,7 +11,7 @@ import HandleBlockAnnotations from './HandleBlockAnnotations';
 
 export const BlockCallout = async (
   block: CalloutBlockObjectResponse,
-  handler: BlockHandler
+  handler: IBlockRenderer
 ) => {
   const { callout } = block;
   const { icon } = callout;

--- a/src/services/NotionService/blocks/BlockChildPage.ts
+++ b/src/services/NotionService/blocks/BlockChildPage.ts
@@ -1,11 +1,11 @@
 import { ChildPageBlockObjectResponse } from '@notionhq/client/build/src/api-endpoints';
-import BlockHandler from '../BlockHandler/BlockHandler';
+import type { IBlockRenderer } from '../BlockHandler/types';
 import getBlockIcon, { WithIcon } from './getBlockIcon';
 import renderLink from '../helpers/renderLink';
 
 export const BlockChildPage = async (
   block: ChildPageBlockObjectResponse,
-  handler: BlockHandler
+  handler: IBlockRenderer
 ) => {
   const childPage = block.child_page;
   const { api } = handler;

--- a/src/services/NotionService/blocks/BlockCode.tsx
+++ b/src/services/NotionService/blocks/BlockCode.tsx
@@ -3,11 +3,11 @@ import {
   RichTextItemResponse,
 } from '@notionhq/client/build/src/api-endpoints';
 import ReactDOMServer from 'react-dom/server';
-import BlockHandler from '../BlockHandler/BlockHandler';
+import type { IBlockRenderer } from '../BlockHandler/types';
 import getPlainText from '../helpers/getPlainText';
 import HandleBlockAnnotations from './HandleBlockAnnotations';
 
-const BlockCode = (block: CodeBlockObjectResponse, handler: BlockHandler) => {
+const BlockCode = (block: CodeBlockObjectResponse, handler: IBlockRenderer) => {
   const { code } = block;
   const { rich_text: richText } = code;
 

--- a/src/services/NotionService/blocks/BlockHeadings.tsx
+++ b/src/services/NotionService/blocks/BlockHeadings.tsx
@@ -5,7 +5,7 @@ import {
 } from '@notionhq/client/build/src/api-endpoints';
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
-import BlockHandler from '../BlockHandler/BlockHandler';
+import type { IBlockRenderer } from '../BlockHandler/types';
 import getPlainText from '../helpers/getPlainText';
 import HandleBlockAnnotations from './HandleBlockAnnotations';
 import { getHeadingText } from '../helpers/getHeadingText';
@@ -47,7 +47,7 @@ const Heading = (props: HeadingProps) => {
 export const BlockHeading = (
   level: 'heading_1' | 'heading_2' | 'heading_3' | 'heading_4',
   block: GetBlockResponse,
-  handler: BlockHandler
+  handler: IBlockRenderer
 ) => {
   const headingText = getHeadingText(block as BlockObjectResponse);
   if (!headingText) {

--- a/src/services/NotionService/blocks/BlockParagraph.tsx
+++ b/src/services/NotionService/blocks/BlockParagraph.tsx
@@ -1,14 +1,14 @@
 import { ParagraphBlockObjectResponse } from '@notionhq/client/build/src/api-endpoints';
 import ReactDOMServer from 'react-dom/server';
 import { convert } from 'html-to-text';
-import BlockHandler from '../BlockHandler/BlockHandler';
+import type { IBlockRenderer } from '../BlockHandler/types';
 
 import renderTextChildren from '../helpers/renderTextChildren';
 import { styleWithColors } from '../NotionColors';
 
 const BlockParagraph = (
   block: ParagraphBlockObjectResponse,
-  handler: BlockHandler
+  handler: IBlockRenderer
 ): string | null => {
   const { paragraph } = block;
   const { rich_text: richText } = paragraph;

--- a/src/services/NotionService/blocks/BlockQuote.tsx
+++ b/src/services/NotionService/blocks/BlockQuote.tsx
@@ -1,13 +1,13 @@
 import { QuoteBlockObjectResponse } from '@notionhq/client/build/src/api-endpoints';
 import ReactDOMServer from 'react-dom/server';
-import BlockHandler from '../BlockHandler/BlockHandler';
+import type { IBlockRenderer } from '../BlockHandler/types';
 import getPlainText from '../helpers/getPlainText';
 import HandleBlockAnnotations from './HandleBlockAnnotations';
 import { styleWithColors } from '../NotionColors';
 
 export const BlockQuote = (
   block: QuoteBlockObjectResponse,
-  handler: BlockHandler
+  handler: IBlockRenderer
 ) => {
   const { quote } = block;
   const { rich_text: richText } = quote;

--- a/src/services/NotionService/blocks/LinkToPage/LinkToPage.ts
+++ b/src/services/NotionService/blocks/LinkToPage/LinkToPage.ts
@@ -1,11 +1,11 @@
 import { LinkToPageBlockObjectResponse } from '@notionhq/client/build/src/api-endpoints';
-import BlockHandler from '../../BlockHandler/BlockHandler';
+import type { IBlockRenderer } from '../../BlockHandler/types';
 import renderLink from '../../helpers/renderLink';
 import getBlockIcon, { WithIcon } from '../getBlockIcon';
 
 export default async function LinkToPage(
   block: LinkToPageBlockObjectResponse,
-  handler: BlockHandler
+  handler: IBlockRenderer
 ) {
   const linkToPage =
     block.link_to_page.type === 'page_id'

--- a/src/services/NotionService/blocks/lists/BlockBulletList.tsx
+++ b/src/services/NotionService/blocks/lists/BlockBulletList.tsx
@@ -4,14 +4,14 @@ import {
 } from '@notionhq/client/build/src/api-endpoints';
 import ReactDOMServer from 'react-dom/server';
 import { convert } from 'html-to-text';
-import BlockHandler from '../../BlockHandler/BlockHandler';
+import type { IBlockRenderer } from '../../BlockHandler/types';
 import getListItems from '../../helpers/getListItems';
 import { styleWithColors } from '../../NotionColors';
 
 export const BlockBulletList = async (
   block: BulletedListItemBlockObjectResponse,
   response: ListBlockChildrenResponse | undefined,
-  handler: BlockHandler
+  handler: IBlockRenderer
 ) => {
   const list = block.bulleted_list_item;
   const items = await getListItems(response, handler, 'bulleted_list_item');

--- a/src/services/NotionService/blocks/lists/BlockColumn.tsx
+++ b/src/services/NotionService/blocks/lists/BlockColumn.tsx
@@ -1,10 +1,10 @@
 import { ColumnBlockObjectResponse } from '@notionhq/client/build/src/api-endpoints';
-import BlockHandler from '../../BlockHandler/BlockHandler';
+import type { IBlockRenderer } from '../../BlockHandler/types';
 import getChildren from '../../helpers/getChildren';
 
 export default function BlockColumn(
   block: ColumnBlockObjectResponse,
-  handler: BlockHandler
+  handler: IBlockRenderer
 ) {
   return getChildren(block, handler);
 }

--- a/src/services/NotionService/blocks/lists/BlockColumnList.ts
+++ b/src/services/NotionService/blocks/lists/BlockColumnList.ts
@@ -1,12 +1,12 @@
 import { ColumnListBlockObjectResponse } from '@notionhq/client/build/src/api-endpoints';
-import BlockHandler from '../../BlockHandler/BlockHandler';
+import type { IBlockRenderer } from '../../BlockHandler/types';
 import getChildren from '../../helpers/getChildren';
 import getColumn from '../../helpers/getColumn';
 import BlockColumn from './BlockColumn';
 
 export default async function BlockColumnList(
   block: ColumnListBlockObjectResponse,
-  handler: BlockHandler
+  handler: IBlockRenderer
 ) {
   const firstColumn = await getColumn(block.id, handler, 0);
   if (firstColumn) {

--- a/src/services/NotionService/blocks/lists/BlockNumberedList.tsx
+++ b/src/services/NotionService/blocks/lists/BlockNumberedList.tsx
@@ -4,14 +4,14 @@ import {
 } from '@notionhq/client/build/src/api-endpoints';
 import ReactDOMServer from 'react-dom/server';
 import { convert } from 'html-to-text';
-import BlockHandler from '../../BlockHandler/BlockHandler';
+import type { IBlockRenderer } from '../../BlockHandler/types';
 import getListItems from '../../helpers/getListItems';
 import { styleWithColors } from '../../NotionColors';
 
 export const BlockNumberedList = async (
   block: NumberedListItemBlockObjectResponse,
   response: ListBlockChildrenResponse | undefined,
-  handler: BlockHandler
+  handler: IBlockRenderer
 ) => {
   const list = block.numbered_list_item;
   const items = await getListItems(response, handler, 'numbered_list_item');

--- a/src/services/NotionService/blocks/lists/BlockTable.tsx
+++ b/src/services/NotionService/blocks/lists/BlockTable.tsx
@@ -7,7 +7,7 @@ import {
 import { inferColumnMapping } from '../../../../lib/notionDatabase/inferColumnMapping';
 import handleClozeDeletions from '../../../../lib/parser/helpers/handleClozeDeletions';
 import hasInlineClozeCode from '../../../../lib/parser/helpers/hasInlineClozeCode';
-import BlockHandler from '../../BlockHandler/BlockHandler';
+import type { IBlockRenderer } from '../../BlockHandler/types';
 import renderTextChildren from '../../helpers/renderTextChildren';
 
 interface TableCard {
@@ -35,14 +35,14 @@ function toClozeCard(front: string, back: string): TableCard {
 
 function renderCell(
   cell: RichTextItemResponse[],
-  handler: BlockHandler
+  handler: IBlockRenderer
 ): string {
   return renderTextChildren(cell, handler.settings, handler.tagRegistry);
 }
 
 function buildExtraColumnsTable(
   extraCells: RichTextItemResponse[][],
-  handler: BlockHandler
+  handler: IBlockRenderer
 ): string {
   const tds = extraCells
     .map((cell) => `<td>${renderCell(cell, handler)}</td>`)
@@ -53,7 +53,7 @@ function buildExtraColumnsTable(
 function resolveColumnRoles(
   rows: readonly TableRowBlockObjectResponse[],
   hasColumnHeader: boolean,
-  handler: BlockHandler
+  handler: IBlockRenderer
 ): ColumnRoles {
   const headerRow = rows[0];
   if (!hasColumnHeader || headerRow == null) {
@@ -89,7 +89,7 @@ function extraColumnCells(
 export function tableRowsToCards(
   block: TableBlockObjectResponse,
   children: ListBlockChildrenResponse,
-  handler: BlockHandler
+  handler: IBlockRenderer
 ): TableCard[] {
   const rows = children.results.filter(
     (r): r is TableRowBlockObjectResponse =>
@@ -146,7 +146,7 @@ export function tableRowsToCards(
 
 export async function BlockTable(
   block: TableBlockObjectResponse,
-  handler: BlockHandler
+  handler: IBlockRenderer
 ): Promise<string> {
   const children = await handler.api.getBlocks({
     createdAt: block.created_time,

--- a/src/services/NotionService/blocks/lists/BlockTodoList.tsx
+++ b/src/services/NotionService/blocks/lists/BlockTodoList.tsx
@@ -4,14 +4,14 @@ import {
 } from '@notionhq/client/build/src/api-endpoints';
 import ReactDOMServer from 'react-dom/server';
 import { convert } from 'html-to-text';
-import BlockHandler from '../../BlockHandler/BlockHandler';
+import type { IBlockRenderer } from '../../BlockHandler/types';
 import getListItems from '../../helpers/getListItems';
 import { styleWithColors } from '../../NotionColors';
 
 export const BlockTodoList = async (
   block: ToDoBlockObjectResponse,
   response: ListBlockChildrenResponse | undefined,
-  handler: BlockHandler
+  handler: IBlockRenderer
 ) => {
   const list = block.to_do;
   const items = await getListItems(response, handler, 'to_do');

--- a/src/services/NotionService/blocks/lists/BlockToggleList.tsx
+++ b/src/services/NotionService/blocks/lists/BlockToggleList.tsx
@@ -2,7 +2,7 @@ import { ToggleBlockObjectResponse } from '@notionhq/client/build/src/api-endpoi
 import ReactDOMServer from 'react-dom/server';
 import { convert } from 'html-to-text';
 
-import BlockHandler from '../../BlockHandler/BlockHandler';
+import type { IBlockRenderer } from '../../BlockHandler/types';
 import renderTextChildren from '../../helpers/renderTextChildren';
 import getChildren from '../../helpers/getChildren';
 import { ReactNode } from 'react';
@@ -14,7 +14,7 @@ interface DetailsProps {
 
 export async function BlockToggleList(
   block: ToggleBlockObjectResponse,
-  handler: BlockHandler
+  handler: IBlockRenderer
 ) {
   const list = block.toggle;
   const { rich_text: richText } = list;

--- a/src/services/NotionService/blocks/media/BlockBookmark/index.tsx
+++ b/src/services/NotionService/blocks/media/BlockBookmark/index.tsx
@@ -3,7 +3,7 @@ import { convert } from 'html-to-text';
 
 import { BookmarkBlockObjectResponse } from '@notionhq/client/build/src/api-endpoints';
 import useMetadata from './hooks/useMetadata';
-import BlockHandler from '../../../BlockHandler/BlockHandler';
+import type { IBlockRenderer } from '../../../BlockHandler/types';
 import React from 'react';
 import { BookmarkTitle } from './components/BookmarkTitle';
 import { BookmarkDescription } from './components/BookmarkDescription';
@@ -13,7 +13,7 @@ import { BookmarkContainer } from './components/BookmarkContainer';
 
 const BlockBookmark = async (
   block: BookmarkBlockObjectResponse,
-  handler: BlockHandler
+  handler: IBlockRenderer
 ): Promise<string | null> => {
   const { bookmark } = block;
   const metadata = await useMetadata(bookmark.url);

--- a/src/services/NotionService/blocks/media/BlockEmbed.tsx
+++ b/src/services/NotionService/blocks/media/BlockEmbed.tsx
@@ -3,7 +3,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import getLoomEmbedUrl from '../../../../lib/parser/helpers/getLoomEmbedUrl';
 import getYouTubeEmbedLink from '../../../../lib/parser/helpers/getYouTubeEmbedLink';
 import getYouTubeID from '../../../../lib/parser/helpers/getYouTubeID';
-import BlockHandler from '../../BlockHandler/BlockHandler';
+import type { IBlockRenderer } from '../../BlockHandler/types';
 import {
   isLoomURL,
   isSoundCloudURL,
@@ -12,7 +12,7 @@ import {
 
 export const BlockEmbed = (
   c: EmbedBlockObjectResponse,
-  handler: BlockHandler
+  handler: IBlockRenderer
 ) => {
   if (handler.settings?.isTextOnlyBack) {
     return '';

--- a/src/services/NotionService/blocks/media/BlockVideo.tsx
+++ b/src/services/NotionService/blocks/media/BlockVideo.tsx
@@ -1,12 +1,12 @@
 import { VideoBlockObjectResponse } from '@notionhq/client/build/src/api-endpoints';
 import { renderToStaticMarkup } from 'react-dom/server';
-import BlockHandler from '../../BlockHandler/BlockHandler';
+import type { IBlockRenderer } from '../../BlockHandler/types';
 import { getVideoUrl } from './helpers/getVideoUrl';
 import { isVimeoLink } from './helpers/isVimeoLink';
 
 export const BlockVideo = (
   c: VideoBlockObjectResponse,
-  handler: BlockHandler
+  handler: IBlockRenderer
 ) => {
   let url = getVideoUrl(c);
   if (handler.settings?.isTextOnlyBack || !url) {

--- a/src/services/NotionService/helpers/blockToStaticMarkup.tsx
+++ b/src/services/NotionService/helpers/blockToStaticMarkup.tsx
@@ -7,7 +7,7 @@ import {
   SyncedBlockBlockObjectResponse,
 } from '@notionhq/client/build/src/api-endpoints';
 import { renderToStaticMarkup } from 'react-dom/server';
-import BlockHandler from '../BlockHandler/BlockHandler';
+import type { IBlockRenderer } from '../BlockHandler/types';
 import { BlockCallout } from '../blocks/BlockCallout';
 import { BlockChildPage } from '../blocks/BlockChildPage';
 import BlockCode from '../blocks/BlockCode';
@@ -36,7 +36,7 @@ const renderPdfLink = (url: string): string =>
 
 const renderPdf = async (
   c: PdfBlockObjectResponse,
-  handler: BlockHandler
+  handler: IBlockRenderer
 ): Promise<string> => {
   const url = c.pdf.type === 'file' ? c.pdf.file.url : c.pdf.external.url;
   if (!url) {
@@ -62,7 +62,7 @@ const renderLinkPreview = (c: LinkPreviewBlockObjectResponse): string => {
 
 const renderSyncedBlock = async (
   c: SyncedBlockBlockObjectResponse,
-  handler: BlockHandler
+  handler: IBlockRenderer
 ): Promise<string> => {
   if (c.has_children) {
     const children = await handler.getBackSide(c, true);
@@ -76,7 +76,7 @@ const renderSyncedBlock = async (
 };
 
 export const blockToStaticMarkup = async (
-  handler: BlockHandler,
+  handler: IBlockRenderer,
   c: BlockObjectResponse,
   response?: ListBlockChildrenResponse
 ) => {

--- a/src/services/NotionService/helpers/getChildren.ts
+++ b/src/services/NotionService/helpers/getChildren.ts
@@ -1,10 +1,10 @@
 import { BlockObjectResponse } from '@notionhq/client/build/src/api-endpoints';
 
-import BlockHandler from '../BlockHandler/BlockHandler';
+import type { IBlockRenderer } from '../BlockHandler/types';
 
 export default async function getChildren(
   block: BlockObjectResponse,
-  handler: BlockHandler
+  handler: IBlockRenderer
 ): Promise<string> {
   let backSide = '';
   if (block.has_children) {

--- a/src/services/NotionService/helpers/getColumn.ts
+++ b/src/services/NotionService/helpers/getColumn.ts
@@ -1,9 +1,9 @@
 import { ColumnBlockObjectResponse } from '@notionhq/client/build/src/api-endpoints';
-import BlockHandler from '../BlockHandler/BlockHandler';
+import type { IBlockRenderer } from '../BlockHandler/types';
 
 export default async function getColumn(
   parentId: string,
-  handler: BlockHandler,
+  handler: IBlockRenderer,
   index: number
 ): Promise<ColumnBlockObjectResponse | null> {
   console.time('[NO_CACHE] - getColumn');

--- a/src/services/NotionService/helpers/getListItems.tsx
+++ b/src/services/NotionService/helpers/getListItems.tsx
@@ -4,7 +4,7 @@ import {
 } from '@notionhq/client/build/src/api-endpoints';
 
 import renderTextChildren from './renderTextChildren';
-import BlockHandler from '../BlockHandler/BlockHandler';
+import type { IBlockRenderer } from '../BlockHandler/types';
 import getChildren from './getChildren';
 import { getListBlock } from './getListBlock';
 import { getListColor } from './getListColor';
@@ -15,7 +15,7 @@ type ListType = 'numbered_list_item' | 'bulleted_list_item' | 'to_do';
 
 export default function getListItems(
   response: ListBlockChildrenResponse | undefined,
-  handler: BlockHandler,
+  handler: IBlockRenderer,
   type: ListType
 ) {
   if (!response) {

--- a/src/services/NotionService/helpers/renderBack.ts
+++ b/src/services/NotionService/helpers/renderBack.ts
@@ -4,11 +4,11 @@ import {
   ListBlockChildrenResponse,
   PartialBlockObjectResponse,
 } from '@notionhq/client/build/src/api-endpoints';
-import BlockHandler from '../BlockHandler/BlockHandler';
+import type { IBlockRenderer } from '../BlockHandler/types';
 import { blockToStaticMarkup } from './blockToStaticMarkup';
 
 export const renderBack = async (
-  handler: BlockHandler,
+  handler: IBlockRenderer,
   requestChildren: Array<PartialBlockObjectResponse | BlockObjectResponse>,
   response: ListBlockChildrenResponse,
   handleChildren: boolean | undefined


### PR DESCRIPTION
Closes https://github.com/2anki/server/issues/4194 (architecture review P1b).

## What

The NotionService cycle cluster — ~35 of the repo's 60 circular dependencies — existed only at the module level: 22 files under `blocks/` and `helpers/` imported the `BlockHandler` **class** solely to type a parameter the instance already arrives through. New `BlockHandler/types.ts` declares `IBlockRenderer` with the eleven members those files actually use (api, settings, skip, useAll, tagRegistry, unsupportedBlockTypes, recordUnsupportedBlockType, getBackSide, embedImage, embedAudioFile, embedFile); `BlockHandler implements IBlockRenderer` guarantees completeness at compile time; the 22 files import the type instead of the class. The `no-circular` depcruise rule now ignores type-only edges — they're erased at compile time and cannot cycle at runtime (same idiom as the existing knex rule).

Every import swap is `import type` — **zero runtime change**.

## Numbers

- Cycles: 60 this morning → **10** on this branch (−35 here, −7 from #4204's composition-root merge, remainder from the type-only exclusion).
- Total depcruise: 319 this morning → **265**.

## Tests

Full server suite 6610 passed (only the documented `getPageCount` pdfinfo environmental failures) — full-suite run per the shared-parser-code rule, not targeted. `tsc --noEmit` clean, `pnpm format:check` clean, `pnpm arch` 0 errors.

Sonar: not run locally (type-only refactor); PR decoration will report.

No changelog — internal refactor, no user-visible behavior change.