### PR TITLE
fix: save a mindmap node label on Enter, Shift+Enter for a newline

### DIFF
--- a/web/src/lib/i18n/locales/de/tools.json
+++ b/web/src/lib/i18n/locales/de/tools.json
@@ -401,6 +401,8 @@
     "actionNewNode": "Neuer Knoten",
     "actionImageNode": "Bildknoten",
     "actionRenameNode": "Knoten umbenennen",
+    "actionSaveNode": "Knoten speichern",
+    "actionNewLine": "Neue Zeile",
     "actionDelete": "Löschen",
     "actionAutoSize": "Automatische Größe",
     "actionTidyLayout": "Layout aufräumen",

--- a/web/src/lib/i18n/locales/en/tools.json
+++ b/web/src/lib/i18n/locales/en/tools.json
@@ -401,6 +401,8 @@
     "actionNewNode": "New node",
     "actionImageNode": "Image node",
     "actionRenameNode": "Rename node",
+    "actionSaveNode": "Save node",
+    "actionNewLine": "New line",
     "actionDelete": "Delete",
     "actionAutoSize": "Auto-size",
     "actionTidyLayout": "Tidy layout",

--- a/web/src/lib/i18n/locales/es/tools.json
+++ b/web/src/lib/i18n/locales/es/tools.json
@@ -401,6 +401,8 @@
     "actionNewNode": "Nuevo nodo",
     "actionImageNode": "Nodo de imagen",
     "actionRenameNode": "Renombrar nodo",
+    "actionSaveNode": "Guardar nodo",
+    "actionNewLine": "Nueva línea",
     "actionDelete": "Eliminar",
     "actionAutoSize": "Ajuste automático",
     "actionTidyLayout": "Ordenar disposición",

--- a/web/src/lib/i18n/locales/fr/tools.json
+++ b/web/src/lib/i18n/locales/fr/tools.json
@@ -401,6 +401,8 @@
     "actionNewNode": "Nouveau nœud",
     "actionImageNode": "Nœud image",
     "actionRenameNode": "Renommer le nœud",
+    "actionSaveNode": "Enregistrer le nœud",
+    "actionNewLine": "Nouvelle ligne",
     "actionDelete": "Supprimer",
     "actionAutoSize": "Taille automatique",
     "actionTidyLayout": "Ranger la disposition",

--- a/web/src/lib/i18n/locales/it/tools.json
+++ b/web/src/lib/i18n/locales/it/tools.json
@@ -401,6 +401,8 @@
     "actionNewNode": "Nuovo nodo",
     "actionImageNode": "Nodo immagine",
     "actionRenameNode": "Rinomina nodo",
+    "actionSaveNode": "Salva nodo",
+    "actionNewLine": "Nuova riga",
     "actionDelete": "Elimina",
     "actionAutoSize": "Dimensione automatica",
     "actionTidyLayout": "Riordina il layout",

--- a/web/src/lib/i18n/locales/ja/tools.json
+++ b/web/src/lib/i18n/locales/ja/tools.json
@@ -394,6 +394,8 @@
     "actionNewNode": "新しいノード",
     "actionImageNode": "画像ノード",
     "actionRenameNode": "ノードの名前を変更",
+    "actionSaveNode": "ノードを保存",
+    "actionNewLine": "改行",
     "actionDelete": "削除",
     "actionAutoSize": "自動サイズ調整",
     "actionTidyLayout": "レイアウトを整える",

--- a/web/src/lib/i18n/locales/nl/tools.json
+++ b/web/src/lib/i18n/locales/nl/tools.json
@@ -401,6 +401,8 @@
     "actionNewNode": "Nieuwe node",
     "actionImageNode": "Afbeeldingsnode",
     "actionRenameNode": "Node hernoemen",
+    "actionSaveNode": "Node opslaan",
+    "actionNewLine": "Nieuwe regel",
     "actionDelete": "Verwijderen",
     "actionAutoSize": "Auto-formaat",
     "actionTidyLayout": "Lay-out opruimen",

--- a/web/src/lib/i18n/locales/pl/tools.json
+++ b/web/src/lib/i18n/locales/pl/tools.json
@@ -415,6 +415,8 @@
     "actionNewNode": "Nowy węzeł",
     "actionImageNode": "Węzeł obrazu",
     "actionRenameNode": "Zmień nazwę węzła",
+    "actionSaveNode": "Zapisz węzeł",
+    "actionNewLine": "Nowa linia",
     "actionDelete": "Usuń",
     "actionAutoSize": "Automatyczny rozmiar",
     "actionTidyLayout": "Uporządkuj układ",

--- a/web/src/lib/i18n/locales/pt/tools.json
+++ b/web/src/lib/i18n/locales/pt/tools.json
@@ -401,6 +401,8 @@
     "actionNewNode": "Novo nó",
     "actionImageNode": "Nó de imagem",
     "actionRenameNode": "Renomear nó",
+    "actionSaveNode": "Salvar nó",
+    "actionNewLine": "Nova linha",
     "actionDelete": "Excluir",
     "actionAutoSize": "Ajustar tamanho",
     "actionTidyLayout": "Organizar layout",

--- a/web/src/lib/i18n/locales/ru/tools.json
+++ b/web/src/lib/i18n/locales/ru/tools.json
@@ -415,6 +415,8 @@
     "actionNewNode": "Новый узел",
     "actionImageNode": "Узел-изображение",
     "actionRenameNode": "Переименовать узел",
+    "actionSaveNode": "Сохранить узел",
+    "actionNewLine": "Новая строка",
     "actionDelete": "Удалить",
     "actionAutoSize": "Авторазмер",
     "actionTidyLayout": "Упорядочить расположение",

--- a/web/src/pages/MindmapsPage/MindmapEditor.tsx
+++ b/web/src/pages/MindmapsPage/MindmapEditor.tsx
@@ -80,6 +80,8 @@ function buildShortcutGroups(t: TFunction<'tools'>): {
           keys: ['F2', t('mindmaps.gestureDoubleClick')],
           action: t('mindmaps.actionRenameNode'),
         },
+        { keys: ['Enter'], action: t('mindmaps.actionSaveNode') },
+        { keys: ['Shift+Enter'], action: t('mindmaps.actionNewLine') },
         { keys: ['Backspace'], action: t('mindmaps.actionDelete') },
         {
           keys: [t('mindmaps.gestureDoubleClickBorder')],

--- a/web/src/pages/MindmapsPage/MindmapNode.test.tsx
+++ b/web/src/pages/MindmapsPage/MindmapNode.test.tsx
@@ -68,13 +68,40 @@ describe('MindmapNode', () => {
     expect(input.value).toBe('Test node');
   });
 
-  it('calls onCommit with trimmed value on Enter', () => {
+  it('calls onCommit with trimmed value on plain Enter', () => {
     const onCommit = vi.fn();
     render(<MindmapNode {...makeProps({ editing: true, onCommit })} />);
     const input = screen.getByRole('textbox');
     fireEvent.change(input, { target: { value: '  Chemistry  ' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onCommit).toHaveBeenCalledWith('Chemistry');
+  });
+
+  it('still commits on Ctrl+Enter', () => {
+    const onCommit = vi.fn();
+    render(<MindmapNode {...makeProps({ editing: true, onCommit })} />);
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'Chemistry' } });
     fireEvent.keyDown(input, { key: 'Enter', ctrlKey: true });
     expect(onCommit).toHaveBeenCalledWith('Chemistry');
+  });
+
+  it('does not commit on Shift+Enter so the textarea gets a newline', () => {
+    const onCommit = vi.fn();
+    render(<MindmapNode {...makeProps({ editing: true, onCommit })} />);
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'Line one' } });
+    fireEvent.keyDown(input, { key: 'Enter', shiftKey: true });
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('does not commit on Enter while an IME composition is in progress', () => {
+    const onCommit = vi.fn();
+    render(<MindmapNode {...makeProps({ editing: true, onCommit })} />);
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: '化学' } });
+    fireEvent.keyDown(input, { key: 'Enter', isComposing: true });
+    expect(onCommit).not.toHaveBeenCalled();
   });
 
   it('calls onCancel on Escape', () => {
@@ -94,7 +121,7 @@ describe('MindmapNode', () => {
     );
     const input = screen.getByRole('textbox');
     fireEvent.change(input, { target: { value: '   ' } });
-    fireEvent.keyDown(input, { key: 'Enter', ctrlKey: true });
+    fireEvent.keyDown(input, { key: 'Enter' });
     expect(onCommit).toHaveBeenCalledWith('Physics');
   });
 

--- a/web/src/pages/MindmapsPage/MindmapNode.tsx
+++ b/web/src/pages/MindmapsPage/MindmapNode.tsx
@@ -105,7 +105,7 @@ export function MindmapNode({ data, selected }: NodeProps) {
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
     e.stopPropagation();
-    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
       e.preventDefault();
       const trimmed = inputRef.current?.value.trim() ?? '';
       nodeData.onCommit?.(trimmed.length > 0 ? trimmed : nodeData.label);

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-27-mindmap-enter-saves.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-27-mindmap-enter-saves.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-27-mindmap-enter-saves",
+  "date": "2026-08-27",
+  "type": "fix",
+  "title": "Mindmap node editing saves on Enter, with Shift+Enter for a line break"
+}


### PR DESCRIPTION
## What

In the mindmap node editor, plain **Enter** now saves the label (empty → reverts to the previous label, as before); **Shift+Enter** inserts a newline; **Ctrl/Cmd+Enter** keeps working; an in-progress IME composition never commits. The keyboard-shortcuts panel gains two rows under Edit — "Enter — Save node" and "Shift+Enter — New line" — in all ten locales.

## Why

Plain Enter inserted a newline and saving needed Ctrl/Cmd+Enter, which nothing on the page said. A paying med-school user struggled on their first map and did not come back; the support reply had to spell out the rule (#4242). Every inline editor users already know (Anki, Notion, spreadsheet cells) commits on Enter.

## Decisions made overnight (please review)

- Enter commits, Shift+Enter newline, Ctrl/Cmd+Enter kept as an alias — pm + designer + engineer all landed here; no setting/toggle for Enter behaviour (universal convention). If you want a toggle, that is a separate card-options decision.
- Copy: `"Save node"` and `"New line"` (designer's call), placed beside the existing F2 / double-click "Rename node" row rather than replacing it (start-editing vs while-editing). Swap if you'd word it differently; keys `actionSaveNode` / `actionNewLine` in `tools.json` × 10 locales.
- IME guard (`e.nativeEvent.isComposing`) added — engineer flagged CJK users would otherwise commit mid-word; not in the issue but mandatory once Enter commits.
- Assumption: few existing labels rely on multi-line via Enter. The pm's suggested pre-check (share of node labels containing `\n`, prod data) was not run overnight — no prod access. If it turns out high, Shift+Enter still covers it; nothing is lost, only retrained.
- Scope: did NOT touch the canvas-level Enter = add-sibling (double-guarded by `isEditableTarget` + the textarea's `stopPropagation`), did NOT add an in-node hint — the panel row carries discoverability.
- Metric (pm): nodes committed in a user's first mindmap session, read via `/api/ops/metrics`, rather than the issue's second-session rate (lagging, low-n). No new event added — existing mindmap events cover it.

## Testing

- `MindmapNode.test.tsx`: plain Enter commits trimmed value; Ctrl+Enter still commits; Shift+Enter does not commit; Enter during IME composition does not commit; empty-on-Enter reverts to the previous label.
- Full web suite: 373 files / 3338 tests green; `pnpm --filter 2anki-web typecheck` clean; web lint only pre-existing warnings; `pnpm format:check` exit 0.
- All 10 `tools.json` files carry both new keys (parity checked by the patch that wrote them).
- Sonar: not run locally; PR decoration will report.

## Browser check

- [x] Golden path on localhost:3000
- [x] No console errors at 375px

Run via the Playwright MCP against `pnpm dev` on this branch: registered a throwaway local user, `/mindmaps` → New map → double-click node → typed → **Enter saved** (1 node, no stray sibling) → Rename → **Shift+Enter inserted a newline** while staying in edit mode (`"Cardiology\n"`) → Enter saved the two-line label → shortcuts panel shows `Enter — Save node` and `Shift+Enter — New line` beside `Enter — Add sibling`. Repeated the edit-and-save at 375×812. Console: 0 errors across the session (29 pre-existing warnings). Dev server stopped and the local test user deleted afterwards.

Changelog: `web/src/pages/WhatsNewPage/changelog/2026-08-27-mindmap-enter-saves.json`.

## Goal alignment

Simpler: the one keystroke every editor uses. Retention on the mindmap surface for the med-school segment that pays for it.

Fixes #4242

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEvzsPguh9r1so2XGvHq3H
