### PR TITLE
fix: clear every scheduler timer at the top of graceful shutdown

### DIFF
--- a/src/app/bootstrapBackgroundJobs.ts
+++ b/src/app/bootstrapBackgroundJobs.ts
@@ -3,6 +3,7 @@ import { Client as NotionClient } from '@notionhq/client';
 import Docker from 'dockerode';
 
 import { scheduleAnkifyReaper } from '../lib/ankify/jobs/scheduleAnkifyReaper';
+import { registerSchedulerTimer } from '../lib/scheduling/timerRegistry';
 import { scheduleImportJobReaper } from '../usecases/apkg/scheduleImportJobReaper';
 import JobRepository from '../data_layer/JobRepository';
 import { scheduleAnkifyPolling } from '../lib/ankify/jobs/scheduleAnkifyPolling';
@@ -47,8 +48,8 @@ export const bootstrapBackgroundJobs = async (database: Knex) => {
     new Docker(),
     ankifySessionTokensRepo
   );
-  scheduleAnkifyReaper(ankifyRac);
-  scheduleImportJobReaper(new JobRepository(database));
+  registerSchedulerTimer(scheduleAnkifyReaper(ankifyRac));
+  registerSchedulerTimer(scheduleImportJobReaper(new JobRepository(database)));
 
   const schedulesRepo = new AnkifyExportSchedulesRepository(database);
   const notionRepo = new NotionRepository(database);
@@ -163,7 +164,7 @@ export const bootstrapBackgroundJobs = async (database: Knex) => {
     topLevelPagesRepo,
     blocksCacheRepo
   );
-  scheduleAnkifyPolling(subscriptionsRepo, syncUseCase, {
+  const pollingHandle = scheduleAnkifyPolling(subscriptionsRepo, syncUseCase, {
     refreshTopLevelPagesForOwner: async (owner) => {
       const newest = await topLevelPagesRepo.newestCachedAt(owner);
       if (
@@ -175,5 +176,6 @@ export const bootstrapBackgroundJobs = async (database: Knex) => {
       await notionServiceForRefresh.refreshTopLevelPagesCache(owner);
     },
   });
+  registerSchedulerTimer(pollingHandle);
   console.info('Ankify polling worker scheduled');
 };

--- a/src/lib/gracefulShutdown.ts
+++ b/src/lib/gracefulShutdown.ts
@@ -4,6 +4,7 @@ import {
   shutdownConversionPool,
   POOL_CLOSE_TIMEOUT_MS,
 } from './conversionPool';
+import { clearSchedulerTimers } from './scheduling/timerRegistry';
 
 // pm2 sends SIGINT then escalates to SIGKILL after kill_timeout
 // (ecosystem.blue-green.config.js). Blue-green puts the new color live before
@@ -42,6 +43,11 @@ export async function gracefulShutdown(
   if (shuttingDown) return;
   shuttingDown = true;
   console.info(`${signal} received — draining HTTP, conversion pool, DB pool`);
+
+  const clearedTimers = clearSchedulerTimers();
+  if (clearedTimers > 0) {
+    console.info(`Cleared ${clearedTimers} scheduler timer(s)`);
+  }
 
   const hardExit = setTimeout(() => {
     console.error(

--- a/src/lib/scheduling/timerRegistry.test.ts
+++ b/src/lib/scheduling/timerRegistry.test.ts
@@ -1,0 +1,32 @@
+import { registerSchedulerTimer, clearSchedulerTimers } from './timerRegistry';
+
+describe('timerRegistry', () => {
+  afterEach(() => {
+    clearSchedulerTimers();
+  });
+
+  it('unrefs and returns the registered handle', () => {
+    const handle = setInterval(() => {}, 60_000);
+    const unref = jest.spyOn(handle, 'unref');
+
+    const returned = registerSchedulerTimer(handle);
+
+    expect(returned).toBe(handle);
+    expect(unref).toHaveBeenCalled();
+  });
+
+  it('clears every registered handle and reports the count', () => {
+    jest.useFakeTimers();
+    const fired = jest.fn();
+    registerSchedulerTimer(setInterval(() => fired(), 1000));
+    registerSchedulerTimer(setInterval(() => fired(), 1000));
+
+    const cleared = clearSchedulerTimers();
+    jest.advanceTimersByTime(5000);
+
+    expect(cleared).toBe(2);
+    expect(fired).not.toHaveBeenCalled();
+    expect(clearSchedulerTimers()).toBe(0);
+    jest.useRealTimers();
+  });
+});

--- a/src/lib/scheduling/timerRegistry.ts
+++ b/src/lib/scheduling/timerRegistry.ts
@@ -1,0 +1,27 @@
+/**
+ * Every boot-time scheduler registers its interval handle here so graceful
+ * shutdown can clear them all before the drain (#4206) — an uncleared timer
+ * can fire mid-shutdown against a closing DB pool or hold the process open
+ * into the 85s force-exit. Registration also unrefs uniformly: no scheduler
+ * should keep the process alive on its own.
+ */
+const handles = new Set<NodeJS.Timeout>();
+
+export function registerSchedulerTimer<
+  T extends NodeJS.Timeout | undefined | null,
+>(handle: T): T {
+  if (handle != null) {
+    handle.unref();
+    handles.add(handle);
+  }
+  return handle;
+}
+
+export function clearSchedulerTimers(): number {
+  const count = handles.size;
+  for (const handle of handles) {
+    clearInterval(handle);
+  }
+  handles.clear();
+  return count;
+}

--- a/src/lib/storage/jobs/ScheduleCleanup.ts
+++ b/src/lib/storage/jobs/ScheduleCleanup.ts
@@ -6,16 +6,18 @@ import deleteOldUploads, {
 } from './helpers/deleteOldUploads';
 import { runFileSystemCleanup } from './helpers/runFileSystemCleanup';
 
-export const ScheduleCleanup = (db: Knex) => {
-  setInterval(() => {
+export const ScheduleCleanup = (db: Knex): NodeJS.Timeout[] => {
+  const fileSystemCleanup = setInterval(() => {
     runFileSystemCleanup(db).catch(console.error);
   }, MS_21);
 
-  setInterval(
+  const oldUploadDeletion = setInterval(
     () =>
       deleteOldUploads(db)
         .then(() => console.info('deleted old uploads'))
         .catch(console.error),
     MS_24_HOURS
   );
+
+  return [fileSystemCleanup, oldUploadDeletion];
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -112,6 +112,7 @@ import { UserDeletionService } from './services/UserDeletionService';
 import SuppressionEventsRepository from './data_layer/SuppressionEventsRepository';
 import { initConversionPool } from './lib/conversionPool';
 import { assertBootConfig } from './lib/config';
+import { registerSchedulerTimer } from './lib/scheduling/timerRegistry';
 import { gracefulShutdown } from './lib/gracefulShutdown';
 
 function registerSignalHandlers(server: http.Server, database: Knex) {
@@ -308,9 +309,11 @@ const serve = async () => {
   const emailService = getDefaultEmailService();
   scheduleReEngagementEmails(reEngagementRepo, emailService, eventsSink, {
     lastRunAt: () => eventsRepo.lastEventAt('email_batch_sent', 'reengagement'),
-  }).catch((error) => {
-    console.error('[re-engagement] failed to schedule:', error);
-  });
+  })
+    .then(registerSchedulerTimer)
+    .catch((error) => {
+      console.error('[re-engagement] failed to schedule:', error);
+    });
 
   const inactivityEmailRepo = new InactivityEmailRepository(database);
   const uploadRepo = new UploadRepository(database);
@@ -322,9 +325,11 @@ const serve = async () => {
   scheduleInactivityWarnings(sendInactivityWarningsUseCase, {
     eventsSink,
     lastRunAt: () => eventsRepo.lastEventAt('email_batch_sent', 'inactivity'),
-  }).catch((error) => {
-    console.error('[inactivity-warnings] failed to schedule:', error);
-  });
+  })
+    .then(registerSchedulerTimer)
+    .catch((error) => {
+      console.error('[inactivity-warnings] failed to schedule:', error);
+    });
 
   const pauseResumeWarningRepo = new PauseResumeWarningRepository(database);
   const sendPauseResumeWarningsUseCase = new SendPauseResumeWarningsUseCase(
@@ -334,9 +339,11 @@ const serve = async () => {
   schedulePauseResumeWarnings(sendPauseResumeWarningsUseCase, {
     eventsSink,
     lastRunAt: () => eventsRepo.lastEventAt('email_batch_sent', 'pause_resume'),
-  }).catch((error) => {
-    console.error('[pause-resume-warnings] failed to schedule:', error);
-  });
+  })
+    .then(registerSchedulerTimer)
+    .catch((error) => {
+      console.error('[pause-resume-warnings] failed to schedule:', error);
+    });
 
   const deleteInactiveUsersUseCase = new DeleteInactiveUsersUseCase(
     inactivityEmailRepo,
@@ -349,21 +356,27 @@ const serve = async () => {
   scheduleInactiveUserDeletions(deleteInactiveUsersUseCase, {
     eventsSink,
     lastRunAt: () => eventsRepo.lastEventAt('inactive_users_deleted'),
-  }).catch((error) => {
-    console.error('[inactivity-deletions] failed to schedule:', error);
-  });
+  })
+    .then(registerSchedulerTimer)
+    .catch((error) => {
+      console.error('[inactivity-deletions] failed to schedule:', error);
+    });
 
-  scheduleParserCanary(emailService);
+  registerSchedulerTimer(scheduleParserCanary(emailService));
 
-  scheduleExportDriftCanary(emailService);
+  registerSchedulerTimer(scheduleExportDriftCanary(emailService));
 
-  scheduleObservabilityCleanup(new ObservabilityRepository(database));
+  registerSchedulerTimer(
+    scheduleObservabilityCleanup(new ObservabilityRepository(database))
+  );
 
-  scheduleMcpOAuthReaper({
-    authorizationCodes: new McpAuthorizationCodeRepository(database),
-    tokens: new McpTokenRepository(database),
-    clients: new McpOAuthClientRepository(database),
-  });
+  registerSchedulerTimer(
+    scheduleMcpOAuthReaper({
+      authorizationCodes: new McpAuthorizationCodeRepository(database),
+      tokens: new McpTokenRepository(database),
+      clients: new McpOAuthClientRepository(database),
+    })
+  );
 
   if (process.env.INSTANCE_ID === 'singapore') {
     console.info(
@@ -371,7 +384,7 @@ const serve = async () => {
     );
   } else {
     try {
-      ScheduleCleanup(database);
+      ScheduleCleanup(database).forEach(registerSchedulerTimer);
     } catch (error) {
       console.error('[fs-cleanup] failed to schedule:', error);
     }


### PR DESCRIPTION
Graceful shutdown drained HTTP, the conversion pool, and the DB — but cleared none of the ~14 interval timers started at boot, and unref discipline was split (canary/observability/mcp handles unref'd; reaper/cleanup/polling not). An un-unref'd timer can hold the process open during drain or fire mid-shutdown against a closing DB pool; the 85s force-exit backstop papered over it (~2/week in pm2 logs).

## What

- `src/lib/scheduling/timerRegistry.ts`: every boot scheduler registers its interval handle; registration unrefs uniformly. `clearSchedulerTimers()` clears and counts them.
- All 14 call sites wired (9 in `server.ts` incl. both `ScheduleCleanup` intervals — it now returns its handles — and the four Promise-returning email schedulers via `.then(registerSchedulerTimer)`; 3 in `bootstrapBackgroundJobs.ts`: ankify reaper, import-job reaper, ankify polling).
- `gracefulShutdown` clears the registry first thing and logs the count.
- Registry tolerates null/undefined handles, so a mocked or failed scheduler can't crash boot.

## Tests

`timerRegistry.test.ts` — unref + return, clear-all stops firing + count, idempotent. Existing gracefulShutdown / ScheduleCleanup / bootstrapBackgroundJobs suites green. Full server suite + tsc green (documented pdfinfo environmental failure only).

Sonar: not run locally; PR decoration will report.

no changelog entry — internal shutdown hygiene; no user-visible change.

Closes #4206

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbQZzLbjr2apKHQC7orhhw