### PR TITLE
fix: gate the REST merge endpoint and share PR-ref extraction

### DIFF
--- a/.claude/docs/autonomous-shipping.md
+++ b/.claude/docs/autonomous-shipping.md
@@ -47,6 +47,6 @@ One GitHub issue per UTC day, `Shipped YYYY-MM-DD`, label `shipped-digest`, one 
 
 ## Rolling it out / rolling it back
 
-- Branch protection was applied with `gh api -X PUT repos/2anki/server/branches/main/protection` after the workflow change landed on `main`. To read the current state: `gh api repos/2anki/server/branches/main/protection`.
+- Branch protection was applied 2026-08-26 with `gh api -X PUT repos/2anki/2anki.net/branches/main/protection` — use the canonical repo name for writes, `gh api` does not follow the rename redirect (`2anki/server` answers a PUT with HTTP 307). To read the current state: `gh api repos/2anki/server/branches/main/protection`.
 - To pause autonomous merging without touching code, set `required_approving_review_count` to 1 in branch protection — every merge then waits for a human approval. Restore with the same PUT.
 - If SonarCloud's GitHub status check is ever enabled in the SonarCloud UI, add its context to the required list and keep `sonar_gate.py` as the finding-count check (the GitHub check reports the gate, not the count).

--- a/.claude/hooks/check-browser-attestation.py
+++ b/.claude/hooks/check-browser-attestation.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import json
 import os
-import re
 import subprocess
 import sys
 
@@ -16,8 +15,6 @@ CHECKBOX_CONSOLE_ERRORS = "- [x] No console errors at 375px"
 OUT_CLAUSE_PREFIX = "Browser check: not applicable —"
 CHANGELOG_DIR_PREFIX = "web/src/pages/WhatsNewPage/changelog/"
 
-GH_PR_MERGE = re.compile(r"\bgh\s+pr\s+merge\b")
-PR_URL = re.compile(r"https?://github\.com/[^/]+/[^/]+/pull/(\d+)")
 
 
 def allow():
@@ -41,16 +38,7 @@ def is_gh_pr_merge(cmd):
 
 
 def extract_pr_ref(cmd):
-    after = GH_PR_MERGE.split(cmd, 1)[1]
-    after = re.split(r"[;&|]", after, 1)[0]
-    url_match = PR_URL.search(after)
-    if url_match:
-        return url_match.group(1)
-    tokens = [t for t in after.split() if not t.startswith("-")]
-    for token in tokens:
-        if token.isdigit():
-            return token
-    return None
+    return merge_command.extract_pr_ref(cmd)
 
 
 def fetch_pr_data(pr_ref):

--- a/.claude/hooks/check-changelog-on-merge.py
+++ b/.claude/hooks/check-changelog-on-merge.py
@@ -25,8 +25,6 @@ import merge_command  # noqa: E402
 CHANGELOG_DIR_PREFIX = "web/src/pages/WhatsNewPage/changelog/"
 OUT_CLAUSE = re.compile(r"no changelog entry", re.IGNORECASE)
 
-GH_PR_MERGE = re.compile(r"\bgh\s+pr\s+merge\b")
-PR_URL = re.compile(r"https?://github\.com/[^/]+/[^/]+/pull/(\d+)")
 USER_VISIBLE_PREFIX = re.compile(r"^(feat|fix)(\([^)]*\))?!?:", re.IGNORECASE)
 
 
@@ -51,16 +49,7 @@ def is_gh_pr_merge(cmd):
 
 
 def extract_pr_ref(cmd):
-    after = GH_PR_MERGE.split(cmd, 1)[1]
-    after = re.split(r"[;&|]", after, 1)[0]
-    url_match = PR_URL.search(after)
-    if url_match:
-        return url_match.group(1)
-    tokens = [t for t in after.split() if not t.startswith("-")]
-    for token in tokens:
-        if token.isdigit():
-            return token
-    return None
+    return merge_command.extract_pr_ref(cmd)
 
 
 def fetch_pr_data(pr_ref):

--- a/.claude/hooks/check-merge-status.py
+++ b/.claude/hooks/check-merge-status.py
@@ -217,6 +217,12 @@ def main():
     if not is_gh_pr_merge(cmd):
         allow()
 
+    if merge_command.is_graphql_merge(cmd):
+        deny(
+            "Refusing a GraphQL mergePullRequest mutation — no PR number to gate on. "
+            "Merge through /ship with `gh pr merge <n>`."
+        )
+
     pr_ref = extract_pr_ref(cmd)
     pr_data = fetch_pr_data(pr_ref)
     if pr_data is None:

--- a/.claude/hooks/check-merge-status.py
+++ b/.claude/hooks/check-merge-status.py
@@ -59,8 +59,6 @@ def deny(reason):
     sys.exit(0)
 
 
-GH_PR_MERGE = re.compile(r"\bgh\s+pr\s+merge\b")
-PR_URL = re.compile(r"https?://github\.com/[^/]+/[^/]+/pull/(\d+)")
 REVIEW_MARKER = re.compile(r"<!--\s*ship-review:\s*pass\s+sha=([0-9a-f]{40})\s*-->")
 DEPENDABOT = "dependabot[bot]"
 
@@ -70,16 +68,7 @@ def is_gh_pr_merge(cmd):
 
 
 def extract_pr_ref(cmd):
-    after = GH_PR_MERGE.split(merge_command.strip_literals(cmd), 1)[1]
-    after = re.split(r"[;&|]", after, maxsplit=1)[0]
-    url_match = PR_URL.search(after)
-    if url_match:
-        return url_match.group(1)
-    tokens = [t for t in after.split() if not t.startswith("-")]
-    for token in tokens:
-        if token.isdigit():
-            return token
-    return None
+    return merge_command.extract_pr_ref(cmd)
 
 
 def run_gh(args, label):

--- a/.claude/hooks/check-merge-status.test.py
+++ b/.claude/hooks/check-merge-status.test.py
@@ -99,6 +99,14 @@ class TestExtractPrRef(unittest.TestCase):
         self.assertEqual(hook.extract_pr_ref('echo "gh pr merge" && gh pr merge 4244'), "4244")
 
 
+class TestGraphqlMerge(unittest.TestCase):
+    def test_graphql_mutation_is_denied_outright(self):
+        cmd = "gh api graphql -f query='mutation { mergePullRequest(input:{pullRequestId:\"PR_x\"}) { clientMutationId } }'"
+        result = run_hook(cmd, pr_json(CLEAN_FILES, comments=[MARKER]))
+        self.assertEqual(result["result"], "deny")
+        self.assertIn("mergePullRequest", result["reason"])
+
+
 class TestHardRails(unittest.TestCase):
     def test_rail_path_denies_and_names_it(self):
         result = run_hook("gh pr merge 4244", pr_json(["src/lib/isPaying.ts"], comments=[MARKER]))

--- a/.claude/hooks/merge_command.py
+++ b/.claude/hooks/merge_command.py
@@ -11,7 +11,9 @@ left is real shell, so any remaining occurrence counts — `then gh pr merge`,
 anchor missed those, per the PR #4244 security review).
 
 The REST merge endpoint (`gh api -X PUT repos/o/r/pulls/N/merge`, or curl to
-the same URL) counts too — it was used once, on 2026-08-26, to merge #4244 on
+the same URL) and the GraphQL `mergePullRequest` mutation count too. Those two
+are matched with quotes kept (the URL is often quoted) but heredoc bodies
+stripped, so a script that merely mentions the path is not a merge — it was used once, on 2026-08-26, to merge #4244 on
 Alexander's instruction after the hook (correctly) refused the rail PR, and that
 is exactly the path an agent must not have.
 
@@ -23,25 +25,43 @@ import re
 HEREDOC = re.compile(r"<<-?\s*(['\"]?)(\w+)\1[^\n]*\n.*?^\s*\2\s*$", re.S | re.M)
 QUOTED_LITERAL = re.compile(r"'[^']*'|\"(?:\\.|[^\"\\])*\"")
 GH_PR_MERGE = re.compile(r"\bgh\s+pr\s+merge\b")
-API_MERGE = re.compile(r"\bpulls/(\d+)/merge\b")
+API_MERGE_PATH = re.compile(r"\bpulls/(\d+)/merge\b")
+API_WRITE_SIGNAL = re.compile(
+    r"(?:-X|--method|--request)[= ]*PUT\b|(?:^|\s)(?:-f|-F|--input|--raw-field|--field)\b"
+)
+GRAPHQL_MERGE = re.compile(r"\bmergePullRequest\b")
 PR_URL = re.compile(r"https?://github\.com/[^/]+/[^/]+/pull/(\d+)")
 
 
+def strip_heredocs(cmd):
+    return HEREDOC.sub("", cmd)
+
+
 def strip_literals(cmd):
-    without_heredocs = HEREDOC.sub("", cmd)
-    return QUOTED_LITERAL.sub("", without_heredocs)
+    return QUOTED_LITERAL.sub("", strip_heredocs(cmd))
+
+
+def is_api_merge(cmd):
+    shell = strip_heredocs(cmd)
+    return bool(API_MERGE_PATH.search(shell) and API_WRITE_SIGNAL.search(shell))
+
+
+def is_graphql_merge(cmd):
+    return bool(GRAPHQL_MERGE.search(strip_heredocs(cmd)))
 
 
 def is_gh_pr_merge(cmd):
-    stripped = strip_literals(cmd)
-    return bool(GH_PR_MERGE.search(stripped) or API_MERGE.search(cmd))
+    return bool(
+        GH_PR_MERGE.search(strip_literals(cmd))
+        or is_api_merge(cmd)
+        or is_graphql_merge(cmd)
+    )
 
 
 def extract_pr_ref(cmd):
     """PR number the command merges, or None when `gh pr merge` targets the current branch."""
-    api_match = API_MERGE.search(cmd)
-    if api_match:
-        return api_match.group(1)
+    if is_api_merge(cmd):
+        return API_MERGE_PATH.search(strip_heredocs(cmd)).group(1)
     parts = GH_PR_MERGE.split(strip_literals(cmd), 1)
     if len(parts) < 2:
         return None

--- a/.claude/hooks/merge_command.py
+++ b/.claude/hooks/merge_command.py
@@ -10,6 +10,11 @@ left is real shell, so any remaining occurrence counts — `then gh pr merge`,
 `exec gh pr merge`, and backtick substitution all match (a command-position
 anchor missed those, per the PR #4244 security review).
 
+The REST merge endpoint (`gh api -X PUT repos/o/r/pulls/N/merge`, or curl to
+the same URL) counts too — it was used once, on 2026-08-26, to merge #4244 on
+Alexander's instruction after the hook (correctly) refused the rail PR, and that
+is exactly the path an agent must not have.
+
 Known limitation: `bash -c "gh pr merge 1"` hides the merge inside a quoted
 literal and is not matched. That is a policy violation, not a hook gap.
 """
@@ -18,6 +23,8 @@ import re
 HEREDOC = re.compile(r"<<-?\s*(['\"]?)(\w+)\1[^\n]*\n.*?^\s*\2\s*$", re.S | re.M)
 QUOTED_LITERAL = re.compile(r"'[^']*'|\"(?:\\.|[^\"\\])*\"")
 GH_PR_MERGE = re.compile(r"\bgh\s+pr\s+merge\b")
+API_MERGE = re.compile(r"\bpulls/(\d+)/merge\b")
+PR_URL = re.compile(r"https?://github\.com/[^/]+/[^/]+/pull/(\d+)")
 
 
 def strip_literals(cmd):
@@ -26,4 +33,23 @@ def strip_literals(cmd):
 
 
 def is_gh_pr_merge(cmd):
-    return bool(GH_PR_MERGE.search(strip_literals(cmd)))
+    stripped = strip_literals(cmd)
+    return bool(GH_PR_MERGE.search(stripped) or API_MERGE.search(cmd))
+
+
+def extract_pr_ref(cmd):
+    """PR number the command merges, or None when `gh pr merge` targets the current branch."""
+    api_match = API_MERGE.search(cmd)
+    if api_match:
+        return api_match.group(1)
+    parts = GH_PR_MERGE.split(strip_literals(cmd), 1)
+    if len(parts) < 2:
+        return None
+    after = re.split(r"[;&|]", parts[1], maxsplit=1)[0]
+    url_match = PR_URL.search(after)
+    if url_match:
+        return url_match.group(1)
+    for token in after.split():
+        if token.isdigit():
+            return token
+    return None

--- a/.claude/hooks/merge_command.test.py
+++ b/.claude/hooks/merge_command.test.py
@@ -68,6 +68,30 @@ class TestApiMerge(unittest.TestCase):
     def test_gh_api_pull_view_is_not_merge(self):
         self.assertFalse(mc.is_gh_pr_merge("gh api repos/2anki/server/pulls/4244"))
 
+    def test_is_merged_probe_get_is_not_merge(self):
+        self.assertFalse(mc.is_gh_pr_merge("gh api repos/2anki/server/pulls/4244/merge"))
+        self.assertFalse(mc.is_gh_pr_merge("gh api -X GET repos/2anki/server/pulls/4244/merge"))
+
+    def test_curl_request_put(self):
+        self.assertTrue(mc.is_gh_pr_merge("curl --request PUT https://api.github.com/repos/2anki/server/pulls/4244/merge"))
+
+    def test_input_body_counts_as_write(self):
+        self.assertTrue(mc.is_gh_pr_merge("gh api repos/2anki/server/pulls/4244/merge --input body.json"))
+
+    def test_api_path_inside_heredoc_is_not_merge(self):
+        cmd = "python3 - <<'EOF'\nassert is_merge('gh api -X PUT repos/o/r/pulls/4244/merge')\nEOF"
+        self.assertFalse(mc.is_gh_pr_merge(cmd))
+
+    def test_graphql_merge_mutation(self):
+        cmd = "gh api graphql -f query='mutation { mergePullRequest(input:{pullRequestId:\"PR_x\"}) { clientMutationId } }'"
+        self.assertTrue(mc.is_gh_pr_merge(cmd))
+        self.assertTrue(mc.is_graphql_merge(cmd))
+        self.assertIsNone(mc.extract_pr_ref(cmd))
+
+    def test_graphql_mention_inside_heredoc_is_not_merge(self):
+        cmd = "cat <<'EOF' > notes.md\nthe mergePullRequest mutation is denied\nEOF"
+        self.assertFalse(mc.is_gh_pr_merge(cmd))
+
 
 class TestExtractPrRef(unittest.TestCase):
     def test_number(self):

--- a/.claude/hooks/merge_command.test.py
+++ b/.claude/hooks/merge_command.test.py
@@ -52,6 +52,40 @@ class TestRunsMerge(unittest.TestCase):
         self.assertTrue(mc.is_gh_pr_merge('echo "it\'s" && gh pr merge 4244 && echo \'y\''))
 
 
+class TestApiMerge(unittest.TestCase):
+    def test_gh_api_put_merge(self):
+        self.assertTrue(mc.is_gh_pr_merge("gh api -X PUT repos/2anki/server/pulls/4244/merge -f merge_method=squash"))
+
+    def test_gh_api_method_flag(self):
+        self.assertTrue(mc.is_gh_pr_merge("gh api --method PUT /repos/2anki/server/pulls/4244/merge"))
+
+    def test_curl_to_merge_endpoint(self):
+        self.assertTrue(mc.is_gh_pr_merge('curl -X PUT "https://api.github.com/repos/2anki/server/pulls/4244/merge"'))
+
+    def test_api_merge_inside_quotes_still_counts(self):
+        self.assertTrue(mc.is_gh_pr_merge('gh api -X PUT "repos/2anki/server/pulls/4244/merge"'))
+
+    def test_gh_api_pull_view_is_not_merge(self):
+        self.assertFalse(mc.is_gh_pr_merge("gh api repos/2anki/server/pulls/4244"))
+
+
+class TestExtractPrRef(unittest.TestCase):
+    def test_number(self):
+        self.assertEqual(mc.extract_pr_ref("gh pr merge 4244 --squash"), "4244")
+
+    def test_url(self):
+        self.assertEqual(mc.extract_pr_ref("gh pr merge https://github.com/2anki/server/pull/4244"), "4244")
+
+    def test_current_branch(self):
+        self.assertIsNone(mc.extract_pr_ref("gh pr merge --squash --delete-branch"))
+
+    def test_api_endpoint(self):
+        self.assertEqual(mc.extract_pr_ref("gh api -X PUT repos/2anki/server/pulls/4244/merge"), "4244")
+
+    def test_quoted_mention_before_real_merge(self):
+        self.assertEqual(mc.extract_pr_ref('echo "gh pr merge" && gh pr merge 4244'), "4244")
+
+
 class TestMentionsOnly(unittest.TestCase):
     def test_gh_pr_view_is_not_merge(self):
         self.assertFalse(mc.is_gh_pr_merge("gh pr view 4244 --json body"))


### PR DESCRIPTION
## What

`merge_command.py` now treats `gh api -X PUT repos/o/r/pulls/N/merge` (and curl to the same URL) as a merge, and owns `extract_pr_ref` for all three merge hooks — the attestation and changelog hooks previously split on the `gh pr merge` phrase and would index-error on the API form.

## Why

The gate matched only the `gh pr merge` form. That path was used once, on Alexander's instruction, to land #4244 after the hook correctly refused the rail PR — an agent must not have it. Closing it in the follow-up that was promised when it was used.

## Testing

- All nine hook suites green (`python3 .claude/hooks/<name>.test.py`); `merge_command.test.py` gains API-endpoint, curl, and shared-extraction cases (31 total).
- `/check` not applicable — no `src/` or `web/src/` change.
- Sonar: not run locally; PR decoration will report.

Browser check: not applicable — no `web/src/` change.

No changelog entry — internal tooling.

## Risks

Rail PR (`.claude/hooks/**`): Alexander merges from the GitHub UI.

## Goal alignment

None — internal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEvzsPguh9r1so2XGvHq3H
