### PR TITLE
feat: inventory and validate required env vars at boot

### DIFF
--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -1,0 +1,70 @@
+import { assertBootConfig, inspectConfig, CONFIG_VARS } from './config';
+
+const fullEnv = (): NodeJS.ProcessEnv =>
+  Object.fromEntries(CONFIG_VARS.map((v) => [v.name, 'set']));
+
+describe('inspectConfig', () => {
+  it('reports nothing missing when every variable is set', () => {
+    expect(inspectConfig(fullEnv())).toEqual({
+      missingFatal: [],
+      missingWarn: [],
+    });
+  });
+
+  it('reports unset and empty-string variables as missing', () => {
+    const env = fullEnv();
+    delete env.SECRET;
+    env.STRIPE_KEY = '';
+
+    const report = inspectConfig(env);
+
+    expect(report.missingFatal).toEqual(['SECRET']);
+    expect(report.missingWarn).toEqual(['STRIPE_KEY']);
+  });
+});
+
+describe('assertBootConfig', () => {
+  it('throws naming every missing fatal variable at once', () => {
+    const env = fullEnv();
+    delete env.SECRET;
+    delete env.WORKSPACE_BASE;
+
+    expect(() => assertBootConfig(env)).toThrow(
+      /SECRET.*WORKSPACE_BASE|WORKSPACE_BASE.*SECRET/
+    );
+  });
+
+  it('boots quietly outside production when warn variables are unset', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const env = fullEnv();
+    delete env.STRIPE_KEY;
+    env.NODE_ENV = 'test';
+
+    expect(() => assertBootConfig(env)).not.toThrow();
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it('prints one block naming unset warn variables in production', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const env = fullEnv();
+    delete env.STRIPE_KEY;
+    delete env.ANTHROPIC_API_KEY;
+    env.NODE_ENV = 'production';
+
+    expect(() => assertBootConfig(env)).not.toThrow();
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const message = errorSpy.mock.calls[0][0] as string;
+    expect(message).toContain('STRIPE_KEY');
+    expect(message).toContain('ANTHROPIC_API_KEY');
+    errorSpy.mockRestore();
+  });
+
+  it('keeps every inventoried variable documented in env.example', () => {
+    const fs = jest.requireActual<typeof import('fs')>('fs');
+    const example = fs.readFileSync('src/env.example', 'utf8');
+    for (const spec of CONFIG_VARS) {
+      expect(example).toContain(`${spec.name}=`);
+    }
+  });
+});

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,111 @@
+/**
+ * Boot-time inventory of the environment variables the server depends on.
+ * New code adds its variable here (and to src/env.example) instead of
+ * scattering bare process.env reads: `fatal` vars refuse to boot when unset,
+ * `warn` vars print one loud block at production boot so a half-configured
+ * box is visible immediately instead of failing at first use, days later.
+ */
+interface ConfigVarSpec {
+  name: string;
+  level: 'fatal' | 'warn';
+  purpose: string;
+}
+
+export const CONFIG_VARS: readonly ConfigVarSpec[] = [
+  { name: 'SECRET', level: 'fatal', purpose: 'signs and verifies JWTs' },
+  {
+    name: 'WORKSPACE_BASE',
+    level: 'fatal',
+    purpose: 'root directory for uploads and conversion workspaces',
+  },
+  {
+    name: 'DATABASE_URL',
+    level: 'warn',
+    purpose: 'Postgres connection; without it every query fails',
+  },
+  {
+    name: 'STRIPE_KEY',
+    level: 'warn',
+    purpose: 'checkout, subscriptions, and Stripe sync',
+  },
+  {
+    name: 'STRIPE_ENDPOINT_SECRET',
+    level: 'warn',
+    purpose: 'verifies Stripe webhook signatures',
+  },
+  {
+    name: 'PASS_24H_PRICE_ID',
+    level: 'warn',
+    purpose: 'day-pass checkout price',
+  },
+  {
+    name: 'PASS_7D_PRICE_ID',
+    level: 'warn',
+    purpose: 'week-pass checkout price',
+  },
+  {
+    name: 'UNLIMITED_MONTHLY_PRICE_ID',
+    level: 'warn',
+    purpose: 'legacy monthly subscription price and v2 fallback',
+  },
+  {
+    name: 'UNLIMITED_YEARLY_PRICE_ID',
+    level: 'warn',
+    purpose: 'legacy annual subscription price and v2 fallback',
+  },
+  {
+    name: 'ANTHROPIC_API_KEY',
+    level: 'warn',
+    purpose: 'AI card generation, chat assistant, file conversion',
+  },
+  {
+    name: 'SENDGRID_API_KEY',
+    level: 'warn',
+    purpose: 'transactional and batch email',
+  },
+  {
+    name: 'DOMAIN',
+    level: 'warn',
+    purpose: 'absolute links in emails and OAuth redirects',
+  },
+];
+
+export interface ConfigReport {
+  missingFatal: string[];
+  missingWarn: string[];
+}
+
+export function inspectConfig(
+  env: NodeJS.ProcessEnv = process.env
+): ConfigReport {
+  const missing = (level: 'fatal' | 'warn') =>
+    CONFIG_VARS.filter(
+      (spec) => spec.level === level && (env[spec.name] ?? '') === ''
+    ).map((spec) => spec.name);
+  return { missingFatal: missing('fatal'), missingWarn: missing('warn') };
+}
+
+/**
+ * Refuses to boot when any fatal variable is unset — all of them listed in
+ * one error, not one crash per variable. In production, additionally prints
+ * a single block naming every unset `warn` variable and what stops working.
+ */
+export function assertBootConfig(env: NodeJS.ProcessEnv = process.env): void {
+  const { missingFatal, missingWarn } = inspectConfig(env);
+
+  if (missingFatal.length > 0) {
+    throw new Error(
+      `Refusing to boot — required environment variable(s) unset: ${missingFatal.join(', ')}`
+    );
+  }
+
+  if (env.NODE_ENV === 'production' && missingWarn.length > 0) {
+    const lines = missingWarn.map((name) => {
+      const spec = CONFIG_VARS.find((v) => v.name === name);
+      return `  ${name} — ${spec?.purpose ?? ''}`;
+    });
+    console.error(
+      `[config] ${missingWarn.length} environment variable(s) unset in production:\n${lines.join('\n')}`
+    );
+  }
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -11,63 +11,35 @@ interface ConfigVarSpec {
   purpose: string;
 }
 
+const FATAL_VARS: ReadonlyArray<[string, string]> = [
+  ['SECRET', 'signs and verifies JWTs'],
+  ['WORKSPACE_BASE', 'root directory for uploads and conversion workspaces'],
+];
+
+const WARN_VARS: ReadonlyArray<[string, string]> = [
+  ['DATABASE_URL', 'Postgres connection; without it every query fails'],
+  ['STRIPE_KEY', 'checkout, subscriptions, and Stripe sync'],
+  ['STRIPE_ENDPOINT_SECRET', 'verifies Stripe webhook signatures'],
+  ['PASS_24H_PRICE_ID', 'day-pass checkout price'],
+  ['PASS_7D_PRICE_ID', 'week-pass checkout price'],
+  ['UNLIMITED_MONTHLY_PRICE_ID', 'legacy monthly price and v2 fallback'],
+  ['UNLIMITED_YEARLY_PRICE_ID', 'legacy annual price and v2 fallback'],
+  ['ANTHROPIC_API_KEY', 'AI card generation, chat assistant, file conversion'],
+  ['SENDGRID_API_KEY', 'transactional and batch email'],
+  ['DOMAIN', 'absolute links in emails and OAuth redirects'],
+];
+
+const toSpec =
+  (level: ConfigVarSpec['level']) =>
+  ([name, purpose]: [string, string]): ConfigVarSpec => ({
+    name,
+    level,
+    purpose,
+  });
+
 export const CONFIG_VARS: readonly ConfigVarSpec[] = [
-  { name: 'SECRET', level: 'fatal', purpose: 'signs and verifies JWTs' },
-  {
-    name: 'WORKSPACE_BASE',
-    level: 'fatal',
-    purpose: 'root directory for uploads and conversion workspaces',
-  },
-  {
-    name: 'DATABASE_URL',
-    level: 'warn',
-    purpose: 'Postgres connection; without it every query fails',
-  },
-  {
-    name: 'STRIPE_KEY',
-    level: 'warn',
-    purpose: 'checkout, subscriptions, and Stripe sync',
-  },
-  {
-    name: 'STRIPE_ENDPOINT_SECRET',
-    level: 'warn',
-    purpose: 'verifies Stripe webhook signatures',
-  },
-  {
-    name: 'PASS_24H_PRICE_ID',
-    level: 'warn',
-    purpose: 'day-pass checkout price',
-  },
-  {
-    name: 'PASS_7D_PRICE_ID',
-    level: 'warn',
-    purpose: 'week-pass checkout price',
-  },
-  {
-    name: 'UNLIMITED_MONTHLY_PRICE_ID',
-    level: 'warn',
-    purpose: 'legacy monthly subscription price and v2 fallback',
-  },
-  {
-    name: 'UNLIMITED_YEARLY_PRICE_ID',
-    level: 'warn',
-    purpose: 'legacy annual subscription price and v2 fallback',
-  },
-  {
-    name: 'ANTHROPIC_API_KEY',
-    level: 'warn',
-    purpose: 'AI card generation, chat assistant, file conversion',
-  },
-  {
-    name: 'SENDGRID_API_KEY',
-    level: 'warn',
-    purpose: 'transactional and batch email',
-  },
-  {
-    name: 'DOMAIN',
-    level: 'warn',
-    purpose: 'absolute links in emails and OAuth redirects',
-  },
+  ...FATAL_VARS.map(toSpec('fatal')),
+  ...WARN_VARS.map(toSpec('warn')),
 ];
 
 export interface ConfigReport {

--- a/src/server.ts
+++ b/src/server.ts
@@ -110,6 +110,7 @@ import StorageHandler from './lib/storage/StorageHandler';
 import { UserDeletionService } from './services/UserDeletionService';
 import SuppressionEventsRepository from './data_layer/SuppressionEventsRepository';
 import { initConversionPool } from './lib/conversionPool';
+import { assertBootConfig } from './lib/config';
 import { gracefulShutdown } from './lib/gracefulShutdown';
 
 function registerSignalHandlers(server: http.Server, database: Knex) {
@@ -239,16 +240,7 @@ const serve = async () => {
 
   const cwd = process.cwd();
   process.chdir(cwd);
-  if (!process.env.SECRET) {
-    throw new Error(
-      'SECRET environment variable is required to sign JWTs. Refusing to boot with an unset secret.'
-    );
-  }
-  if (!process.env.WORKSPACE_BASE) {
-    throw new Error(
-      'WORKSPACE_BASE environment variable is required. Refusing to boot without a workspace root.'
-    );
-  }
+  assertBootConfig();
   initConversionPool();
   const port = process.env.PORT || 2020;
   server.listen(port, () => {


### PR DESCRIPTION
Boot validated exactly two env vars (SECRET, WORKSPACE_BASE) — one at a time, one crash each. STRIPE_KEY, the price IDs, ANTHROPIC_API_KEY, and SENDGRID_API_KEY failed at first use, sometimes days after a deploy on a half-configured box.

## What

- **`src/lib/config.ts`** — one inventory (`CONFIG_VARS`) of the variables the server depends on, each `fatal` (refuse to boot) or `warn` (loud one-block report at production boot naming what stops working). `assertBootConfig()` replaces the two inline throws in `server.ts` and lists **all** missing fatal vars in one error instead of one per crash.
- A test pins every inventoried var to an entry in `src/env.example`, so the inventory and the documentation can't drift apart.
- Convention (in the module doc): new code adds its variable to `CONFIG_VARS` + `env.example` instead of scattering bare `process.env` reads. Existing 148 reads migrate opportunistically, per the issue.

## Decisions made overnight (please review)

- **Payment/AI/email keys are `warn`, not `fatal`.** The issue proposes failing fast in production for these, but I can't verify from here that the prod `.env` actually has every one set — making them fatal on an unverified assumption could crashloop the next deploy. The warn block gives you the visibility immediately; flip any line to `level: 'fatal'` once you've confirmed prod has it (one-word change each, and the warn block on next boot tells you exactly which are safe to flip).
- Warn block prints only under `NODE_ENV=production` — a dev checkout without Stripe keys is normal and shouldn't get boot noise.
- Scope: validation core only. Typed accessors / threading values into use-case constructors is the opportunistic half of the issue and rides with future touches.

## Tests

`config.test.ts` — nothing-missing report, unset + empty-string detection, multi-var fatal error, quiet non-production boot, one-block production warn naming each var, env.example parity.

Fatal semantics for SECRET/WORKSPACE_BASE are byte-equivalent to the old checks (unset or empty → refuse to boot, any NODE_ENV).

Sonar: not run locally; PR decoration will report.

no changelog entry — internal boot validation; no user-visible change.

Closes #4197

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbQZzLbjr2apKHQC7orhhw
