### PR TITLE
fix: tag search auth failures so expired sessions bounce to login

### DIFF
--- a/web/src/lib/backend/Backend.test.ts
+++ b/web/src/lib/backend/Backend.test.ts
@@ -159,6 +159,35 @@ describe('Backend', () => {
       expect(results[0].parent).toEqual({ type: 'page_id' });
       expect(results[1].parent).toEqual({ type: 'database_id' });
     });
+
+    it('tags an expired-session 401 as a client fault and bounces to login', async () => {
+      vi.mocked(api.post).mockResolvedValue(
+        createMockResponse(401, false, 'Unauthorized', {
+          message: 'Authentication required',
+        })
+      );
+
+      const error = await backend.search('biology').catch((e) => e);
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toBe('Authentication required');
+      expect(error.status).toBe(401);
+      expect(api.redirectToLogin).toHaveBeenCalled();
+    });
+
+    it('tags a server failure with its status without redirecting', async () => {
+      vi.mocked(api.post).mockResolvedValue(
+        createMockResponse(500, false, 'Internal Server Error', {
+          message: 'Search blew up',
+        })
+      );
+
+      const error = await backend.search('biology').catch((e) => e);
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error.status).toBe(500);
+      expect(api.redirectToLogin).not.toHaveBeenCalled();
+    });
   });
 
   describe('restartClaudeJob', () => {

--- a/web/src/lib/backend/Backend.ts
+++ b/web/src/lib/backend/Backend.ts
@@ -238,6 +238,36 @@ export class Backend {
     );
   }
 
+  // The search POST reads its body here instead of going through api.ts's
+  // taggedHttpError, so a failed response must be tagged with its status —
+  // otherwise an expired session's 401 slips past reportClientError's
+  // expected-client-fault filter and lands in /ops/errors as a crash.
+  private searchFailure(
+    status: number,
+    data: { message?: unknown; code?: unknown }
+  ): Error {
+    const message =
+      typeof data.message === 'string'
+        ? data.message
+        : `Search failed (${status})`;
+    if (isIntentionalBackendNotice(message)) {
+      return new UserNotice(
+        message,
+        typeof data.code === 'string' ? data.code : undefined
+      );
+    }
+    if (status === UNAUTHORIZED) {
+      redirectToLogin();
+    }
+    const error = new Error(message) as Error & {
+      status?: number;
+      method?: string;
+    };
+    error.status = status;
+    error.method = 'POST';
+    return error;
+  }
+
   async search(query: string): Promise<NotionObject[]> {
     const favorites = await this.getFavorites();
 
@@ -268,6 +298,9 @@ export class Backend {
     } else {
       const response = await post(`${this.baseURL}notion/pages`, { query });
       data = await response.json();
+      if (!response.ok) {
+        throw this.searchFailure(response.status, data);
+      }
     }
 
     if ('message' in data) {

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-24-search-expired-session.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-24-search-expired-session.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-24-search-expired-session",
+  "date": "2026-08-24",
+  "type": "fix",
+  "title": "Notion search with an expired session sends you back to sign in instead of showing an error"
+}


### PR DESCRIPTION
## Summary

Clears the last live gap from today's /ops/errors sweep (the "Authentication required" group, 3× over a month on `/notion`).

- `Backend.search` posts to `/api/notion/pages` and reads the body itself, so a failed response never went through `api.ts`'s `taggedHttpError` — an expired session's 401 threw a plain untagged `Error` that slipped past `reportClientError`'s expected-client-fault filter and recorded as a crash.
- The new `searchFailure` helper tags the thrown error with `status` + `method` (so the reporter classifies 4xx as client faults), bounces a 401 to login exactly like the GET paths' `throwForUnauthorized`, and keeps intentional backend notices surfacing as `UserNotice`.
- Server 5xx still reports — now with status metadata instead of bare text.

## Tests

- New: expired-session 401 → error tagged `status: 401`, `redirectToLogin` called; 500 → tagged, no redirect. Watched both fail (`expected undefined to be 401/500`) before the fix.
- `src/lib/backend` suite: 105 pass. Web typecheck, lint (exit 0, pre-existing warnings only), tree-wide `format:check` clean.

Sonar: not run locally; PR decoration will report.

Changelog entry included.

## Browser check

Browser check: not applicable — no rendered UI changes; the behavior change (401 → login redirect) reuses the existing `redirectToLogin` path and is pinned by unit tests.
