### PR TITLE
fix: name the stuck phase and open resources on shutdown timeout

### DIFF
--- a/src/lib/conversionPool.ts
+++ b/src/lib/conversionPool.ts
@@ -97,6 +97,19 @@ export function getConversionPool(): Piscina {
   return initConversionPool();
 }
 
+export function describeConversionPool(): {
+  queueSize: number;
+  threads: number;
+  utilization: number;
+} | null {
+  if (pool == null) return null;
+  return {
+    queueSize: pool.queueSize,
+    threads: pool.threads.length,
+    utilization: Number(pool.utilization.toFixed(2)),
+  };
+}
+
 // Swap in a fresh pool and drain the retiring one in the background so heaps
 // reset without dropping in-flight conversions — close() waits for outstanding
 // tasks up to its budget. Guarded against re-entry so a burst of completions

--- a/src/lib/gracefulShutdown.test.ts
+++ b/src/lib/gracefulShutdown.test.ts
@@ -14,6 +14,8 @@ import type http from 'http';
 import type { Knex } from 'knex';
 import { shutdownConversionPool } from './conversionPool';
 import {
+  describeActiveResources,
+  describeDatabasePool,
   gracefulShutdown,
   HTTP_CLOSE_BUDGET_MS,
   POOL_DRAIN_TIMEOUT_MS,
@@ -236,6 +238,23 @@ describe('gracefulShutdown', () => {
       expect.stringMatching(/^Conversion pool drained in \d+ms$/),
       expect.stringMatching(/^Database pool drained in \d+ms$/),
     ]);
+  });
+
+  it('reports null for a database client without a tarn pool and defaults missing counters', () => {
+    expect(describeDatabasePool({} as Knex)).toBeNull();
+    expect(
+      describeDatabasePool({
+        client: { pool: { numUsed: () => 3 } },
+      } as unknown as Knex)
+    ).toEqual({ used: 3, free: 0, pendingAcquires: 0, pendingCreates: 0 });
+  });
+
+  it('tallies active resource handles by type', () => {
+    const spy = jest
+      .spyOn(process, 'getActiveResourcesInfo')
+      .mockReturnValue(['Timeout', 'Timeout', 'TCPSocketWrap']);
+    expect(describeActiveResources()).toEqual({ Timeout: 2, TCPSocketWrap: 1 });
+    spy.mockRestore();
   });
 
   it('gives in-flight conversions room past the old 23s window that force-killed large decks', () => {

--- a/src/lib/gracefulShutdown.test.ts
+++ b/src/lib/gracefulShutdown.test.ts
@@ -1,6 +1,11 @@
 jest.mock('./conversionPool', () => ({
   __esModule: true,
   shutdownConversionPool: jest.fn(),
+  describeConversionPool: jest.fn(() => ({
+    queueSize: 2,
+    threads: 3,
+    utilization: 0.5,
+  })),
   POOL_CLOSE_TIMEOUT_MS:
     jest.requireActual('./conversionPool').POOL_CLOSE_TIMEOUT_MS,
 }));
@@ -186,6 +191,51 @@ describe('gracefulShutdown', () => {
     expect(exitSpy).toHaveBeenCalledWith(0);
     warnSpy.mockRestore();
     jest.useRealTimers();
+  });
+
+  it('names the stuck phase and the open resources when the hard exit fires', async () => {
+    jest.useFakeTimers();
+    const { server } = fakeServer();
+    const { db } = fakeDatabase();
+    (db as unknown as { client: unknown }).client = {
+      pool: {
+        numUsed: () => 4,
+        numFree: () => 1,
+        numPendingAcquires: () => 2,
+        numPendingCreates: () => 0,
+      },
+    };
+    drainMock.mockReturnValue(new Promise(() => undefined));
+
+    const done = gracefulShutdown('SIGINT', server, db);
+    await jest.advanceTimersByTimeAsync(SHUTDOWN_TIMEOUT_MS + 1);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const [message, details] = errorSpy.mock.calls.find(([m]) =>
+      String(m).includes('forcing exit')
+    ) as [string, Record<string, unknown>];
+    expect(message).toContain('during conversion pool drain');
+    expect(details).toMatchObject({
+      databasePool: { used: 4, free: 1, pendingAcquires: 2, pendingCreates: 0 },
+      conversionPool: { queueSize: 2, threads: 3, utilization: 0.5 },
+    });
+    expect(details.activeResources).toEqual(expect.any(Object));
+    jest.useRealTimers();
+    void done;
+  });
+
+  it('logs how long each drain phase took so a slow deploy shows which one ate the clock', async () => {
+    const { server } = fakeServer();
+    const { db } = fakeDatabase();
+    await gracefulShutdown('SIGINT', server, db);
+    const phases = infoSpy.mock.calls
+      .map(([m]) => String(m))
+      .filter((m) => / drained in \d+ms$/.test(m));
+    expect(phases).toEqual([
+      expect.stringMatching(/^HTTP server drained in \d+ms$/),
+      expect.stringMatching(/^Conversion pool drained in \d+ms$/),
+      expect.stringMatching(/^Database pool drained in \d+ms$/),
+    ]);
   });
 
   it('gives in-flight conversions room past the old 23s window that force-killed large decks', () => {

--- a/src/lib/gracefulShutdown.ts
+++ b/src/lib/gracefulShutdown.ts
@@ -1,6 +1,7 @@
 import type http from 'http';
 import type { Knex } from 'knex';
 import {
+  describeConversionPool,
   shutdownConversionPool,
   POOL_CLOSE_TIMEOUT_MS,
 } from './conversionPool';
@@ -35,6 +36,49 @@ export function resetGracefulShutdownStateForTesting(): void {
   shuttingDown = false;
 }
 
+type DrainPhase = 'HTTP server' | 'Conversion pool' | 'Database pool';
+
+export function describeActiveResources(): Record<string, number> {
+  const tally: Record<string, number> = {};
+  for (const kind of process.getActiveResourcesInfo()) {
+    tally[kind] = (tally[kind] ?? 0) + 1;
+  }
+  return tally;
+}
+
+export function describeDatabasePool(database: Knex): {
+  used: number;
+  free: number;
+  pendingAcquires: number;
+  pendingCreates: number;
+} | null {
+  const pool = (
+    database as unknown as {
+      client?: {
+        pool?: {
+          numUsed?: () => number;
+          numFree?: () => number;
+          numPendingAcquires?: () => number;
+          numPendingCreates?: () => number;
+        };
+      };
+    }
+  ).client?.pool;
+  if (pool?.numUsed == null) return null;
+  return {
+    used: pool.numUsed(),
+    free: pool.numFree?.() ?? 0,
+    pendingAcquires: pool.numPendingAcquires?.() ?? 0,
+    pendingCreates: pool.numPendingCreates?.() ?? 0,
+  };
+}
+
+async function timedPhase(phase: DrainPhase, run: () => Promise<void>) {
+  const startedAt = Date.now();
+  await run();
+  console.info(`${phase} drained in ${Date.now() - startedAt}ms`);
+}
+
 export async function gracefulShutdown(
   signal: string,
   server: http.Server,
@@ -49,37 +93,53 @@ export async function gracefulShutdown(
     console.info(`Cleared ${clearedTimers} scheduler timer(s)`);
   }
 
+  let phase: DrainPhase = 'HTTP server';
   const hardExit = setTimeout(() => {
     console.error(
-      `Graceful shutdown exceeded ${SHUTDOWN_TIMEOUT_MS}ms — forcing exit`
+      `Graceful shutdown exceeded ${SHUTDOWN_TIMEOUT_MS}ms during ${phase.toLowerCase()} drain — forcing exit`,
+      {
+        activeResources: describeActiveResources(),
+        databasePool: describeDatabasePool(database),
+        conversionPool: describeConversionPool(),
+      }
     );
     process.exit(1);
   }, SHUTDOWN_TIMEOUT_MS);
   hardExit.unref();
 
-  server.closeIdleConnections?.();
-  const closed = new Promise<void>((resolve) => server.close(() => resolve()));
-  const closeBudget = setTimeout(() => {
-    console.warn(
-      `HTTP close exceeded ${HTTP_CLOSE_BUDGET_MS}ms — severing remaining connections`
+  await timedPhase('HTTP server', async () => {
+    server.closeIdleConnections?.();
+    const closed = new Promise<void>((resolve) =>
+      server.close(() => resolve())
     );
-    server.closeAllConnections?.();
-  }, HTTP_CLOSE_BUDGET_MS);
-  closeBudget.unref();
-  await closed;
-  clearTimeout(closeBudget);
+    const closeBudget = setTimeout(() => {
+      console.warn(
+        `HTTP close exceeded ${HTTP_CLOSE_BUDGET_MS}ms — severing remaining connections`
+      );
+      server.closeAllConnections?.();
+    }, HTTP_CLOSE_BUDGET_MS);
+    closeBudget.unref();
+    await closed;
+    clearTimeout(closeBudget);
+  });
 
-  try {
-    await shutdownConversionPool({ timeoutMs: POOL_DRAIN_TIMEOUT_MS });
-  } catch (err) {
-    console.error('Conversion pool drain failed:', err);
-  }
+  phase = 'Conversion pool';
+  await timedPhase('Conversion pool', async () => {
+    try {
+      await shutdownConversionPool({ timeoutMs: POOL_DRAIN_TIMEOUT_MS });
+    } catch (err) {
+      console.error('Conversion pool drain failed:', err);
+    }
+  });
 
-  try {
-    await database.destroy();
-  } catch (err) {
-    console.error('Database pool teardown failed:', err);
-  }
+  phase = 'Database pool';
+  await timedPhase('Database pool', async () => {
+    try {
+      await database.destroy();
+    } catch (err) {
+      console.error('Database pool teardown failed:', err);
+    }
+  });
 
   clearTimeout(hardExit);
   console.info(`${signal} drain complete — exiting cleanly`);


### PR DESCRIPTION
## What

The 85s hard-exit line now names the drain phase that was running (`HTTP server` / `Conversion pool` / `Database pool`) and dumps what is still open: the Node active-handle tally (`process.getActiveResourcesInfo()`), the Knex/tarn pool counters (`used/free/pendingAcquires/pendingCreates`), and the conversion pool's `queueSize/threads/utilization`. On the happy path each phase logs `<phase> drained in <ms>ms`, so a deploy that takes long shows where the clock went even when it does not force-exit.

## Why

Every deploy in the last 48h ended on `Graceful shutdown exceeded 85000ms — forcing exit` with nothing saying which resource held the process (#4234). Both prior shutdown fixes (#4186, #4225) were live; the fast path works on some boots. This is the diagnosis step the issue asks for — no timeout value changes (prod safety limits stay as they are, per the runtime-evidence rule).

## Measuring success

Next deploy's retiring-color log shows either three `drained in` lines and `SIGINT drain complete`, or the hard-exit line with `during <phase> drain` plus the resource dump. Either answers #4234's question; the fix PR follows from what it says.

## Testing

- `pnpm test src/lib/gracefulShutdown.test.ts` — 10 passed (2 new: stuck-phase + resource dump on hard exit; per-phase timing lines).
- `pnpm test src/lib/conversionPool.test.ts` — 20 passed.
- Full server suite: green (background run, exit 0).
- `tsc -p . --noEmit` clean; `pnpm format:check` clean; `pnpm lint` only pre-existing warnings in unrelated files.
- Sonar: not run locally; PR decoration will report.

Browser check: not applicable — no `web/src/` change.

No changelog entry — internal observability, nothing user-visible.

## Goal alignment

None — internal. Feeds the fix for deploy-time force-kills of in-flight conversions.

Fixes #4234

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEvzsPguh9r1so2XGvHq3H
