### PR TITLE
fix: answer an over-long chat message with a clean 413

### DIFF
--- a/src/lib/misc/isExpectedClientFault.ts
+++ b/src/lib/misc/isExpectedClientFault.ts
@@ -29,5 +29,11 @@ export const isExpectedClientFault = (error?: Error): boolean => {
   if (isHttpCodedClientFault(error)) {
     return true;
   }
+  // Every multer error is the request's fault (too large, wrong field,
+  // too many files) and ErrorHandler maps each to a clean 4xx — recording
+  // them as server errors buries real crashes in the dashboard.
+  if (error.name === 'MulterError') {
+    return true;
+  }
   return error.name === 'AnkiAppExportError';
 };

--- a/src/routes/ChatRouter.ts
+++ b/src/routes/ChatRouter.ts
@@ -23,7 +23,9 @@ import RequirePayingJson from './middleware/RequirePayingJson';
 
 const chatUpload = multer({
   storage: multer.memoryStorage(),
-  limits: { fileSize: 10 * 1024 * 1024, files: 5 },
+  // fieldSize codifies multer's default: a text field (the chat message)
+  // caps at 1 MB and overflow maps to a clean 413 in ErrorHandler (#4209).
+  limits: { fileSize: 10 * 1024 * 1024, files: 5, fieldSize: 1024 * 1024 },
 });
 
 const ChatRouter = () => {

--- a/src/routes/middleware/ErrorCaptureMiddleware.test.ts
+++ b/src/routes/middleware/ErrorCaptureMiddleware.test.ts
@@ -293,6 +293,21 @@ describe('makeErrorCaptureMiddleware', () => {
     expect(next).toHaveBeenCalledWith(limitError);
   });
 
+  it('does not record an over-long form field multer error', async () => {
+    const repo = makeRepository();
+    const middleware = makeErrorCaptureMiddleware(repo);
+    const next = makeNext();
+    const fieldError = Object.assign(new Error('Field value too long'), {
+      code: 'LIMIT_FIELD_VALUE',
+      name: 'MulterError',
+    });
+
+    await middleware(fieldError, makeReq('/api/chat/message'), makeRes(), next);
+
+    expect(repo.inserts).toHaveLength(0);
+    expect(next).toHaveBeenCalledWith(fieldError);
+  });
+
   it('does not record a client-abort error', async () => {
     const repo = makeRepository();
     const middleware = makeErrorCaptureMiddleware(repo);

--- a/src/routes/middleware/ErrorHandler.test.ts
+++ b/src/routes/middleware/ErrorHandler.test.ts
@@ -382,6 +382,20 @@ describe('ErrorHandler', () => {
     errorSpy.mockRestore();
   });
 
+  test('an over-long form field responds 413 with a friendly message', async () => {
+    const res = makeResponse(false);
+    const req = makeRequest();
+
+    const fieldError = new multer.MulterError('LIMIT_FIELD_VALUE');
+    await ErrorHandler(res as unknown as express.Response, req, fieldError);
+
+    expect(res.statusCode).toBe(413);
+    expect(res.body).toEqual({
+      code: 'too_large',
+      message: 'Message is too long — shorten it and try again.',
+    });
+  });
+
   test('a malformed-JSON body error keeps its 400 and message', async () => {
     const res = makeResponse(false);
     const req = makeRequest();

--- a/src/routes/middleware/ErrorHandler.tsx
+++ b/src/routes/middleware/ErrorHandler.tsx
@@ -192,5 +192,12 @@ function toMulterErrorBody(err: multer.MulterError): {
         "This file type isn't supported. Use .zip, .html, .md, .csv, or .apkg.",
     };
   }
+  if (err.code === 'LIMIT_FIELD_VALUE') {
+    return {
+      status: 413,
+      code: 'too_large',
+      message: 'Message is too long — shorten it and try again.',
+    };
+  }
   return { status: 400, code: 'unknown', message: err.message };
 }

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-22-chat-message-too-long.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-22-chat-message-too-long.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-22-chat-message-too-long",
+  "date": "2026-08-22",
+  "type": "fix",
+  "title": "Chat tells you when a message is too long instead of failing with a server error"
+}


### PR DESCRIPTION
One prod error event (2026-08-20): `MulterError: Field value too long` from /api/chat/message — a chat text field past multer's default 1 MB `fieldSize` surfaced as an unhandled error with raw multer text and was recorded in error_events as a server fault.

## What

- `ErrorHandler`'s multer map gains `LIMIT_FIELD_VALUE` → **413** `too_large` with "Message is too long — shorten it and try again."
- `isExpectedClientFault` now treats every `MulterError` as a client fault: no error_events row, no error email — ErrorHandler already maps each to a clean 4xx.
- `ChatRouter` codifies `fieldSize: 1 MB` explicitly instead of relying on the silent default.

## Decisions made overnight (please review)

- **Kept the cap at multer's current 1 MB** rather than choosing a tighter product limit — the issue flags that decision and it's yours (a real chat message is orders of magnitude smaller; tightening is a one-number change on the annotated line in ChatRouter.ts).
- Heads-up: this PR and #4216 both touch `isExpectedClientFault.ts` and `ErrorHandler.test.ts` with small additive edits — whichever merges second needs a trivial rebase.

## Tests

ErrorHandler: 413 body asserted. ErrorCaptureMiddleware: LIMIT_FIELD_VALUE not recorded. Full server suite + tsc green (documented pdfinfo environmental failure only). Changelog entry included.

Sonar: not run locally; PR decoration will report.

Fixes #4209

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbQZzLbjr2apKHQC7orhhw