### PR TITLE
fix: call metascraper rule factories so bookmarks get metadata

### DIFF
--- a/src/services/NotionService/blocks/media/BlockBookmark/hooks/useMetadata.composition.test.ts
+++ b/src/services/NotionService/blocks/media/BlockBookmark/hooks/useMetadata.composition.test.ts
@@ -1,0 +1,31 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Guards #4205: every metascraper-* package exports a rule FACTORY that must
+ * be CALLED. Passing the factory itself makes metascraper key its output on
+ * the module's helper exports (createFavicon, pickBiggerSize, ...) and
+ * bookmark previews silently lose title/description/image. The real packages
+ * cannot run under jest (ESM-only dependency chain — they are stubbed via
+ * moduleNameMapper), which is exactly how the regression shipped green, so
+ * this suite pins the contract at the source and stub level instead.
+ */
+describe('metascraper composition', () => {
+  it('every metascraper rule package in useMetadata is invoked as a factory', () => {
+    const source = fs.readFileSync(
+      path.join(__dirname, 'useMetadata.ts'),
+      'utf8'
+    );
+    const requires = source.match(/require\('metascraper-[a-z-]+'\)\(?\)?/g);
+    expect(requires?.length).toBeGreaterThanOrEqual(5);
+    for (const call of requires ?? []) {
+      expect(call.endsWith(')()')).toBe(true);
+    }
+  });
+
+  it('the jest stub keeps the factory shape of the real packages', () => {
+    const plugin = require('metascraper-title');
+    expect(typeof plugin).toBe('function');
+    expect(typeof plugin()).toBe('object');
+  });
+});

--- a/src/services/NotionService/blocks/media/BlockBookmark/hooks/useMetadata.test.ts
+++ b/src/services/NotionService/blocks/media/BlockBookmark/hooks/useMetadata.test.ts
@@ -31,11 +31,11 @@ jest.mock(
     (...args: unknown[]) =>
       scrape(...args)
 );
-jest.mock('metascraper-description', () => ({}), { virtual: true });
-jest.mock('metascraper-image', () => ({}), { virtual: true });
-jest.mock('metascraper-logo-favicon', () => ({}), { virtual: true });
-jest.mock('metascraper-title', () => ({}), { virtual: true });
-jest.mock('metascraper-url', () => ({}), { virtual: true });
+jest.mock('metascraper-description', () => () => ({}), { virtual: true });
+jest.mock('metascraper-image', () => () => ({}), { virtual: true });
+jest.mock('metascraper-logo-favicon', () => () => ({}), { virtual: true });
+jest.mock('metascraper-title', () => () => ({}), { virtual: true });
+jest.mock('metascraper-url', () => () => ({}), { virtual: true });
 
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 const mockedLookup = dns.promises.lookup as jest.Mock;

--- a/src/services/NotionService/blocks/media/BlockBookmark/hooks/useMetadata.ts
+++ b/src/services/NotionService/blocks/media/BlockBookmark/hooks/useMetadata.ts
@@ -1,11 +1,15 @@
 import instrumentedAxios from '../../../../../observability/instrumentedAxios';
 
+// Every metascraper-* package exports a rule FACTORY — it must be called.
+// Passing the factory itself makes metascraper treat the module's attached
+// helper exports (createFavicon, pickBiggerSize, ...) as rule names and
+// bookmark blocks silently lose their preview metadata (#4205).
 const metascraper = require('metascraper')([
-  require('metascraper-description'),
-  require('metascraper-image'),
-  require('metascraper-logo-favicon'),
-  require('metascraper-title'),
-  require('metascraper-url'),
+  require('metascraper-description')(),
+  require('metascraper-image')(),
+  require('metascraper-logo-favicon')(),
+  require('metascraper-title')(),
+  require('metascraper-url')(),
 ]);
 
 export interface Metadata {

--- a/src/test/mocks/metascraperPlugin.ts
+++ b/src/test/mocks/metascraperPlugin.ts
@@ -1,3 +1,8 @@
-// Jest stub for metascraper-* plugin packages (passed into the metascraper
-// factory). See metascraper.ts for why the real packages are kept out of jest.
-export = {};
+// Jest stub for metascraper-* plugin packages. The real packages export a
+// rule FACTORY that useMetadata must call (#4205) — the stub keeps that
+// shape so a composition that forgets the call fails in jest the same way
+// it fails in production. See metascraper.ts for why the real packages are
+// kept out of the jest module graph.
+const pluginFactory = (): Record<string, unknown> => ({});
+
+export = pluginFactory;

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-22-bookmark-previews.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-22-bookmark-previews.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-22-bookmark-previews",
+  "date": "2026-08-22",
+  "type": "fix",
+  "title": "Notion bookmark blocks convert with their title, description, and preview image again"
+}


### PR DESCRIPTION
Root cause of #4205, and it's a one-character-class bug: every `metascraper-*` package exports a rule **factory** that must be **called**. `useMetadata.ts` passed the factories themselves, so metascraper keyed its output on the modules' attached helper exports — the observed `{"createFavicon":null,"pickBiggerSize":null,"resolveFaviconUrl":null,"google":null}` — and every Notion bookmark block converted without title, description, or preview image, silently. Git history shows the `()` calls existed in earlier revisions and were dropped in a later rewrite, not by a dependency bump.

## Why CI never caught it

Jest stubs the entire metascraper family via `moduleNameMapper` (`src/test/mocks/`) because its dependency chain is ESM-only — so no test ever ran the real composition, and the old plugin stub (`export = {}`) didn't even match the real factory shape.

## What

- `useMetadata.ts`: call all five rule factories (with a comment pinning why).
- `src/test/mocks/metascraperPlugin.ts`: stub is now factory-shaped, so an uncalled-factory regression fails in jest the same way it fails in production.
- New `useMetadata.composition.test.ts`: source sensor asserting every `require('metascraper-…')` ends in `()`, plus a stub-shape parity check.
- Existing `useMetadata.test.ts` virtual mocks updated to the factory shape.

## Verification

Executed against the real library (outside jest, where the real packages load):

```
$ npx tsx -e "…useMetadata('https://github.com/2anki/server')…"
{"description":"Server to create Anki flashcards faster, easier and better today ⭐️ - 2anki/2anki.net","title":"GitHub - 2anki/2anki.net: …","url":"…","image":"…","logo":"https://github.com/fluidicon.png"}
```

Same call returned only helper keys before the fix. Plain-node CJS require confirmed callable (`typeof === 'function'`), so the compiled prod build composes identically. Full server suite + tsc green (documented pdfinfo environmental failure only).

Changelog entry included (bookmark previews are user-visible).

Sonar: not run locally; PR decoration will report.

Fixes #4205

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbQZzLbjr2apKHQC7orhhw
