### PR TITLE
fix: stop duplicate batch emails when both deploy colors overlap

### DIFF
--- a/src/data_layer/JobLockRepository.test.ts
+++ b/src/data_layer/JobLockRepository.test.ts
@@ -1,0 +1,63 @@
+import type { Knex } from 'knex';
+import { JobLockRepository, JOB_LOCK_KEYS } from './JobLockRepository';
+
+function makeDatabase(locked: boolean) {
+  const rawCalls: Array<{ sql: string; bindings: unknown[] }> = [];
+  const trx = {
+    raw: jest.fn(async (sql: string, bindings: unknown[]) => {
+      rawCalls.push({ sql, bindings });
+      return { rows: [{ locked }] };
+    }),
+  };
+  const database = {
+    transaction: jest.fn(async (cb: (t: typeof trx) => Promise<unknown>) =>
+      cb(trx)
+    ),
+  } as unknown as Knex;
+  return { database, rawCalls };
+}
+
+describe('JobLockRepository', () => {
+  it('acquires the advisory lock with the given key and runs the batch', async () => {
+    const { database, rawCalls } = makeDatabase(true);
+    const repo = new JobLockRepository(database);
+    const fn = jest.fn().mockResolvedValue(undefined);
+
+    const ran = await repo.runExclusively(JOB_LOCK_KEYS.reEngagementEmails, fn);
+
+    expect(ran).toBe(true);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(rawCalls).toEqual([
+      {
+        sql: 'select pg_try_advisory_xact_lock(?) as locked',
+        bindings: [JOB_LOCK_KEYS.reEngagementEmails],
+      },
+    ]);
+  });
+
+  it('skips the batch and returns false when the lock is held elsewhere', async () => {
+    const { database } = makeDatabase(false);
+    const repo = new JobLockRepository(database);
+    const fn = jest.fn();
+
+    const ran = await repo.runExclusively(JOB_LOCK_KEYS.inactivityWarnings, fn);
+
+    expect(ran).toBe(false);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('propagates a batch failure so the transaction rolls back', async () => {
+    const { database } = makeDatabase(true);
+    const repo = new JobLockRepository(database);
+    const fn = jest.fn().mockRejectedValue(new Error('batch exploded'));
+
+    await expect(
+      repo.runExclusively(JOB_LOCK_KEYS.pauseResumeWarnings, fn)
+    ).rejects.toThrow('batch exploded');
+  });
+
+  it('allocates a distinct key per job', () => {
+    const keys = Object.values(JOB_LOCK_KEYS);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});

--- a/src/data_layer/JobLockRepository.ts
+++ b/src/data_layer/JobLockRepository.ts
@@ -1,0 +1,46 @@
+import type { Knex } from 'knex';
+
+/**
+ * Central registry so two jobs can never collide on a key. Advisory lock
+ * keys are a global namespace per database; allocate new ones here only.
+ */
+export const JOB_LOCK_KEYS = {
+  reEngagementEmails: 21001,
+  inactivityWarnings: 21002,
+  pauseResumeWarnings: 21003,
+  inactiveUserDeletions: 21004,
+} as const;
+
+export interface IJobLockRepository {
+  runExclusively(lockKey: number, fn: () => Promise<void>): Promise<boolean>;
+}
+
+/**
+ * Cross-instance mutual exclusion for background batch jobs. During a
+ * blue-green deploy both pm2 colors boot the same schedulers; a
+ * transaction-scoped Postgres advisory lock (released automatically at
+ * commit/rollback, so a crashed holder can never leak it) makes sure only
+ * one color executes a batch. Returns false when the lock is held elsewhere
+ * and the batch was skipped.
+ */
+export class JobLockRepository implements IJobLockRepository {
+  constructor(private readonly database: Knex) {}
+
+  async runExclusively(
+    lockKey: number,
+    fn: () => Promise<void>
+  ): Promise<boolean> {
+    return this.database.transaction(async (trx) => {
+      const result = await trx.raw(
+        'select pg_try_advisory_xact_lock(?) as locked',
+        [lockKey]
+      );
+      const locked = result?.rows?.[0]?.locked === true;
+      if (!locked) {
+        return false;
+      }
+      await fn();
+      return true;
+    });
+  }
+}

--- a/src/lib/inactivity/jobs/scheduleInactiveUserDeletions.ts
+++ b/src/lib/inactivity/jobs/scheduleInactiveUserDeletions.ts
@@ -1,5 +1,8 @@
 import type { DeleteInactiveUsersUseCase } from '../../../usecases/ops/DeleteInactiveUsersUseCase';
+import type { IJobLockRepository } from '../../../data_layer/JobLockRepository';
+import { JOB_LOCK_KEYS } from '../../../data_layer/JobLockRepository';
 import type { EventsSink } from '../../../services/events/EventsSink';
+import { makeExclusiveBatchRunner } from '../../scheduling/exclusiveBatch';
 import { isOverdue, type LastRunAt } from './lastRunAt';
 
 export const INACTIVE_USER_DELETION_DAILY_LIMIT = 100;
@@ -12,6 +15,7 @@ export const scheduleInactiveUserDeletions = async (
     limit?: number;
     eventsSink?: EventsSink;
     lastRunAt?: LastRunAt;
+    lock?: IJobLockRepository;
   } = {}
 ): Promise<NodeJS.Timeout> => {
   const intervalMs = options.intervalMs ?? INACTIVE_USER_DELETION_INTERVAL_MS;
@@ -34,14 +38,24 @@ export const scheduleInactiveUserDeletions = async (
     }
   };
 
+  const eventsSink = options.eventsSink;
+  const runBatch = makeExclusiveBatchRunner(tick, {
+    label: 'inactivity-deletions',
+    lockKey: JOB_LOCK_KEYS.inactiveUserDeletions,
+    intervalMs,
+    lock: options.lock,
+    lastRunAt: options.lastRunAt,
+    flush: eventsSink != null ? () => eventsSink.flush() : undefined,
+  });
+
   if (options.lastRunAt != null) {
     const lastRun = await options.lastRunAt();
     if (isOverdue(lastRun, intervalMs, Date.now())) {
-      await tick();
+      await runBatch();
     }
   }
 
-  const handle = setInterval(tick, intervalMs);
+  const handle = setInterval(runBatch, intervalMs);
   handle.unref();
   return handle;
 };

--- a/src/lib/inactivity/jobs/scheduleInactivityWarnings.ts
+++ b/src/lib/inactivity/jobs/scheduleInactivityWarnings.ts
@@ -1,5 +1,8 @@
 import type { SendInactivityWarningsUseCase } from '../../../usecases/ops/SendInactivityWarningsUseCase';
+import type { IJobLockRepository } from '../../../data_layer/JobLockRepository';
+import { JOB_LOCK_KEYS } from '../../../data_layer/JobLockRepository';
 import type { EventsSink } from '../../../services/events/EventsSink';
+import { makeExclusiveBatchRunner } from '../../scheduling/exclusiveBatch';
 import { isOverdue, type LastRunAt } from './lastRunAt';
 
 export const INACTIVITY_WARNING_DAILY_LIMIT = 100;
@@ -12,6 +15,7 @@ export const scheduleInactivityWarnings = async (
     limit?: number;
     eventsSink?: EventsSink;
     lastRunAt?: LastRunAt;
+    lock?: IJobLockRepository;
   } = {}
 ): Promise<NodeJS.Timeout> => {
   const intervalMs = options.intervalMs ?? INACTIVITY_WARNING_INTERVAL_MS;
@@ -32,14 +36,24 @@ export const scheduleInactivityWarnings = async (
     }
   };
 
+  const eventsSink = options.eventsSink;
+  const runBatch = makeExclusiveBatchRunner(tick, {
+    label: 'inactivity-warnings',
+    lockKey: JOB_LOCK_KEYS.inactivityWarnings,
+    intervalMs,
+    lock: options.lock,
+    lastRunAt: options.lastRunAt,
+    flush: eventsSink != null ? () => eventsSink.flush() : undefined,
+  });
+
   if (options.lastRunAt != null) {
     const lastRun = await options.lastRunAt();
     if (isOverdue(lastRun, intervalMs, Date.now())) {
-      await tick();
+      await runBatch();
     }
   }
 
-  const handle = setInterval(tick, intervalMs);
+  const handle = setInterval(runBatch, intervalMs);
   handle.unref();
   return handle;
 };

--- a/src/lib/reengagement/jobs/scheduleReEngagementEmails.test.ts
+++ b/src/lib/reengagement/jobs/scheduleReEngagementEmails.test.ts
@@ -15,8 +15,8 @@ import { sendReEngagementEmails } from '../../storage/jobs/helpers/sendReEngagem
 const mockRepo = {} as IReEngagementRepository;
 const mockEmailService = {} as IEmailService;
 
-function makeSink(): jest.Mocked<Pick<EventsSink, 'record'>> {
-  return { record: jest.fn() };
+function makeSink(): jest.Mocked<Pick<EventsSink, 'record' | 'flush'>> {
+  return { record: jest.fn(), flush: jest.fn().mockResolvedValue(undefined) };
 }
 
 describe('scheduleReEngagementEmails', () => {
@@ -159,6 +159,73 @@ describe('scheduleReEngagementEmails', () => {
     );
 
     expect(sendReEngagementEmails).not.toHaveBeenCalled();
+    clearInterval(handle);
+  });
+
+  it('skips the catch-up batch when another instance holds the lock', async () => {
+    const sink = makeSink();
+    const lastRunAt = jest.fn().mockResolvedValue(null);
+    const lock = {
+      runExclusively: jest.fn().mockResolvedValue(false),
+    };
+
+    const handle = await scheduleReEngagementEmails(
+      mockRepo,
+      mockEmailService,
+      sink as unknown as EventsSink,
+      { intervalMs: 1000, lastRunAt, lock }
+    );
+
+    expect(lock.runExclusively).toHaveBeenCalledTimes(1);
+    expect(sendReEngagementEmails).not.toHaveBeenCalled();
+    clearInterval(handle);
+  });
+
+  it('skips the batch when the lock re-check sees a run by another instance', async () => {
+    const sink = makeSink();
+    // Outer check reads overdue; the re-check inside the lock reads a batch
+    // another instance finished moments ago — the blue-green boot race.
+    const lastRunAt = jest
+      .fn()
+      .mockResolvedValueOnce(new Date(Date.now() - 2000))
+      .mockResolvedValueOnce(new Date(Date.now() - 10));
+    const lock = {
+      runExclusively: jest.fn(async (_key: number, fn: () => Promise<void>) => {
+        await fn();
+        return true;
+      }),
+    };
+
+    const handle = await scheduleReEngagementEmails(
+      mockRepo,
+      mockEmailService,
+      sink as unknown as EventsSink,
+      { intervalMs: 1000, lastRunAt, lock }
+    );
+
+    expect(sendReEngagementEmails).not.toHaveBeenCalled();
+    clearInterval(handle);
+  });
+
+  it('sends and flushes events inside the lock when still overdue', async () => {
+    const sink = makeSink();
+    const lastRunAt = jest.fn().mockResolvedValue(null);
+    const lock = {
+      runExclusively: jest.fn(async (_key: number, fn: () => Promise<void>) => {
+        await fn();
+        return true;
+      }),
+    };
+
+    const handle = await scheduleReEngagementEmails(
+      mockRepo,
+      mockEmailService,
+      sink as unknown as EventsSink,
+      { intervalMs: 1000, lastRunAt, lock }
+    );
+
+    expect(sendReEngagementEmails).toHaveBeenCalledTimes(1);
+    expect(sink.flush).toHaveBeenCalledTimes(1);
     clearInterval(handle);
   });
 });

--- a/src/lib/reengagement/jobs/scheduleReEngagementEmails.ts
+++ b/src/lib/reengagement/jobs/scheduleReEngagementEmails.ts
@@ -1,7 +1,10 @@
 import type { IReEngagementRepository } from '../../../data_layer/ReEngagementRepository';
+import type { IJobLockRepository } from '../../../data_layer/JobLockRepository';
+import { JOB_LOCK_KEYS } from '../../../data_layer/JobLockRepository';
 import type { IEmailService } from '../../../services/EmailService/EmailService';
 import type { EventsSink } from '../../../services/events/EventsSink';
 import { sendReEngagementEmails } from '../../storage/jobs/helpers/sendReEngagementEmails';
+import { makeExclusiveBatchRunner } from '../../scheduling/exclusiveBatch';
 import { isOverdue, type LastRunAt } from '../../inactivity/jobs/lastRunAt';
 
 export const RE_ENGAGEMENT_INTERVAL_MS = 24 * 60 * 60 * 1000;
@@ -10,7 +13,11 @@ export const scheduleReEngagementEmails = async (
   repo: IReEngagementRepository,
   emailService: IEmailService,
   eventsSink: EventsSink,
-  options: { intervalMs?: number; lastRunAt?: LastRunAt } = {}
+  options: {
+    intervalMs?: number;
+    lastRunAt?: LastRunAt;
+    lock?: IJobLockRepository;
+  } = {}
 ): Promise<NodeJS.Timeout> => {
   const intervalMs = options.intervalMs ?? RE_ENGAGEMENT_INTERVAL_MS;
 
@@ -27,17 +34,26 @@ export const scheduleReEngagementEmails = async (
     }
   };
 
+  const runBatch = makeExclusiveBatchRunner(tick, {
+    label: 're-engagement',
+    lockKey: JOB_LOCK_KEYS.reEngagementEmails,
+    intervalMs,
+    lock: options.lock,
+    lastRunAt: options.lastRunAt,
+    flush: () => eventsSink.flush(),
+  });
+
   // Blue-green redeploys reset the interval before it can elapse, so without a
   // catch-up the tick almost never fires. Eligibility is a fixed 24-hour band,
   // which makes a missed day permanent for everyone in it.
   if (options.lastRunAt != null) {
     const lastRun = await options.lastRunAt();
     if (isOverdue(lastRun, intervalMs, Date.now())) {
-      await tick();
+      await runBatch();
     }
   }
 
-  const handle = setInterval(tick, intervalMs);
+  const handle = setInterval(runBatch, intervalMs);
   handle.unref();
   return handle;
 };

--- a/src/lib/scheduling/exclusiveBatch.test.ts
+++ b/src/lib/scheduling/exclusiveBatch.test.ts
@@ -1,0 +1,148 @@
+import { makeExclusiveBatchRunner } from './exclusiveBatch';
+import type { IJobLockRepository } from '../../data_layer/JobLockRepository';
+
+const HOUR = 60 * 60 * 1000;
+const INTERVAL = 24 * HOUR;
+
+function grantingLock(): IJobLockRepository & { calls: number[] } {
+  const calls: number[] = [];
+  return {
+    calls,
+    async runExclusively(key, fn) {
+      calls.push(key);
+      await fn();
+      return true;
+    },
+  };
+}
+
+function deniedLock(): IJobLockRepository {
+  return {
+    async runExclusively() {
+      return false;
+    },
+  };
+}
+
+describe('makeExclusiveBatchRunner', () => {
+  it('runs the tick directly when no lock is configured', async () => {
+    const tick = jest.fn().mockResolvedValue(undefined);
+    const run = makeExclusiveBatchRunner(tick, {
+      label: 'test-job',
+      lockKey: 1,
+      intervalMs: INTERVAL,
+    });
+
+    await run();
+
+    expect(tick).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs the tick under the lock with the configured key', async () => {
+    const tick = jest.fn().mockResolvedValue(undefined);
+    const lock = grantingLock();
+    const run = makeExclusiveBatchRunner(tick, {
+      label: 'test-job',
+      lockKey: 21099,
+      intervalMs: INTERVAL,
+      lock,
+    });
+
+    await run();
+
+    expect(lock.calls).toEqual([21099]);
+    expect(tick).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the tick when the lock is held by another instance', async () => {
+    const tick = jest.fn();
+    const run = makeExclusiveBatchRunner(tick, {
+      label: 'test-job',
+      lockKey: 1,
+      intervalMs: INTERVAL,
+      lock: deniedLock(),
+    });
+
+    await run();
+
+    expect(tick).not.toHaveBeenCalled();
+  });
+
+  it('skips the tick when another instance ran within the last half interval', async () => {
+    const tick = jest.fn();
+    const run = makeExclusiveBatchRunner(tick, {
+      label: 'test-job',
+      lockKey: 1,
+      intervalMs: INTERVAL,
+      lock: grantingLock(),
+      lastRunAt: async () => new Date(Date.now() - 2 * HOUR),
+    });
+
+    await run();
+
+    expect(tick).not.toHaveBeenCalled();
+  });
+
+  it('runs the tick when the last run is older than half the interval', async () => {
+    const tick = jest.fn().mockResolvedValue(undefined);
+    const run = makeExclusiveBatchRunner(tick, {
+      label: 'test-job',
+      lockKey: 1,
+      intervalMs: INTERVAL,
+      lock: grantingLock(),
+      lastRunAt: async () => new Date(Date.now() - 23 * HOUR),
+    });
+
+    await run();
+
+    expect(tick).toHaveBeenCalledTimes(1);
+  });
+
+  it('flushes recorded events before the lock is released', async () => {
+    const order: string[] = [];
+    const tick = jest.fn(async () => {
+      order.push('tick');
+    });
+    const flush = jest.fn(async () => {
+      order.push('flush');
+    });
+    const lock: IJobLockRepository = {
+      async runExclusively(_key, fn) {
+        await fn();
+        order.push('release');
+        return true;
+      },
+    };
+    const run = makeExclusiveBatchRunner(tick, {
+      label: 'test-job',
+      lockKey: 1,
+      intervalMs: INTERVAL,
+      lock,
+      flush,
+    });
+
+    await run();
+
+    expect(order).toEqual(['tick', 'flush', 'release']);
+  });
+
+  it('contains a lock failure instead of crashing the scheduler', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const tick = jest.fn();
+    const lock: IJobLockRepository = {
+      async runExclusively() {
+        throw new Error('db unreachable');
+      },
+    };
+    const run = makeExclusiveBatchRunner(tick, {
+      label: 'test-job',
+      lockKey: 1,
+      intervalMs: INTERVAL,
+      lock,
+    });
+
+    await expect(run()).resolves.toBeUndefined();
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});

--- a/src/lib/scheduling/exclusiveBatch.ts
+++ b/src/lib/scheduling/exclusiveBatch.ts
@@ -1,0 +1,58 @@
+import type { IJobLockRepository } from '../../data_layer/JobLockRepository';
+import { isOverdue, type LastRunAt } from '../inactivity/jobs/lastRunAt';
+
+export interface ExclusiveBatchOptions {
+  label: string;
+  lockKey: number;
+  intervalMs: number;
+  lock?: IJobLockRepository;
+  lastRunAt?: LastRunAt;
+  flush?: () => Promise<void>;
+}
+
+/**
+ * Wraps a scheduler tick so only one instance runs the batch at a time.
+ * Inside the lock the batch re-checks lastRunAt with a half-interval guard:
+ * an instance that acquires the lock right after another instance finished
+ * (the blue-green boot-overlap race) sees the fresh run and skips instead of
+ * duplicating the batch. The guard is half the interval — not the full one —
+ * so the holder's own next on-schedule tick, which lands a few seconds shy
+ * of the exact interval, still runs. `flush` is awaited before the lock is
+ * released so the run's events are durably visible to the next contender's
+ * re-check (the events sink buffers writes).
+ */
+export const makeExclusiveBatchRunner = (
+  tick: () => Promise<void>,
+  options: ExclusiveBatchOptions
+): (() => Promise<void>) => {
+  const { label, lockKey, intervalMs, lock, lastRunAt, flush } = options;
+
+  return async () => {
+    if (lock == null) {
+      await tick();
+      return;
+    }
+    try {
+      const ran = await lock.runExclusively(lockKey, async () => {
+        if (lastRunAt != null) {
+          const lastRun = await lastRunAt();
+          if (!isOverdue(lastRun, intervalMs / 2, Date.now())) {
+            console.info(
+              `[${label}] batch skipped: ran recently on another instance`
+            );
+            return;
+          }
+        }
+        await tick();
+        if (flush != null) {
+          await flush();
+        }
+      });
+      if (!ran) {
+        console.info(`[${label}] batch skipped: lock held by another instance`);
+      }
+    } catch (error) {
+      console.error(`[${label}] exclusive batch run failed:`, error);
+    }
+  };
+};

--- a/src/lib/subscriptions/jobs/schedulePauseResumeWarnings.ts
+++ b/src/lib/subscriptions/jobs/schedulePauseResumeWarnings.ts
@@ -1,5 +1,8 @@
 import type { SendPauseResumeWarningsUseCase } from '../../../usecases/ops/SendPauseResumeWarningsUseCase';
+import type { IJobLockRepository } from '../../../data_layer/JobLockRepository';
+import { JOB_LOCK_KEYS } from '../../../data_layer/JobLockRepository';
 import type { EventsSink } from '../../../services/events/EventsSink';
+import { makeExclusiveBatchRunner } from '../../scheduling/exclusiveBatch';
 import { isOverdue, type LastRunAt } from '../../inactivity/jobs/lastRunAt';
 
 export const PAUSE_RESUME_WARNING_INTERVAL_MS = 24 * 60 * 60 * 1000;
@@ -10,6 +13,7 @@ export const schedulePauseResumeWarnings = async (
     intervalMs?: number;
     eventsSink?: EventsSink;
     lastRunAt?: LastRunAt;
+    lock?: IJobLockRepository;
   } = {}
 ): Promise<NodeJS.Timeout> => {
   const intervalMs = options.intervalMs ?? PAUSE_RESUME_WARNING_INTERVAL_MS;
@@ -29,14 +33,24 @@ export const schedulePauseResumeWarnings = async (
     }
   };
 
+  const eventsSink = options.eventsSink;
+  const runBatch = makeExclusiveBatchRunner(tick, {
+    label: 'pause-resume-warnings',
+    lockKey: JOB_LOCK_KEYS.pauseResumeWarnings,
+    intervalMs,
+    lock: options.lock,
+    lastRunAt: options.lastRunAt,
+    flush: eventsSink != null ? () => eventsSink.flush() : undefined,
+  });
+
   if (options.lastRunAt != null) {
     const lastRun = await options.lastRunAt();
     if (isOverdue(lastRun, intervalMs, Date.now())) {
-      await tick();
+      await runBatch();
     }
   }
 
-  const handle = setInterval(tick, intervalMs);
+  const handle = setInterval(runBatch, intervalMs);
   handle.unref();
   return handle;
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -93,6 +93,7 @@ import PauseResumeWarningRepository from './data_layer/PauseResumeWarningReposit
 import { SendPauseResumeWarningsUseCase } from './usecases/ops/SendPauseResumeWarningsUseCase';
 import { scheduleInactiveUserDeletions } from './lib/inactivity/jobs/scheduleInactiveUserDeletions';
 import { EventsRepository } from './data_layer/EventsRepository';
+import { JobLockRepository } from './data_layer/JobLockRepository';
 import { scheduleParserCanary } from './lib/parser/canary/scheduleParserCanary';
 import { scheduleExportDriftCanary } from './lib/parser/canary/scheduleExportDriftCanary';
 import { scheduleObservabilityCleanup } from './lib/observability/jobs/scheduleObservabilityCleanup';
@@ -305,10 +306,12 @@ const serve = async () => {
 
   const eventsSink = getEventsSink();
   const eventsRepo = new EventsRepository(database);
+  const jobLock = new JobLockRepository(database);
   const reEngagementRepo = new ReEngagementRepository(database);
   const emailService = getDefaultEmailService();
   scheduleReEngagementEmails(reEngagementRepo, emailService, eventsSink, {
     lastRunAt: () => eventsRepo.lastEventAt('email_batch_sent', 'reengagement'),
+    lock: jobLock,
   })
     .then(registerSchedulerTimer)
     .catch((error) => {
@@ -325,6 +328,7 @@ const serve = async () => {
   scheduleInactivityWarnings(sendInactivityWarningsUseCase, {
     eventsSink,
     lastRunAt: () => eventsRepo.lastEventAt('email_batch_sent', 'inactivity'),
+    lock: jobLock,
   })
     .then(registerSchedulerTimer)
     .catch((error) => {
@@ -339,6 +343,7 @@ const serve = async () => {
   schedulePauseResumeWarnings(sendPauseResumeWarningsUseCase, {
     eventsSink,
     lastRunAt: () => eventsRepo.lastEventAt('email_batch_sent', 'pause_resume'),
+    lock: jobLock,
   })
     .then(registerSchedulerTimer)
     .catch((error) => {
@@ -356,6 +361,7 @@ const serve = async () => {
   scheduleInactiveUserDeletions(deleteInactiveUsersUseCase, {
     eventsSink,
     lastRunAt: () => eventsRepo.lastEventAt('inactive_users_deleted'),
+    lock: jobLock,
   })
     .then(registerSchedulerTimer)
     .catch((error) => {


### PR DESCRIPTION
During every blue-green deploy both pm2 colors boot the same schedulers, and the boot catch-up race is real: both colors read `lastRunAt` as overdue before either records `email_batch_sent`, so both send the batch — duplicate re-engagement/inactivity/pause-resume emails, double inactive-user deletion sweeps. No scheduler held any cross-instance lock.

## What

- **`JobLockRepository`** (data layer): `pg_try_advisory_xact_lock` inside a transaction — auto-released at commit/rollback, so a crashed holder can never leak the lock. Central `JOB_LOCK_KEYS` registry so keys can't collide.
- **`makeExclusiveBatchRunner`** (`src/lib/scheduling/exclusiveBatch.ts`): wraps a scheduler tick with three layers:
  1. try-lock — if another instance holds it, skip (covers simultaneous ticks);
  2. **re-check `lastRunAt` inside the lock** with a half-interval guard — an instance that acquires the lock right after another finished sees the fresh run and skips (covers the sequential boot race). Half — not full — interval so the holder's own next on-schedule tick, which lands seconds shy of exact, still fires;
  3. `await eventsSink.flush()` before the lock releases — the sink buffers writes, so without the flush the next contender's re-check would read stale state and the guard would be theater.
- Wired into all four batch schedulers (re-engagement, inactivity warnings, pause-resume warnings, inactive-user deletions) via a new optional `lock` option; `server.ts` passes one shared `JobLockRepository`. Without `lock` the schedulers behave exactly as before (all existing tests pass unchanged).

## Decisions made overnight (please review)

- **Ankify polling deliberately NOT wrapped**, though the issue lists it: its tick can run for minutes (sync fan-out), and holding an idle transaction + pool connection across that is a worse failure mode than the overlap it prevents. Its duplicate-dispatch exposure is already bounded by the atomic job claim from #4148. If you want it locked too, it needs a session-level lock on a pinned connection, not the xact pattern — say the word and I'll do that as a follow-up.
- Guard threshold: half the interval. Assumption: no legitimate need to run the same batch twice within 12h. If wrong, change the `intervalMs / 2` in `exclusiveBatch.ts`.

## Tests

- `JobLockRepository.test.ts` — exact SQL + binding, denied-lock skip, error propagation (rollback), key uniqueness.
- `exclusiveBatch.test.ts` — no-lock passthrough, key propagation, denied skip, half-interval re-check skip/run boundary, tick→flush→release ordering, lock failure contained (scheduler survives a DB blip).
- `scheduleReEngagementEmails.test.ts` — the boot race end-to-end: outer check overdue, re-check inside lock sees the other instance's run, batch skipped; plus denied-lock and send+flush paths.

Full server suite + tsc: green (only the documented pdfinfo environmental failure).

Sonar: not run locally; PR decoration will report.

no changelog entry — internal scheduler correctness; no user-visible behavior change (except no longer occasionally receiving the same email twice after a deploy, which nobody will miss).

Closes #4196

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbQZzLbjr2apKHQC7orhhw
