### PR TITLE
fix: widen scanner-probe rejection and stop logging the noise

### DIFF
--- a/src/routes/middleware/rejectScannerProbes.test.ts
+++ b/src/routes/middleware/rejectScannerProbes.test.ts
@@ -29,6 +29,56 @@ describe('rejectScannerProbes', () => {
   });
 
   it.each([
+    '/.git/config',
+    '/.docker/laravel/app/.env',
+    '/.aws/credentials',
+    '/.cache',
+    '/.ssh/id_rsa',
+  ])('returns 404 for the hidden-directory probe %s', (path) => {
+    const { req, res, next } = mockReqRes('GET', path);
+    rejectScannerProbes(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.end).toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    '/wp-admin/',
+    '/wp-content/plugins/x.txt',
+    '/wp-includes/wlwmanifest.xml',
+    '/wordpress/wp-login.js',
+    '/phpmyadmin/index.html',
+    '/cgi-bin/test',
+    '/vendor/phpunit/whatever',
+  ])('returns 404 for the CMS-scanner path %s', (path) => {
+    const { req, res, next } = mockReqRes('GET', path);
+    rejectScannerProbes(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('rejects probe paths on POST too', () => {
+    const { req, res, next } = mockReqRes('POST', '/xmlrpc.php');
+    rejectScannerProbes(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    '/.well-known/security.txt',
+    '/.well-known/apple-developer-domain-association.txt',
+  ])('passes through the legitimate dot path %s', (path) => {
+    const { req, res, next } = mockReqRes('GET', path);
+    rejectScannerProbes(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it.each([
     '/login',
     '/downloads',
     '/notion-to-anki',
@@ -37,14 +87,6 @@ describe('rejectScannerProbes', () => {
     '/index.html',
   ])('passes through for %s', (path) => {
     const { req, res, next } = mockReqRes('GET', path);
-    rejectScannerProbes(req, res, next);
-
-    expect(next).toHaveBeenCalled();
-    expect(res.status).not.toHaveBeenCalled();
-  });
-
-  it('passes through POST requests even with probe extensions', () => {
-    const { req, res, next } = mockReqRes('POST', '/test.php');
     rejectScannerProbes(req, res, next);
 
     expect(next).toHaveBeenCalled();

--- a/src/routes/middleware/rejectScannerProbes.ts
+++ b/src/routes/middleware/rejectScannerProbes.ts
@@ -3,12 +3,25 @@ import { Request, Response, NextFunction } from 'express';
 const PROBE_EXTENSIONS =
   /\.(php|env|asp|aspx|jsp|cgi|bak|old|save|sql|htaccess|htpasswd)$/i;
 
+const CMS_SCANNER_PREFIXES =
+  /^\/(wp-|wordpress|phpmyadmin|cgi-bin|vendor\/phpunit)/i;
+
+const HIDDEN_FIRST_SEGMENT = /^\/\.(?!well-known(\/|$))/;
+
+function isScannerProbe(path: string): boolean {
+  return (
+    PROBE_EXTENSIONS.test(path) ||
+    CMS_SCANNER_PREFIXES.test(path) ||
+    HIDDEN_FIRST_SEGMENT.test(path)
+  );
+}
+
 export default function rejectScannerProbes(
   req: Request,
   res: Response,
   next: NextFunction
 ) {
-  if (req.method === 'GET' && PROBE_EXTENSIONS.test(req.path)) {
+  if (isScannerProbe(req.path)) {
     res.status(404).end();
     return;
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -168,6 +168,7 @@ const serve = async () => {
   app.use(noindexNonCanonicalHosts);
   app.use(redirectConvertDuplicates);
 
+  app.use(rejectScannerProbes);
   app.use(morgan('combined') as RequestHandler);
   app.use(requestLoggingMiddleware);
 
@@ -216,7 +217,6 @@ const serve = async () => {
   const database = getDatabase();
   app.use(healthRouter(database));
   app.use(wellKnownRouter());
-  app.use(rejectScannerProbes);
   app.use(defaultRouter());
   const errorEventRepo = new ErrorEventRepository(database);
   app.use(


### PR DESCRIPTION
Prompted by the php-probe noise in today's prod logs.

## What

`rejectScannerProbes` only caught **GET** requests ending in script extensions. The logs show what slipped past: directory probes (`/wp-admin/`, `/.git/config`, `/.docker/.env`) got the **full 12 KB SPA page** as their 404, POST probes (`/xmlrpc.php`) bypassed the GET-only check, and every probe wrote a morgan line plus an observability `request_logs` row before rejection.

Now:
- **CMS scanner prefixes** (`/wp-*`, `/wordpress`, `/phpmyadmin`, `/cgi-bin`, `/vendor/phpunit`) and **hidden first segments** (`/.anything` — with `/.well-known` explicitly exempted for the Apple association + security.txt routes) reject with an empty 404.
- **All methods**, not just GET.
- Middleware mounts **before morgan and the observability logger**, so app logs stay readable. No forensic loss: Apache fronts the node process and its access log still records every probe.

The old test asserting POST probes pass through codified the gap — replaced with the all-methods contract per the testing rules.

## Not done deliberately

IP-level blocking (fail2ban / Apache deny rules) — scanners rotate IPs and the app-level empty 404 already costs microseconds per probe; infra-side blocking is complexity without measurable win.

## Tests

27/27 middleware cases (new: hidden-directory probes, CMS prefixes, POST rejection, `/.well-known` pass-through). Full server suite 6624 passed (only the documented `getPageCount` pdfinfo environmental failures). `tsc --noEmit` clean, `pnpm format:check` clean.

No changelog — bots aren't users.

Sonar: not run locally; PR decoration will report.


no changelog entry — infrastructure noise reduction; scanner probes get the same 404 they always got, no user-visible behavior change.
