### PR TITLE
fix: redact the AnkiConnect API key from the provision log line

### DIFF
--- a/src/services/ankify/RacService.test.ts
+++ b/src/services/ankify/RacService.test.ts
@@ -164,6 +164,26 @@ describe('RacService.provision', () => {
     expect(client.owner).toBe(42);
   });
 
+  test('never writes the AnkiConnect API key to the log', async () => {
+    const info = jest.spyOn(console, 'info').mockImplementation(() => {});
+    try {
+      const { service, repo } = makeService();
+
+      await service.provision(42);
+
+      const { anki_connect_api_key: key } = (repo.create as jest.Mock).mock
+        .calls[0][0] as { anki_connect_api_key: string };
+      const logged = info.mock.calls.map((args) => JSON.stringify(args));
+      expect(key).toMatch(/^[A-Za-z0-9_-]{43}$/);
+      expect(logged.some((line) => line.includes(key))).toBe(false);
+      expect(
+        logged.some((line) => line.includes('docker.createContainer args'))
+      ).toBe(true);
+    } finally {
+      info.mockRestore();
+    }
+  });
+
   test('binds host ports on 127.0.0.1 only and does not publish 5900', async () => {
     const { service, docker } = makeService();
 

--- a/src/services/ankify/RacService.ts
+++ b/src/services/ankify/RacService.ts
@@ -498,7 +498,7 @@ export class RacService {
     };
     console.info(
       '[ankify-provision] docker.createContainer args:',
-      JSON.stringify(createOpts)
+      JSON.stringify({ ...createOpts, Env: ['ANKICONNECT_API_KEY=<redacted>'] })
     );
     let container: DockerContainerLike;
     try {


### PR DESCRIPTION
## What

`RacService.createAndStartContainer` logged `JSON.stringify(createOpts)`, and `createOpts.Env` carries `ANKICONNECT_API_KEY=<key>`. Every Ankify provision therefore wrote the container's AnkiConnect key into the pm2 out log (4 hits in the last 48h; rotated log files back to May are still on the box). The line now logs the same shape with `Env` replaced by `['ANKICONNECT_API_KEY=<redacted>']`.

## Test

`RacService.test.ts`: spies on `console.info`, provisions, reads the minted key off `repo.create`'s argument, and asserts no logged line contains it (and that the diagnostic line itself still fires). Fails on `main` (`Received: true`), passes here.

Closes #4233

## Checks

- `pnpm test src/services/ankify/RacService.test.ts` — 31 passed
- `pnpm format:check` — clean
- `tsc -p . --noEmit` — clean
- No changelog entry — internal log hygiene, no user-visible behavior change.
- Sonar: not run locally; PR decoration will report.
- No `web/src` changes — no browser attestation needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NX8jUkjnkXq5xttMFBVrvn
