### PR TITLE
fix: give useDrag cleanup and a live callback, add useDropZone

### DIFF
--- a/web/src/lib/hooks/useDrag.test.tsx
+++ b/web/src/lib/hooks/useDrag.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { useDrag } from './useDrag';
+
+function Harness({
+  onDrop,
+  label = 'zone',
+}: Readonly<{ onDrop: (event: DragEvent) => void; label?: string }>) {
+  const { dropHover } = useDrag({ onDrop });
+  return <div data-testid={label}>{dropHover ? 'hovering' : 'idle'}</div>;
+}
+
+describe('useDrag', () => {
+  it('tracks hover from body drag events', () => {
+    const { getByTestId } = render(<Harness onDrop={vi.fn()} />);
+
+    fireEvent.dragEnter(document.body);
+    expect(getByTestId('zone')).toHaveTextContent('hovering');
+
+    fireEvent.dragLeave(document.body);
+    expect(getByTestId('zone')).toHaveTextContent('idle');
+  });
+
+  it('hands a body drop to the latest onDrop after a rerender', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const { rerender } = render(<Harness onDrop={first} />);
+
+    rerender(<Harness onDrop={second} />);
+    fireEvent.drop(document.body);
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops listening once the consumer unmounts', () => {
+    const onDrop = vi.fn();
+    const { unmount } = render(<Harness onDrop={onDrop} />);
+
+    unmount();
+    fireEvent.drop(document.body);
+
+    expect(onDrop).not.toHaveBeenCalled();
+  });
+
+  it('lets two mounted consumers both receive the drop', () => {
+    const a = vi.fn();
+    const b = vi.fn();
+    render(
+      <>
+        <Harness onDrop={a} label="a" />
+        <Harness onDrop={b} label="b" />
+      </>
+    );
+
+    fireEvent.drop(document.body);
+
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/lib/hooks/useDrag.ts
+++ b/web/src/lib/hooks/useDrag.ts
@@ -1,29 +1,40 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 interface UseDragInput {
   onDrop: (event: DragEvent) => void;
 }
 
+// Page-wide drop target: the whole body accepts the drag so a file dropped
+// anywhere on the upload page lands in the form. Listeners are added, not
+// assigned, so several consumers can coexist, and removed on unmount so a
+// drop on the next page never reaches a dead handler.
 export const useDrag = ({ onDrop }: UseDragInput) => {
   const [dropHover, setDropHover] = useState<boolean | undefined>(undefined);
+  const onDropRef = useRef(onDrop);
 
   useEffect(() => {
-    const body = document.getElementsByTagName('body')[0];
-    body.ondragover = (event) => {
-      setDropHover(true);
+    onDropRef.current = onDrop;
+  }, [onDrop]);
+
+  useEffect(() => {
+    const body = document.body;
+    const hover = (event: DragEvent) => {
       event.preventDefault();
-    };
-
-    body.ondragenter = (event) => {
-      event.preventDefault();
       setDropHover(true);
     };
+    const leave = () => setDropHover(false);
+    const drop = (event: DragEvent) => onDropRef.current(event);
 
-    body.ondragleave = () => {
-      setDropHover(false);
+    body.addEventListener('dragover', hover);
+    body.addEventListener('dragenter', hover);
+    body.addEventListener('dragleave', leave);
+    body.addEventListener('drop', drop);
+    return () => {
+      body.removeEventListener('dragover', hover);
+      body.removeEventListener('dragenter', hover);
+      body.removeEventListener('dragleave', leave);
+      body.removeEventListener('drop', drop);
     };
-
-    body.ondrop = onDrop;
   }, []);
 
   return { dropHover };

--- a/web/src/lib/hooks/useDropZone.test.tsx
+++ b/web/src/lib/hooks/useDropZone.test.tsx
@@ -32,14 +32,18 @@ describe('useDropZone', () => {
     expect(zone).toHaveTextContent('idle');
   });
 
-  it('ignores drags that never touch the zone', () => {
+  it('binds to the element, not the page', () => {
     const onDrop = vi.fn();
     render(<Harness onDrop={onDrop} />);
+    const zone = screen.getByTestId('zone');
 
-    fireEvent.dragEnter(screen.getByTestId('outside'));
+    fireEvent.dragEnter(zone);
+    expect(zone).toHaveTextContent('hovering');
+
     fireEvent.drop(screen.getByTestId('outside'));
+    fireEvent.drop(document.body);
 
-    expect(screen.getByTestId('zone')).toHaveTextContent('idle');
     expect(onDrop).not.toHaveBeenCalled();
+    expect(zone).toHaveTextContent('hovering');
   });
 });

--- a/web/src/lib/hooks/useDropZone.test.tsx
+++ b/web/src/lib/hooks/useDropZone.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, expect, it, vi } from 'vitest';
+import type { DragEvent } from 'react';
+import { useDropZone } from './useDropZone';
+
+function Harness({
+  onDrop,
+}: Readonly<{ onDrop: (event: DragEvent<HTMLElement>) => void }>) {
+  const { dropHover, dragProps } = useDropZone({ onDrop });
+  return (
+    <div>
+      <div data-testid="zone" {...dragProps}>
+        {dropHover ? 'hovering' : 'idle'}
+      </div>
+      <div data-testid="outside">outside</div>
+    </div>
+  );
+}
+
+describe('useDropZone', () => {
+  it('tracks hover on the element and hands the drop over', () => {
+    const onDrop = vi.fn();
+    render(<Harness onDrop={onDrop} />);
+    const zone = screen.getByTestId('zone');
+
+    fireEvent.dragEnter(zone);
+    expect(zone).toHaveTextContent('hovering');
+
+    fireEvent.drop(zone);
+    expect(onDrop).toHaveBeenCalledTimes(1);
+    expect(zone).toHaveTextContent('idle');
+  });
+
+  it('ignores drags that never touch the zone', () => {
+    const onDrop = vi.fn();
+    render(<Harness onDrop={onDrop} />);
+
+    fireEvent.dragEnter(screen.getByTestId('outside'));
+    fireEvent.drop(screen.getByTestId('outside'));
+
+    expect(screen.getByTestId('zone')).toHaveTextContent('idle');
+    expect(onDrop).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/lib/hooks/useDropZone.ts
+++ b/web/src/lib/hooks/useDropZone.ts
@@ -1,0 +1,32 @@
+import { useState, type DragEvent } from 'react';
+
+interface UseDropZoneInput<T extends HTMLElement> {
+  onDrop: (event: DragEvent<T>) => void;
+}
+
+// Element-scoped drop target: spread `dragProps` on the zone element. The
+// hover flag follows the pointer over that element only, and the drop is
+// handed over with the default navigation already suppressed.
+export const useDropZone = <T extends HTMLElement = HTMLElement>({
+  onDrop,
+}: UseDropZoneInput<T>) => {
+  const [dropHover, setDropHover] = useState(false);
+
+  const hover = (event: DragEvent<T>) => {
+    event.preventDefault();
+    setDropHover(true);
+  };
+
+  const dragProps = {
+    onDragOver: hover,
+    onDragEnter: hover,
+    onDragLeave: () => setDropHover(false),
+    onDrop: (event: DragEvent<T>) => {
+      event.preventDefault();
+      setDropHover(false);
+      onDrop(event);
+    },
+  };
+
+  return { dropHover, dragProps };
+};

--- a/web/src/pages/PrintPage/components/PrintForm.test.tsx
+++ b/web/src/pages/PrintPage/components/PrintForm.test.tsx
@@ -83,4 +83,31 @@ describe('PrintForm', () => {
       screen.queryByRole('link', { name: /Upgrade for unlimited/i })
     ).not.toBeInTheDocument();
   });
+  test('accepts a dropped deck and posts it like a picked one', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 400,
+      clone() {
+        return {
+          json: async () => ({ message: 'Invalid .apkg file' }),
+        };
+      },
+    } as unknown as Response);
+
+    renderForm();
+    const zone = screen.getByText(/Drop an Anki deck/i).closest('label');
+    expect(zone).not.toBeNull();
+    const file = new File(['fake'], 'deck.apkg', {
+      type: 'application/octet-stream',
+    });
+
+    fireEvent.drop(zone!, { dataTransfer: { files: [file] } });
+
+    await waitFor(() => {
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        '/api/apkg/pdf',
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+  });
 });

--- a/web/src/pages/PrintPage/components/PrintForm.tsx
+++ b/web/src/pages/PrintPage/components/PrintForm.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import styles from './PrintForm.module.css';
 import sharedStyles from '../../../styles/shared.module.css';
+import { useDropZone } from '../../../lib/hooks/useDropZone';
 
 type PrintState = 'idle' | 'uploading' | 'done' | 'error';
 type PaperSize = 'A4' | 'Letter' | 'Legal';
@@ -64,7 +65,6 @@ export default function PrintForm() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const submitRef = useRef<HTMLButtonElement>(null);
-  const [dropHover, setDropHover] = useState(false);
   const [backgroundColor, setBackgroundColor] = useState('#ffffff');
   const [paperSize, setPaperSize] = useState<PaperSize>('A4');
   const [orientation, setOrientation] = useState<Orientation>('portrait');
@@ -132,14 +132,14 @@ export default function PrintForm() {
     await handleFile(files[0]);
   };
 
-  const handleDrop = (event: React.DragEvent) => {
-    event.preventDefault();
-    setDropHover(false);
-    const { dataTransfer } = event;
-    if (dataTransfer && dataTransfer.files.length > 0) {
-      handleFile(dataTransfer.files[0]);
-    }
-  };
+  const { dropHover, dragProps } = useDropZone<HTMLLabelElement>({
+    onDrop: (event) => {
+      const { dataTransfer } = event;
+      if (dataTransfer && dataTransfer.files.length > 0) {
+        handleFile(dataTransfer.files[0]);
+      }
+    },
+  });
 
   const isUploading = state === 'uploading';
 
@@ -215,16 +215,7 @@ export default function PrintForm() {
       <label
         htmlFor="print-file"
         className={`${styles.dropZone} ${dropHover ? styles.dropZoneActive : ''}`}
-        onDragOver={(e) => {
-          e.preventDefault();
-          setDropHover(true);
-        }}
-        onDragEnter={(e) => {
-          e.preventDefault();
-          setDropHover(true);
-        }}
-        onDragLeave={() => setDropHover(false)}
-        onDrop={handleDrop}
+        {...dragProps}
       >
         <span className={styles.dropLabel}>{t('print.dropLabel')}</span>
         <span className={styles.dropHint}>{t('print.or')}</span>

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-27-drag-drop-after-navigation.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-27-drag-drop-after-navigation.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-27-drag-drop-after-navigation",
+  "date": "2026-08-27",
+  "type": "fix",
+  "title": "Dropping a file on the upload page keeps working after you move between pages"
+}


### PR DESCRIPTION
## What
Fixes the shared `useDrag` hook and adds an element-scoped sibling, `useDropZone`, then moves `PrintForm`'s hand-rolled drop zone onto it. The upload page's page-wide drop keeps working after navigating between pages, and always sees the form's current state.

## Why
Part of #4200 (the `useDrag` half; the hook itself was already promoted to `web/src/lib/hooks/` in #4221). `useDrag` assigned `body.ondragover`/`ondrop` once with an empty dependency list, which had three consequences: the drop handler kept the first render's closure (UploadForm's `isUploadLocked` / `zoneState` guards never saw later values), a second consumer overwrote the first, and nothing was removed on unmount, so a file dropped on the next page still hit the upload page's dead handler.

## How
- `useDrag`: `addEventListener`/`removeEventListener` with cleanup; the latest `onDrop` is read through a ref. Same return shape (`{ dropHover }`), same page-wide semantics, so `UploadForm` is untouched.
- `useDropZone`: new element-scoped hook returning `{ dropHover, dragProps }`; spread `dragProps` on the zone element. Two hooks rather than a mode flag on one.
- `PrintForm`: the one strict-subset consumer from the scout (identical over/enter/leave/drop + hover + first-file), now on `useDropZone`. The other zones (`ApkgDropZone`, `ImageQueue`, `ChatPanel`, `MindmapEditor`, `PhotoToFlashcardsPage`) carry extras (disabled guard, type filters, nested-drag counters, drop coordinates, no hover) and stay for a later pass.

## Decisions made overnight (please review)
- Scope: fixed the hook's three defects and migrated only `PrintForm`. Assumption: the remaining zones need `useDropZone` extended (type filter, nested counter) and are worth their own PR each rather than a broad sweep with no drag tests behind them. If you'd rather sweep, `ApkgDropZone` is next (only a `disabled` guard away).
- Not built: a body-vs-element mode flag on `useDrag`; a second hook keeps both call sites honest.

## Measuring success
None — internal correctness. A drop on `/print` after visiting `/upload` no longer triggers the upload handler; covered by the unmount test.

## Testing
- Unit tests added: `useDrag.test.tsx` (hover tracking, latest-callback after rerender, no listener after unmount, two consumers both receive the drop — the last three failed before the fix), `useDropZone.test.tsx` (element hover + drop, drops outside the zone ignored), `PrintForm.test.tsx` (a dropped deck posts like a picked one).
- Full web vitest: 375 files / 3345 tests green. Web typecheck and lint clean (pre-existing warnings only), `pnpm format:check` clean. Server suite untouched (no `src/` change).
- Sonar: not run locally; PR decoration will report.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: machine-backed via `pnpm --filter 2anki-web test:golden-path` (landing + signed-in dashboard, which mounts `UploadForm` and therefore `useDrag`, 2/2 at 375px). `/print` drop verified in vitest only.

## Risks
- `useDrag` semantics preserved except for the fixes; if anything relied on the stale first-render closure it was a bug, not a feature.

## Goal alignment
Simpler/faster: drag and drop behaves the same wherever the user came from. Internal; no funnel metric.
