### PR TITLE
refactor: add HttpCodedError base and migrate the mindmap surface

### DIFF
--- a/src/controllers/MindmapController.ts
+++ b/src/controllers/MindmapController.ts
@@ -1,10 +1,7 @@
 import { Request, Response } from 'express';
 
 import StorageHandler from '../lib/storage/StorageHandler';
-import {
-  CreateMindmapUseCase,
-  MindmapLimitError,
-} from '../usecases/mindmaps/CreateMindmapUseCase';
+import { CreateMindmapUseCase } from '../usecases/mindmaps/CreateMindmapUseCase';
 import { UpdateMindmapUseCase } from '../usecases/mindmaps/UpdateMindmapUseCase';
 import { DeleteMindmapUseCase } from '../usecases/mindmaps/DeleteMindmapUseCase';
 import { ListMindmapsUseCase } from '../usecases/mindmaps/ListMindmapsUseCase';
@@ -12,13 +9,8 @@ import { GetMindmapUseCase } from '../usecases/mindmaps/GetMindmapUseCase';
 import {
   ExportMindmapUseCase,
   MindmapCardType,
-  MindmapNotFoundError,
 } from '../usecases/mindmaps/ExportMindmapUseCase';
-import {
-  UploadMindmapImageUseCase,
-  MindmapImageTooLargeError,
-  MindmapImageTypeError,
-} from '../usecases/mindmaps/UploadMindmapImageUseCase';
+import { UploadMindmapImageUseCase } from '../usecases/mindmaps/UploadMindmapImageUseCase';
 import { MindmapsId } from '../data_layer/public/Mindmaps';
 import { UsersId } from '../data_layer/public/Users';
 import {
@@ -88,23 +80,15 @@ export class MindmapController {
       typeof req.body?.title === 'string' ? req.body.title.trim() : '';
     const title = rawTitle.length > 0 ? rawTitle : 'Untitled';
 
-    try {
-      const map = await this.createUseCase.execute({
-        userId,
-        title,
-        user,
-        subscriptions,
-        autoSyncProductId,
-        isPaying,
-      });
-      res.status(201).json(map);
-    } catch (error) {
-      if (error instanceof MindmapLimitError) {
-        res.status(402).json({ message: error.message });
-        return;
-      }
-      throw error;
-    }
+    const map = await this.createUseCase.execute({
+      userId,
+      title,
+      user,
+      subscriptions,
+      autoSyncProductId,
+      isPaying,
+    });
+    res.status(201).json(map);
   }
 
   async getById(req: Request, res: Response) {
@@ -126,29 +110,21 @@ export class MindmapController {
       req.body?.title != null ? String(req.body.title).trim() : undefined;
     const data = req.body?.data ?? undefined;
 
-    try {
-      const map = await this.updateUseCase.execute({
-        id,
-        userId,
-        title,
-        data,
-        user,
-        subscriptions,
-        autoSyncProductId,
-        isPaying,
-      });
-      if (map == null) {
-        res.status(404).json({ message: 'Mind map not found' });
-        return;
-      }
-      res.status(200).json(map);
-    } catch (error) {
-      if (error instanceof MindmapLimitError) {
-        res.status(402).json({ message: error.message });
-        return;
-      }
-      throw error;
+    const map = await this.updateUseCase.execute({
+      id,
+      userId,
+      title,
+      data,
+      user,
+      subscriptions,
+      autoSyncProductId,
+      isPaying,
+    });
+    if (map == null) {
+      res.status(404).json({ message: 'Mind map not found' });
+      return;
     }
+    res.status(200).json(map);
   }
 
   async remove(req: Request, res: Response) {
@@ -168,28 +144,17 @@ export class MindmapController {
         : undefined;
     const cardType = this.resolveCardType(req.body?.card_type);
 
-    try {
-      const { buffer, excludedNodeCount } = await this.exportUseCase.execute({
-        id,
-        userId,
-        deckName,
-        cardType,
-      });
-      const fileName = `${(deckName ?? id).replace(/[^a-zA-Z0-9._-]/g, '_')}.apkg`;
-      res.setHeader('Content-Type', 'application/octet-stream');
-      res.setHeader(
-        'Content-Disposition',
-        `attachment; filename="${fileName}"`
-      );
-      res.setHeader('X-Excluded-Node-Count', String(excludedNodeCount));
-      res.status(200).send(buffer);
-    } catch (error) {
-      if (error instanceof MindmapNotFoundError) {
-        res.status(404).json({ message: 'Mind map not found' });
-        return;
-      }
-      throw error;
-    }
+    const { buffer, excludedNodeCount } = await this.exportUseCase.execute({
+      id,
+      userId,
+      deckName,
+      cardType,
+    });
+    const fileName = `${(deckName ?? id).replace(/[^a-zA-Z0-9._-]/g, '_')}.apkg`;
+    res.setHeader('Content-Type', 'application/octet-stream');
+    res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`);
+    res.setHeader('X-Excluded-Node-Count', String(excludedNodeCount));
+    res.status(200).send(buffer);
   }
 
   async uploadImage(req: Request, res: Response) {
@@ -204,28 +169,16 @@ export class MindmapController {
 
     const useCase = new UploadMindmapImageUseCase(this.storage);
 
-    try {
-      const result = await useCase.execute({
-        userId,
-        mapId,
-        file: { buffer: file.buffer, size: file.size },
-      });
-      res.status(201).json({
-        url: result.presignedUrl,
-        width: result.width,
-        height: result.height,
-      });
-    } catch (error) {
-      if (error instanceof MindmapImageTypeError) {
-        res.status(415).json({ message: error.message });
-        return;
-      }
-      if (error instanceof MindmapImageTooLargeError) {
-        res.status(413).json({ message: error.message });
-        return;
-      }
-      throw error;
-    }
+    const result = await useCase.execute({
+      userId,
+      mapId,
+      file: { buffer: file.buffer, size: file.size },
+    });
+    res.status(201).json({
+      url: result.presignedUrl,
+      width: result.width,
+      height: result.height,
+    });
   }
 
   async serveImage(req: Request, res: Response): Promise<void> {

--- a/src/lib/errors/HttpCodedError.test.ts
+++ b/src/lib/errors/HttpCodedError.test.ts
@@ -1,0 +1,34 @@
+import { HttpCodedError, isHttpCodedClientFault } from './HttpCodedError';
+
+class TeapotError extends HttpCodedError {
+  constructor() {
+    super('I am a teapot', 418, 'teapot');
+  }
+}
+
+describe('HttpCodedError', () => {
+  it('carries status, code, and message', () => {
+    const err = new TeapotError();
+    expect(err.status).toBe(418);
+    expect(err.code).toBe('teapot');
+    expect(err.message).toBe('I am a teapot');
+    expect(err.name).toBe('TeapotError');
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(HttpCodedError);
+  });
+
+  it.each([
+    [402, true],
+    [404, true],
+    [499, true],
+    [500, false],
+    [503, false],
+  ])('isHttpCodedClientFault for status %i is %s', (status, expected) => {
+    const err = new HttpCodedError('x', status, 'x');
+    expect(isHttpCodedClientFault(err)).toBe(expected);
+  });
+
+  it('isHttpCodedClientFault is false for plain errors', () => {
+    expect(isHttpCodedClientFault(new Error('plain'))).toBe(false);
+  });
+});

--- a/src/lib/errors/HttpCodedError.ts
+++ b/src/lib/errors/HttpCodedError.ts
@@ -1,0 +1,22 @@
+/**
+ * Base class for deliberate HTTP-mapped errors. A use case throws a subclass
+ * with the status and machine-readable code it wants on the wire; the error
+ * funnel (ErrorHandler) turns it into `res.status(status).json({code,
+ * message})` so controllers can `next(err)`/rethrow instead of duplicating
+ * instanceof→status maps. Statuses below 500 are treated as expected client
+ * faults: no error email, no error_events row, no stack in the logs.
+ */
+export class HttpCodedError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly code: string
+  ) {
+    super(message);
+    this.name = new.target.name;
+  }
+}
+
+export function isHttpCodedClientFault(error: Error): boolean {
+  return error instanceof HttpCodedError && error.status < 500;
+}

--- a/src/lib/misc/isExpectedClientFault.test.ts
+++ b/src/lib/misc/isExpectedClientFault.test.ts
@@ -1,4 +1,5 @@
 import { isExpectedClientFault } from './isExpectedClientFault';
+import { HttpCodedError } from '../errors/HttpCodedError';
 
 describe('isExpectedClientFault', () => {
   it('returns false for undefined', () => {
@@ -43,5 +44,17 @@ describe('isExpectedClientFault', () => {
     expect(isExpectedClientFault(new SyntaxError('thrown by our code'))).toBe(
       false
     );
+  });
+
+  it('returns true for a 4xx HttpCodedError', () => {
+    expect(
+      isExpectedClientFault(new HttpCodedError('limit reached', 402, 'limit'))
+    ).toBe(true);
+  });
+
+  it('returns false for a 5xx HttpCodedError', () => {
+    expect(
+      isExpectedClientFault(new HttpCodedError('upstream down', 503, 'up'))
+    ).toBe(false);
   });
 });

--- a/src/lib/misc/isExpectedClientFault.ts
+++ b/src/lib/misc/isExpectedClientFault.ts
@@ -1,3 +1,5 @@
+import { isHttpCodedClientFault } from '../errors/HttpCodedError';
+
 // Errors that are the client's fault and fully handled by ErrorHandler as a
 // 4xx — not bugs to investigate. Logging a full stack for these floods the
 // server logs and buries real crashes. Mirrors the dashboard skip in
@@ -22,6 +24,9 @@ export const isExpectedClientFault = (error?: Error): boolean => {
     return true;
   }
   if (isClientAbort(error)) {
+    return true;
+  }
+  if (isHttpCodedClientFault(error)) {
     return true;
   }
   return error.name === 'AnkiAppExportError';

--- a/src/routes/MindmapRouter.test.ts
+++ b/src/routes/MindmapRouter.test.ts
@@ -81,9 +81,26 @@ process.env.SKIP_CREATE_DECK = '1';
 
 async function buildServer() {
   const { default: MindmapRouter } = await import('./MindmapRouter');
+  const { default: ErrorHandler } = await import('./middleware/ErrorHandler');
   const app = express();
   app.use(express.json());
   app.use(MindmapRouter());
+  // Mirror the server.ts error funnel so HttpCodedError thrown from use
+  // cases resolves to its status here the same way it does in production.
+  app.use(
+    (
+      err: Error,
+      req: express.Request,
+      res: express.Response,
+      next: express.NextFunction
+    ) => {
+      if (!err) {
+        next();
+        return;
+      }
+      void ErrorHandler(res, req, err);
+    }
+  );
   const server = http.createServer(app);
   await new Promise<void>((resolve) => server.listen(0, resolve));
   const { port } = server.address() as AddressInfo;
@@ -145,6 +162,11 @@ describe('MindmapRouter', () => {
       });
 
       expect(res.status).toBe(402);
+      const body = await res.json();
+      expect(body).toEqual({
+        code: 'mindmap_limit',
+        message: 'Mind map limit reached (3)',
+      });
     });
   });
 

--- a/src/routes/middleware/ErrorCaptureMiddleware.test.ts
+++ b/src/routes/middleware/ErrorCaptureMiddleware.test.ts
@@ -5,6 +5,7 @@ import {
   ErrorEventInsert,
 } from '../../data_layer/ErrorEventRepository';
 import { FallbackErrorPayload } from '../../lib/errorFallback';
+import { HttpCodedError } from '../../lib/errors/HttpCodedError';
 import { PythonExitError } from '../../lib/anki/buildPythonExitError';
 
 function makeRepository(
@@ -243,6 +244,38 @@ describe('makeErrorCaptureMiddleware', () => {
 
     expect(repo.inserts).toHaveLength(0);
     expect(next).toHaveBeenCalledWith(parseError);
+  });
+
+  it('does not record a 4xx HttpCodedError (deliberate client fault)', async () => {
+    const repo = makeRepository();
+    const middleware = makeErrorCaptureMiddleware(repo);
+    const next = makeNext();
+    const codedError = new HttpCodedError(
+      'Mind map limit reached (3)',
+      402,
+      'mindmap_limit'
+    );
+
+    await middleware(codedError, makeReq('/api/mindmaps'), makeRes(), next);
+
+    expect(repo.inserts).toHaveLength(0);
+    expect(next).toHaveBeenCalledWith(codedError);
+  });
+
+  it('records a 5xx HttpCodedError', async () => {
+    const repo = makeRepository();
+    const middleware = makeErrorCaptureMiddleware(repo);
+    const next = makeNext();
+    const codedError = new HttpCodedError(
+      'Upstream unavailable',
+      503,
+      'upstream'
+    );
+
+    await middleware(codedError, makeReq('/api/mindmaps'), makeRes(), next);
+
+    expect(repo.inserts).toHaveLength(1);
+    expect(next).toHaveBeenCalledWith(codedError);
   });
 
   it('does not record a multer file-size limit error', async () => {

--- a/src/routes/middleware/ErrorHandler.test.ts
+++ b/src/routes/middleware/ErrorHandler.test.ts
@@ -3,6 +3,7 @@ import express from 'express';
 import multer from 'multer';
 
 import ErrorHandler from './ErrorHandler';
+import { HttpCodedError } from '../../lib/errors/HttpCodedError';
 import { PythonExitError } from '../../lib/anki/buildPythonExitError';
 
 const makeAPIResponseError = (
@@ -392,5 +393,45 @@ describe('ErrorHandler', () => {
     await ErrorHandler(res as unknown as express.Response, req, parseError);
 
     expect(res.statusCode).toBe(400);
+  });
+
+  test('a 4xx HttpCodedError responds with its status, code, and message, quietly', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const res = makeResponse(false);
+    const req = makeRequest();
+
+    await ErrorHandler(
+      res as unknown as express.Response,
+      req,
+      new HttpCodedError('Mind map limit reached (3)', 402, 'mindmap_limit')
+    );
+
+    expect(res.statusCode).toBe(402);
+    expect(res.body).toEqual({
+      code: 'mindmap_limit',
+      message: 'Mind map limit reached (3)',
+    });
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  test('a 5xx HttpCodedError keeps its status and message and is not quiet', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const res = makeResponse(false);
+    const req = makeRequest();
+
+    await ErrorHandler(
+      res as unknown as express.Response,
+      req,
+      new HttpCodedError('Upstream export service unavailable', 503, 'upstream')
+    );
+
+    expect(res.statusCode).toBe(503);
+    expect(res.body).toEqual({
+      code: 'upstream',
+      message: 'Upstream export service unavailable',
+    });
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
   });
 });

--- a/src/routes/middleware/ErrorHandler.tsx
+++ b/src/routes/middleware/ErrorHandler.tsx
@@ -9,6 +9,7 @@ import { isEmptyPayload } from '../../lib/misc/isEmptyPayload';
 import { preserveFilesForDebugging } from '../../lib/debug/preserveFilesForDebugging';
 import { shouldShareFilesForDebugging } from './shouldShareFilesForDebugging';
 import * as cheerio from 'cheerio';
+import { HttpCodedError } from '../../lib/errors/HttpCodedError';
 import {
   PythonExitError,
   toUploadErrorCode,
@@ -109,6 +110,11 @@ export default async function ErrorHandler(
 
   if (res.headersSent) {
     console.info('Skipping error response: headers already sent');
+    return;
+  }
+
+  if (err instanceof HttpCodedError) {
+    res.status(err.status).json({ code: err.code, message: err.message });
     return;
   }
 

--- a/src/usecases/mindmaps/CreateMindmapUseCase.ts
+++ b/src/usecases/mindmaps/CreateMindmapUseCase.ts
@@ -3,6 +3,7 @@ import {
   AnkifyAccessUser,
   AnkifyAccessSubscription,
 } from '../../lib/ankify/access';
+import { HttpCodedError } from '../../lib/errors/HttpCodedError';
 import { MindmapRepositoryInterface } from '../../data_layer/MindmapRepository';
 import Mindmaps from '../../data_layer/public/Mindmaps';
 import { UsersId } from '../../data_layer/public/Users';
@@ -10,10 +11,9 @@ import { UsersId } from '../../data_layer/public/Users';
 export const FREE_MAP_LIMIT = 3;
 export const SUBSCRIBER_MAP_LIMIT = 25;
 
-export class MindmapLimitError extends Error {
+export class MindmapLimitError extends HttpCodedError {
   constructor(public readonly limit: number) {
-    super(`Mind map limit reached (${limit})`);
-    this.name = 'MindmapLimitError';
+    super(`Mind map limit reached (${limit})`, 402, 'mindmap_limit');
   }
 }
 

--- a/src/usecases/mindmaps/ExportMindmapUseCase.ts
+++ b/src/usecases/mindmaps/ExportMindmapUseCase.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 
 import StorageHandler from '../../lib/storage/StorageHandler';
+import { HttpCodedError } from '../../lib/errors/HttpCodedError';
 import { MindmapRepositoryInterface } from '../../data_layer/MindmapRepository';
 import { MindmapsId } from '../../data_layer/public/Mindmaps';
 import { UsersId } from '../../data_layer/public/Users';
@@ -20,10 +21,9 @@ import { buildMindmapDeckInfo } from './buildMindmapDeckInfo';
 import CustomExporter from '../../lib/parser/exporters/CustomExporter';
 import Note from '../../lib/parser/Note';
 
-export class MindmapNotFoundError extends Error {
+export class MindmapNotFoundError extends HttpCodedError {
   constructor() {
-    super('Mind map not found');
-    this.name = 'MindmapNotFoundError';
+    super('Mind map not found', 404, 'not_found');
   }
 }
 

--- a/src/usecases/mindmaps/UploadMindmapImageUseCase.ts
+++ b/src/usecases/mindmaps/UploadMindmapImageUseCase.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import imageSize from 'image-size';
 
 import StorageHandler from '../../lib/storage/StorageHandler';
+import { HttpCodedError } from '../../lib/errors/HttpCodedError';
 import { detectFileMime } from '../../lib/detectFileMime';
 
 const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
@@ -13,17 +14,19 @@ const ALLOWED_MIME_TYPES = new Set([
   'image/webp',
 ]);
 
-export class MindmapImageTooLargeError extends Error {
+export class MindmapImageTooLargeError extends HttpCodedError {
   constructor() {
-    super('Image exceeds the 5 MB limit');
-    this.name = 'MindmapImageTooLargeError';
+    super('Image exceeds the 5 MB limit', 413, 'too_large');
   }
 }
 
-export class MindmapImageTypeError extends Error {
+export class MindmapImageTypeError extends HttpCodedError {
   constructor() {
-    super('Only PNG, JPEG, GIF, and WebP images are accepted');
-    this.name = 'MindmapImageTypeError';
+    super(
+      'Only PNG, JPEG, GIF, and WebP images are accepted',
+      415,
+      'unsupported_format'
+    );
   }
 }
 


### PR DESCRIPTION
Stage (b) of the error-funnel unification (#4195; stage (a) — the 400/err.message leak — shipped in #4210).

## What

- **`HttpCodedError`** (`src/lib/errors/HttpCodedError.ts`): one base class carrying `status` + machine-readable `code`. A use case throws a subclass; the funnel puts `res.status(status).json({ code, message })` on the wire. No controller instanceof→status map needed.
- **ErrorHandler** maps `HttpCodedError` first (before the multer/Notion/internal-fault branches).
- **`isExpectedClientFault`** now treats a 4xx `HttpCodedError` as a deliberate client fault: no error email, no stack spam, no `error_events` row (ErrorCaptureMiddleware skip). 5xx coded errors still record and log.
- **Proof migration — the mindmap surface**: `MindmapLimitError` (402 `mindmap_limit`), `MindmapNotFoundError` (404 `not_found`), `MindmapImageTooLargeError` (413 `too_large`), `MindmapImageTypeError` (415 `unsupported_format`) now extend `HttpCodedError`; all four catch-and-map blocks in `MindmapController` are deleted. Express 5 forwards the async rejection to the funnel.

## Wire-contract check

Statuses and messages are byte-identical to before; the body gains an additive `code` field. The web client reads the mindmap limit from the access endpoint (`data.access.freeMapLimit`), not the 402 body — verified, nothing parses these bodies beyond `message`.

## Tests

- `HttpCodedError.test.ts` — status/code carry, client-fault classification boundary (499/500).
- `ErrorHandler.test.ts` — 4xx coded → status+code+message, quiet; 5xx coded → status kept, not quiet.
- `ErrorCaptureMiddleware.test.ts` — 4xx coded skipped, 5xx coded recorded.
- `MindmapRouter.test.ts` — harness now mounts the real ErrorHandler funnel (mirrors server.ts), so the 402/404/413/415 router tests prove the end-to-end path; 402 body asserted exactly.

Full server suite + tsc: green (counts in the final commit status).

Remaining stage (c) — migrating the other ~12 controllers' hand-rolled maps — is deliberately opportunistic: convert each controller as it's next touched, using the mindmap surface as the template. No standing issue needed once this merges.

Sonar: not run locally; PR decoration will report.

no changelog entry — internal error-funnel refactor; every response keeps its status and message.

Closes #4195

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbQZzLbjr2apKHQC7orhhw
