### PR TITLE
refactor: make every UploadService dependency required

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -24,6 +24,7 @@ module.exports = {
     '!src/migrations/**',
     '!src/test/fixtures/**',
     '!src/test/mocks/**',
+    '!src/test/fakes/**',
     '!src/config/swagger.ts',
   ],
   coverageDirectory: 'coverage',

--- a/src/controllers/Upload/DropboxController.test.ts
+++ b/src/controllers/Upload/DropboxController.test.ts
@@ -23,6 +23,7 @@ import UsersRepository from '../../data_layer/UsersRepository';
 import UploadController from './UploadController';
 import { GetDropboxUploadsUseCase } from '../../usecases/uploads/GetDropboxUploadsUseCase';
 import { DeleteDropboxUploadUseCase } from '../../usecases/uploads/DeleteDropboxUploadUseCase';
+import { fakeUploadServiceDeps } from '../../test/fakes/uploadServiceDeps';
 
 function makeController(
   getUseCase: GetDropboxUploadsUseCase,
@@ -62,7 +63,8 @@ function makeController(
         .fn()
         .mockResolvedValue({ cards_used: 0, month_started_at: new Date() }),
       incrementCardUsage: jest.fn().mockResolvedValue(1),
-    } as unknown as UsersRepository
+    } as unknown as UsersRepository,
+    ...fakeUploadServiceDeps()
   );
   const notionService = new NotionService(notionRepository);
   return new UploadController(

--- a/src/controllers/Upload/GoogleDriveController.test.ts
+++ b/src/controllers/Upload/GoogleDriveController.test.ts
@@ -22,6 +22,7 @@ import UsersRepository from '../../data_layer/UsersRepository';
 import UploadController from './UploadController';
 import { GetGoogleDriveUploadsUseCase } from '../../usecases/uploads/GetGoogleDriveUploadsUseCase';
 import { DeleteGoogleDriveUploadUseCase } from '../../usecases/uploads/DeleteGoogleDriveUploadUseCase';
+import { fakeUploadServiceDeps } from '../../test/fakes/uploadServiceDeps';
 
 function makeController(
   getUseCase: GetGoogleDriveUploadsUseCase,
@@ -61,7 +62,8 @@ function makeController(
         .fn()
         .mockResolvedValue({ cards_used: 0, month_started_at: new Date() }),
       incrementCardUsage: jest.fn().mockResolvedValue(1),
-    } as unknown as UsersRepository
+    } as unknown as UsersRepository,
+    ...fakeUploadServiceDeps()
   );
   const notionService = new NotionService(notionRepository);
   return new UploadController(

--- a/src/controllers/Upload/UploadController.test.ts
+++ b/src/controllers/Upload/UploadController.test.ts
@@ -25,6 +25,7 @@ import UploadService from '../../services/UploadService';
 import JobRepository from '../../data_layer/JobRepository';
 import UsersRepository from '../../data_layer/UsersRepository';
 import UploadController from './UploadController';
+import { fakeUploadServiceDeps } from '../../test/fakes/uploadServiceDeps';
 
 function buildUsersRepo(): UsersRepository {
   return {
@@ -120,7 +121,8 @@ describe('Upload file', () => {
     const uploadService = new UploadService(
       repository,
       {} as JobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const notionService = new NotionService(notionRepository);
     const uploadController = new UploadController(uploadService, notionService);
@@ -196,7 +198,8 @@ describe('Upload file — multer error handling', () => {
     const uploadService = new UploadService(
       repository,
       {} as JobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const notionService = new NotionService(notionRepository);
     const controller = new UploadController(uploadService, notionService);
@@ -259,7 +262,8 @@ describe('UploadController.retryPdfWithCredential rate limit', () => {
     const uploadService = new UploadService(
       repository,
       {} as JobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const notionService = new NotionService(notionRepository);
 
@@ -341,7 +345,8 @@ describe('UploadController.retryPdfWithCredential rate limit', () => {
     const uploadService = new UploadService(
       repository,
       {} as JobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const notionService = new NotionService(notionRepository);
 

--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -85,6 +85,7 @@ import JobRepository from '../data_layer/JobRepository';
 import UsersRepository from '../data_layer/UsersRepository';
 import { ISettingsRepository } from '../data_layer/SettingsRepository';
 import Uploads from '../data_layer/public/Uploads';
+import { fakeUploadServiceDeps } from '../test/fakes/uploadServiceDeps';
 
 const MockGeneratePackagesUseCase = GeneratePackagesUseCase as jest.MockedClass<
   typeof GeneratePackagesUseCase
@@ -221,7 +222,8 @@ describe('UploadService.handleUpload — error paths', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest({
       cookies: { anon_id: 'anon-upload-1' },
@@ -256,9 +258,9 @@ describe('UploadService.handleUpload — error paths', () => {
       buildRepository(),
       {} as JobRepository,
       buildUsersRepo(),
-      {
-        attachCustomTemplates,
-      } as unknown as ISettingsRepository
+      ...fakeUploadServiceDeps({
+        settings: { attachCustomTemplates } as unknown as ISettingsRepository,
+      })
     );
     const req = buildRequest({
       body: { template: 'custom' },
@@ -287,9 +289,9 @@ describe('UploadService.handleUpload — error paths', () => {
       buildRepository(),
       {} as JobRepository,
       buildUsersRepo(),
-      {
-        attachCustomTemplates,
-      } as unknown as ISettingsRepository
+      ...fakeUploadServiceDeps({
+        settings: { attachCustomTemplates } as unknown as ISettingsRepository,
+      })
     );
     const req = buildRequest({
       body: { template: 'custom' },
@@ -312,7 +314,8 @@ describe('UploadService.handleUpload — error paths', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest({
       path: '/api/upload/dropbox',
@@ -340,7 +343,8 @@ describe('UploadService.handleUpload — error paths', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest();
     const { res, capturedStatus, capturedJson } = buildResponse();
@@ -377,7 +381,8 @@ describe('UploadService.handleUpload — error paths', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest({
       files: [
@@ -425,7 +430,8 @@ describe('UploadService.handleUpload — error paths', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest();
     const { res, capturedStatus, capturedJson } = buildResponse();
@@ -452,7 +458,8 @@ describe('UploadService.handleUpload — error paths', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest();
     const { res, capturedJson } = buildResponse();
@@ -482,7 +489,8 @@ describe('UploadService.handleUpload — error paths', () => {
       const service = new UploadService(
         buildRepository(),
         {} as JobRepository,
-        buildUsersRepo()
+        buildUsersRepo(),
+        ...fakeUploadServiceDeps()
       );
       const req = buildRequest({
         files: [
@@ -522,7 +530,8 @@ describe('UploadService.handleUpload — error paths', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest();
     const { res, capturedStatus, capturedJson } = buildResponse();
@@ -548,7 +557,8 @@ describe('UploadService.handleUpload — error paths', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest();
     const { res, capturedJson } = buildResponse();
@@ -577,7 +587,8 @@ describe('UploadService.handleUpload — error paths', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest({
       files: [
@@ -619,7 +630,8 @@ describe('UploadService.handleUpload — error paths', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest({
       files: [
@@ -697,7 +709,8 @@ describe('UploadService.handleSyncUpload — card-limit enforcement', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest({
       cookies: { anon_id: 'anon-sync-start' },
@@ -735,7 +748,8 @@ describe('UploadService.handleSyncUpload — card-limit enforcement', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      usersRepo
+      usersRepo,
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest();
     const { res, capturedSend, redirectedTo } = responseWithRedirect();
@@ -780,7 +794,8 @@ describe('UploadService.handleSyncUpload — card-limit enforcement', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      usersRepo
+      usersRepo,
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest();
     const { res, capturedStatus, capturedSend } = buildResponse();
@@ -801,7 +816,8 @@ describe('UploadService.handleSyncUpload — card-limit enforcement', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      usersRepo
+      usersRepo,
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest();
     const { res, capturedSend, redirectedTo } = responseWithRedirect();
@@ -839,7 +855,8 @@ describe('UploadService.handleSyncUpload — card-limit enforcement', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      usersRepo
+      usersRepo,
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest({
       cookies: { token: 'a-valid-session-token' },
@@ -874,7 +891,8 @@ describe('UploadService.handleSyncUpload — card-limit enforcement', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest();
     const { res, capturedStatus } = buildResponse();
@@ -891,7 +909,8 @@ describe('UploadService.handleSyncUpload — card-limit enforcement', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest();
     const { res } = buildResponse();
@@ -927,7 +946,8 @@ describe('UploadService.handleSyncUpload — card-limit enforcement', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest();
     const { res, capturedStatus } = buildResponse();
@@ -944,7 +964,8 @@ describe('UploadService.handleSyncUpload — card-limit enforcement', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest();
     const { res } = buildResponse();
@@ -979,7 +1000,8 @@ describe('UploadService.handleSyncUpload — card-limit enforcement', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest();
     const { res, capturedStatus, capturedSend } = buildResponse();
@@ -997,7 +1019,8 @@ describe('UploadService.handleSyncUpload — card-limit enforcement', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest();
     const { res } = buildResponse();
@@ -1032,7 +1055,8 @@ describe('UploadService.handleSyncUpload — card-limit enforcement', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest();
     const { res, capturedStatus } = buildResponse();
@@ -1065,7 +1089,8 @@ describe('UploadService.handleSyncUpload — card-limit enforcement', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest();
     const { res } = buildResponse();
@@ -1084,7 +1109,8 @@ describe('UploadService.handleSyncUpload — card-limit enforcement', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest();
     const { res } = buildResponse();
@@ -1106,7 +1132,8 @@ describe('UploadService.handleSyncUpload — card-limit enforcement', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      usersRepo
+      usersRepo,
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest();
     const { res, capturedStatus } = buildResponse();
@@ -1125,7 +1152,8 @@ describe('UploadService.handleSyncUpload — card-limit enforcement', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      usersRepo
+      usersRepo,
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest();
     const { res, capturedStatus, capturedSend } = buildResponse();
@@ -1145,7 +1173,8 @@ describe('UploadService.handleSyncUpload — card-limit enforcement', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      usersRepo
+      usersRepo,
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest();
     const { res, capturedStatus, capturedSend, capturedJson } = buildResponse();
@@ -1174,7 +1203,8 @@ describe('UploadService.handleSyncUpload — card-limit enforcement', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest();
     const { res, capturedStatus, capturedJson } = buildResponse();
@@ -1278,7 +1308,8 @@ describe('UploadService.handleSyncUpload — zero-card Claude fallback', () => {
     const service = new UploadService(
       buildRepository(),
       jobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = entitledRequest();
     const { res, capturedStatus, capturedJson } = entitledResponse();
@@ -1309,7 +1340,8 @@ describe('UploadService.handleSyncUpload — zero-card Claude fallback', () => {
     const service = new UploadService(
       buildRepository(),
       jobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = entitledRequest({
       body: { 'claude-ai-flashcards': 'false' },
@@ -1339,7 +1371,8 @@ describe('UploadService.handleSyncUpload — zero-card Claude fallback', () => {
     const service = new UploadService(
       buildRepository(),
       jobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = entitledRequest();
     const { res, capturedStatus, capturedJson } = buildResponse();
@@ -1362,7 +1395,8 @@ describe('UploadService.handleSyncUpload — zero-card Claude fallback', () => {
     const service = new UploadService(
       buildRepository(),
       jobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = entitledRequest();
     const { res, capturedStatus, capturedJson } = buildResponse();
@@ -1384,7 +1418,8 @@ describe('UploadService.handleSyncUpload — zero-card Claude fallback', () => {
     const service = new UploadService(
       buildRepository(),
       jobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = entitledRequest({
       files: [
@@ -1415,7 +1450,8 @@ describe('UploadService.handleSyncUpload — zero-card Claude fallback', () => {
     const service = new UploadService(
       buildRepository(),
       jobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = entitledRequest({
       files: [
@@ -1456,7 +1492,8 @@ describe('UploadService.handleSyncUpload — zero-card Claude fallback', () => {
     const service = new UploadService(
       buildRepository(),
       jobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = entitledRequest();
     const { res, capturedStatus } = entitledResponse();
@@ -1498,7 +1535,12 @@ describe('UploadService.deleteUpload — cascade', () => {
       deleteJobByObjectId: jest.fn().mockResolvedValue(1),
     } as unknown as JobRepository;
 
-    const service = new UploadService(repo, jobRepository, buildUsersRepo());
+    const service = new UploadService(
+      repo,
+      jobRepository,
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
+    );
     await service.deleteUpload(7, 'k.apkg');
 
     expect(repo.findByKey).toHaveBeenCalledWith(7, 'k.apkg');
@@ -1528,7 +1570,12 @@ describe('UploadService.deleteUpload — cascade', () => {
       deleteJobByObjectId: jest.fn(),
     } as unknown as JobRepository;
 
-    const service = new UploadService(repo, jobRepository, buildUsersRepo());
+    const service = new UploadService(
+      repo,
+      jobRepository,
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
+    );
     await service.deleteUpload(7, 'k.apkg');
 
     expect(repo.deleteUpload).toHaveBeenCalledWith(7, 'k.apkg');
@@ -1546,7 +1593,12 @@ describe('UploadService.deleteUpload — cascade', () => {
       deleteJobByObjectId: jest.fn(),
     } as unknown as JobRepository;
 
-    const service = new UploadService(repo, jobRepository, buildUsersRepo());
+    const service = new UploadService(
+      repo,
+      jobRepository,
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
+    );
     await service.deleteUpload(7, 'k.apkg');
 
     expect(jobRepository.deleteJobByObjectId).not.toHaveBeenCalled();
@@ -1612,7 +1664,12 @@ describe('UploadService.promoteClaudeJobToUpload — async fs reads', () => {
         }) as unknown as InstanceType<typeof GeneratePackagesUseCase>
     );
 
-    const service = new UploadService(repo, jobRepository, buildUsersRepo());
+    const service = new UploadService(
+      repo,
+      jobRepository,
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
+    );
     const req = buildRequest({ body: { 'claude-ai-flashcards': 'true' } });
     const { res } = buildResponse();
     (res.locals as Record<string, unknown>).owner = 42;
@@ -1660,7 +1717,12 @@ describe('UploadService.promoteClaudeJobToUpload — async fs reads', () => {
         }) as unknown as InstanceType<typeof GeneratePackagesUseCase>
     );
 
-    const service = new UploadService(repo, jobRepository, buildUsersRepo());
+    const service = new UploadService(
+      repo,
+      jobRepository,
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
+    );
     const req = buildRequest({
       body: { 'claude-ai-flashcards': 'true' },
       cookies: { anon_id: 'anon-async-1' },
@@ -1729,7 +1791,12 @@ describe('UploadService.promoteClaudeJobToUpload — async fs reads', () => {
         }) as unknown as InstanceType<typeof GeneratePackagesUseCase>
     );
 
-    const service = new UploadService(repo, jobRepository, buildUsersRepo());
+    const service = new UploadService(
+      repo,
+      jobRepository,
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
+    );
     const req = buildRequest({
       body: { 'claude-ai-flashcards': 'true', ...body },
     });
@@ -1792,7 +1859,8 @@ describe('UploadService.promoteClaudeJobToUpload — async fs reads', () => {
     const service = new UploadService(
       buildRepository(),
       jobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest({ body: { 'claude-ai-flashcards': 'true' } });
     const { res } = buildResponse();
@@ -1869,7 +1937,12 @@ describe('UploadService.promoteClaudeJobToUpload — async fs reads', () => {
         }) as unknown as InstanceType<typeof GeneratePackagesUseCase>
     );
 
-    const service = new UploadService(repo, jobRepository, buildUsersRepo());
+    const service = new UploadService(
+      repo,
+      jobRepository,
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
+    );
     const req = buildRequest({ body: { 'claude-ai-flashcards': 'true' } });
     const { res } = buildResponse();
     (res.locals as Record<string, unknown>).owner = 42;
@@ -1941,7 +2014,8 @@ describe('UploadService.handleUpload — multi-deck batch', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest();
     const { res, capturedStatus, capturedJson } = buildResponse();
@@ -2012,7 +2086,8 @@ describe('UploadService.handleUpload — multi-deck batch', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest();
     const { res, capturedJson } = buildResponse();
@@ -2050,7 +2125,8 @@ describe('UploadService.handleUpload — multi-deck batch', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest();
     const { res, capturedJson } = buildResponse();
@@ -2092,7 +2168,8 @@ describe('UploadService.handleUpload — multi-deck batch', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest();
     const { res, capturedJson } = buildResponse();
@@ -2130,7 +2207,8 @@ describe('UploadService.handleUpload — multi-deck batch', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest();
     const { res, capturedJson } = buildResponse();
@@ -2220,7 +2298,12 @@ describe('UploadService.restartClaudeJob — concurrent restart guard', () => {
 
     const repo = buildRepository();
     const jobRepository = new JobRepository(db);
-    const service = new UploadService(repo, jobRepository, buildUsersRepo());
+    const service = new UploadService(
+      repo,
+      jobRepository,
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
+    );
 
     const firstResponse = buildResponse();
     (firstResponse.res.locals as Record<string, unknown>).owner = 42;
@@ -2256,7 +2339,12 @@ describe('UploadService.restartClaudeJob — concurrent restart guard', () => {
 
     const repo = buildRepository();
     const jobRepository = new JobRepository(db);
-    const service = new UploadService(repo, jobRepository, buildUsersRepo());
+    const service = new UploadService(
+      repo,
+      jobRepository,
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
+    );
 
     const { res, capturedStatus, capturedJson } = buildResponse();
     (res.locals as Record<string, unknown>).owner = 42;
@@ -2282,7 +2370,12 @@ describe('UploadService.restartClaudeJob — concurrent restart guard', () => {
 
     const repo = buildRepository();
     const jobRepository = new JobRepository(db);
-    const service = new UploadService(repo, jobRepository, buildUsersRepo());
+    const service = new UploadService(
+      repo,
+      jobRepository,
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
+    );
 
     const { res, capturedStatus, capturedJson } = buildResponse();
     (res.locals as Record<string, unknown>).owner = 42;
@@ -2320,7 +2413,12 @@ describe('UploadService.restartClaudeJob — concurrent restart guard', () => {
 
     const repo = buildRepository();
     const jobRepository = new JobRepository(db);
-    const service = new UploadService(repo, jobRepository, buildUsersRepo());
+    const service = new UploadService(
+      repo,
+      jobRepository,
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
+    );
 
     const { res, capturedStatus } = buildResponse();
     (res.locals as Record<string, unknown>).owner = 42;
@@ -2343,7 +2441,12 @@ describe('UploadService.restartClaudeJob — concurrent restart guard', () => {
 
     const repo = buildRepository();
     const jobRepository = new JobRepository(db);
-    const service = new UploadService(repo, jobRepository, buildUsersRepo());
+    const service = new UploadService(
+      repo,
+      jobRepository,
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
+    );
 
     const { res, capturedStatus, capturedJson } = buildResponse();
     (res.locals as Record<string, unknown>).owner = 42;
@@ -2435,7 +2538,8 @@ describe('UploadService.restartClaudeJob — replays original conversion setting
     const service = new UploadService(
       buildRepository(),
       new JobRepository(db),
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const generateCalled = new Promise<unknown[]>((resolve) => {
       mockGenerateDeckInfo.mockImplementation((...args: unknown[]) => {
@@ -2589,7 +2693,8 @@ describe('UploadService.restartClaudeJob — replays the PDF-image-fallback flag
     const service = new UploadService(
       buildRepository(),
       new JobRepository(db),
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const generateCalled = new Promise<unknown[]>((resolve) => {
       mockGenerateDeckInfo.mockImplementation((...args: unknown[]) => {
@@ -2741,7 +2846,12 @@ describe('UploadService.handleUpload — claude flag does not bypass the card li
     const incrementSpy = usersRepo.incrementCardUsage as jest.Mock;
     const { repo: jobRepo, create } = buildJobRepo();
 
-    const service = new UploadService(buildRepository(), jobRepo, usersRepo);
+    const service = new UploadService(
+      buildRepository(),
+      jobRepo,
+      usersRepo,
+      ...fakeUploadServiceDeps()
+    );
     const req = buildRequest({ body: { 'claude-ai-flashcards': 'true' } });
     const built = buildResponse();
     let redirectedTo: string | null = null;
@@ -2770,7 +2880,12 @@ describe('UploadService.handleUpload — claude flag does not bypass the card li
     const incrementSpy = usersRepo.incrementCardUsage as jest.Mock;
     const { repo: jobRepo, create } = buildJobRepo();
 
-    const service = new UploadService(buildRepository(), jobRepo, usersRepo);
+    const service = new UploadService(
+      buildRepository(),
+      jobRepo,
+      usersRepo,
+      ...fakeUploadServiceDeps()
+    );
     const req = buildRequest({ body: { 'claude-ai-flashcards': 'true' } });
     const { res, capturedStatus, capturedSend } = buildResponse();
     (res.locals as Record<string, unknown>).owner = 42;
@@ -2787,7 +2902,12 @@ describe('UploadService.handleUpload — claude flag does not bypass the card li
     const usersRepo = buildUsersRepo();
     const { repo: jobRepo, create } = buildJobRepo();
 
-    const service = new UploadService(buildRepository(), jobRepo, usersRepo);
+    const service = new UploadService(
+      buildRepository(),
+      jobRepo,
+      usersRepo,
+      ...fakeUploadServiceDeps()
+    );
     const req = buildRequest({ body: { 'claude-ai-flashcards': 'true' } });
     const { res, capturedStatus, capturedJson } = buildResponse();
     (res.locals as Record<string, unknown>).owner = 42;
@@ -2809,7 +2929,12 @@ describe('UploadService.handleUpload — claude flag does not bypass the card li
       const usersRepo = buildUsersRepo();
       const { repo: jobRepo } = buildJobRepo();
 
-      const service = new UploadService(buildRepository(), jobRepo, usersRepo);
+      const service = new UploadService(
+        buildRepository(),
+        jobRepo,
+        usersRepo,
+        ...fakeUploadServiceDeps()
+      );
       const req = buildRequest({
         body: {
           'claude-ai-flashcards': 'true',
@@ -2933,7 +3058,8 @@ describe('UploadService.restartClaudeJob — card-limit enforcement', () => {
     const service = new UploadService(
       buildRepository(),
       new JobRepository(db),
-      usersRepo
+      usersRepo,
+      ...fakeUploadServiceDeps()
     );
     const req = {
       params: { jobId: 'job-obj-limit' },
@@ -2997,7 +3123,8 @@ describe('UploadService.handleUpload — signup_origin attribution', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest({
       cookies: { first_touch: firstTouchCookie('/pricing') },
@@ -3032,7 +3159,8 @@ describe('UploadService.handleUpload — signup_origin attribution', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      usersRepo
+      usersRepo,
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest({
       cookies: { first_touch: firstTouchCookie('/photo-to-deck') },
@@ -3060,7 +3188,8 @@ describe('UploadService.handleUpload — signup_origin attribution', () => {
     const service = new UploadService(
       buildRepository(),
       {} as JobRepository,
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
     const req = buildRequest();
     const { res } = buildResponse();
@@ -3104,7 +3233,8 @@ describe('UploadService.handleUpload — in-flight duplicate guard', () => {
     return new UploadService(
       buildRepository(),
       buildJobRepo(),
-      buildUsersRepo()
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
     );
   }
 
@@ -3265,12 +3395,7 @@ describe('UploadService.handleUpload — image uploads route through vision', ()
         create: jest.fn().mockResolvedValue(undefined),
       } as unknown as JobRepository,
       buildUsersRepo(),
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      vision
+      ...fakeUploadServiceDeps({ photoToFlashcards: vision })
     );
   }
 

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -369,12 +369,12 @@ class UploadService {
     private readonly uploadRepository: IUploadRepository,
     private readonly jobRepository: JobRepository,
     private readonly usersRepository: UsersRepository,
-    private readonly settingsRepository?: ISettingsRepository,
-    private readonly conversionOutputStatsRepository?: IConversionOutputStatsRepository,
-    private readonly parsePathSignatureRepository?: IParsePathSignatureRepository,
-    private readonly conversionRuleScoresRepository?: IConversionRuleScoresRepository,
-    private readonly cardGuidLedgerRepository?: ICardGuidLedgerRepository,
-    private readonly photoToFlashcardsUseCase?: PhotoToFlashcardsUseCase
+    private readonly settingsRepository: ISettingsRepository,
+    private readonly conversionOutputStatsRepository: IConversionOutputStatsRepository,
+    private readonly parsePathSignatureRepository: IParsePathSignatureRepository,
+    private readonly conversionRuleScoresRepository: IConversionRuleScoresRepository,
+    private readonly cardGuidLedgerRepository: ICardGuidLedgerRepository,
+    private readonly photoToFlashcardsUseCase: PhotoToFlashcardsUseCase
   ) {}
 
   // Every conversion is scored, not just fallbacks — without the baseline there
@@ -402,7 +402,6 @@ class UploadService {
     source: ConversionScoreSource,
     inputFormat: string
   ): void {
-    if (this.conversionRuleScoresRepository == null) return;
     for (const pkg of packages) {
       if (pkg.score == null) continue;
       const induced = pkg.inducedRule;
@@ -438,7 +437,7 @@ class UploadService {
   private async loadKnownGuids(
     ownerId: number | null
   ): Promise<KnownGuids | undefined> {
-    if (ownerId == null || this.cardGuidLedgerRepository == null) {
+    if (ownerId == null) {
       return undefined;
     }
     try {
@@ -453,7 +452,7 @@ class UploadService {
     packages: { guidEntries?: IssuedCardGuid[] }[],
     ownerId: number | null
   ): void {
-    if (ownerId == null || this.cardGuidLedgerRepository == null) {
+    if (ownerId == null) {
       return;
     }
     const entries = packages.flatMap((p) => p.guidEntries ?? []);
@@ -483,7 +482,7 @@ class UploadService {
       0
     );
     this.conversionOutputStatsRepository
-      ?.record('upload', { decks: packages.length, cards, emptyBack })
+      .record('upload', { decks: packages.length, cards, emptyBack })
       .catch((error) =>
         console.error(
           '[UploadService] failed to record conversion output stats',
@@ -495,7 +494,7 @@ class UploadService {
       .filter((p): p is string => typeof p === 'string');
     if (parsePaths.length > 0) {
       this.parsePathSignatureRepository
-        ?.record(parsePaths)
+        .record(parsePaths)
         .catch((error) =>
           console.error(
             '[UploadService] failed to record parse path signatures',
@@ -719,7 +718,7 @@ class UploadService {
       const paying = isPaying(res.locals);
 
       if (owner != null && settings.n2aBasic == null) {
-        await this.settingsRepository?.attachCustomTemplates(
+        await this.settingsRepository.attachCustomTemplates(
           String(owner),
           settings
         );
@@ -735,12 +734,7 @@ class UploadService {
       });
 
       const files = req.files as UploadedFile[];
-      if (
-        owner != null &&
-        this.photoToFlashcardsUseCase != null &&
-        files.length === 1 &&
-        isImageOnlyUpload(files)
-      ) {
+      if (owner != null && files.length === 1 && isImageOnlyUpload(files)) {
         return await this.handleImageUpload(req, res, String(owner), paying);
       }
 
@@ -1345,7 +1339,7 @@ class UploadService {
     const deckName = deckNameFromImageFilename(file.originalname);
     let result: Awaited<ReturnType<PhotoToFlashcardsUseCase['execute']>>;
     try {
-      result = await this.photoToFlashcardsUseCase!.execute({
+      result = await this.photoToFlashcardsUseCase.execute({
         imageBase64: decoded.imageBase64,
         mediaType: decoded.mediaType,
         deckName,

--- a/src/test/fakes/uploadServiceDeps.ts
+++ b/src/test/fakes/uploadServiceDeps.ts
@@ -1,0 +1,64 @@
+import type { ISettingsRepository } from '../../data_layer/SettingsRepository';
+import type { IConversionOutputStatsRepository } from '../../data_layer/ConversionOutputStatsRepository';
+import type { IParsePathSignatureRepository } from '../../data_layer/ParsePathSignatureRepository';
+import type { IConversionRuleScoresRepository } from '../../data_layer/ConversionRuleScoresRepository';
+import type { ICardGuidLedgerRepository } from '../../data_layer/CardGuidLedgerRepository';
+import type { PhotoToFlashcardsUseCase } from '../../usecases/imageOcclusion/PhotoToFlashcardsUseCase';
+
+export type UploadServiceDeps = [
+  ISettingsRepository,
+  IConversionOutputStatsRepository,
+  IParsePathSignatureRepository,
+  IConversionRuleScoresRepository,
+  ICardGuidLedgerRepository,
+  PhotoToFlashcardsUseCase,
+];
+
+export interface UploadServiceDepOverrides {
+  settings?: ISettingsRepository;
+  outputStats?: IConversionOutputStatsRepository;
+  parsePaths?: IParsePathSignatureRepository;
+  ruleScores?: IConversionRuleScoresRepository;
+  guidLedger?: ICardGuidLedgerRepository;
+  photoToFlashcards?: PhotoToFlashcardsUseCase;
+}
+
+export function fakeUploadServiceDeps(
+  overrides: UploadServiceDepOverrides = {}
+): UploadServiceDeps {
+  return [
+    overrides.settings ??
+      ({
+        load: jest.fn(),
+        loadIfExists: jest.fn().mockResolvedValue(null),
+        attachCustomTemplates: jest.fn().mockResolvedValue(undefined),
+        loadAnkifyTemplateOverrides: jest.fn().mockResolvedValue(null),
+      } as unknown as ISettingsRepository),
+    overrides.outputStats ?? {
+      record: jest.fn().mockResolvedValue(undefined),
+      list: jest.fn().mockResolvedValue([]),
+    },
+    overrides.parsePaths ?? {
+      record: jest.fn().mockResolvedValue(undefined),
+      list: jest.fn().mockResolvedValue([]),
+    },
+    overrides.ruleScores ?? {
+      record: jest.fn().mockResolvedValue(undefined),
+      distribution: jest.fn().mockResolvedValue([]),
+    },
+    overrides.guidLedger ?? {
+      getAllForOwner: jest.fn().mockResolvedValue({}),
+      record: jest.fn().mockResolvedValue(undefined),
+    },
+    overrides.photoToFlashcards ??
+      ({
+        execute: jest
+          .fn()
+          .mockRejectedValue(
+            new Error(
+              'fakeUploadServiceDeps: pass photoToFlashcards to test image uploads'
+            )
+          ),
+      } as unknown as PhotoToFlashcardsUseCase),
+  ];
+}


### PR DESCRIPTION
## What

`UploadService`'s six optional constructor dependencies (settings, conversion-output stats, parse-path signatures, rule scores, card-GUID ledger, photo-to-flashcards) are required now. The `== null` / `?.` / `!` guards around them are gone. Tests pass explicit fakes through one shared builder, `src/test/fakes/uploadServiceDeps.ts` (`fakeUploadServiceDeps({ settings?, outputStats?, parsePaths?, ruleScores?, guidLedger?, photoToFlashcards? })`), so the 71 three-argument constructions in the four suites spread `...fakeUploadServiceDeps()` and the three that cared pass an override.

## Why

A test that omitted a dependency still passed while the production path it guards never executed — the same test-blindness that hid the `ai_usage` user_id NULL attribution bug (#4113). With every dependency present, those paths run in every test (#4207). No behaviour change in prod, where both call sites (`UploadRouter`, `McpRouter`) always passed all nine.

## Decisions made overnight (please review)

- Default fakes are "safe no-ops": stats/paths/scores/ledger `record` resolve, `getAllForOwner` returns `{}`, settings `attachCustomTemplates` resolves. The photo-to-flashcards default **rejects** with a pointed message, so an image-upload test that forgets to pass a vision fake fails loudly instead of silently falling through to the old "no use case → normal conversion" branch. That branch is gone from the source too (`this.photoToFlashcardsUseCase != null` check removed) — in prod it was always present.
- The builder lives under `src/test/fakes/` (new dir, beside the existing `src/test/mocks/`), not next to the service, so it is clearly test-only.
- Scope: did NOT touch the ~26-controller inline-repository cluster (#4201) — that is a separate, auth-adjacent refactor.

## Testing

- `pnpm test src/services/UploadService.test.ts src/controllers/Upload` — 9 suites / 130 tests green with the real paths now executing.
- Full server suite: green apart from the documented `getPageCount` (pdfinfo) environmental failure.
- `tsc -p . --noEmit` clean (the deploy build typechecks tests — the interface change is covered); `pnpm format:check` exit 0.
- Sonar: not run locally; PR decoration will report.

Browser check: not applicable — no `web/src/` change.

No changelog entry — internal refactor, no user-visible behaviour change.

## Goal alignment

None — internal. Closes a class of green-but-untested suites on the conversion hot path.

Fixes #4207

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEvzsPguh9r1so2XGvHq3H
