### PR TITLE
docs: ban add-on for plans and features in VOICE.md

### DIFF
--- a/VOICE.md
+++ b/VOICE.md
@@ -157,6 +157,7 @@ These words are banned from product UI copy. Marketing pages get slightly more l
 | Let's, now let's, don't forget to | Tutorial voice | Use imperative: "Export your page" |
 | Exclamation marks | Overenthusiasm | Period. Reserve for genuine celebration (rare) |
 | Emoji in product UI | Noise | Marketing pages can use one, rarely |
+| Add-on, add on (for a 2anki plan or feature) | Means an installable Anki extension | "its own plan", "sold separately", or the plan's name |
 
 ---
 


### PR DESCRIPTION
## What
Adds one row to the banned-words table in VOICE.md: never call a 2anki plan or feature an add-on.

## Why
In Anki an add-on is an installable extension. A support draft today called Auto Sync an add on, which tells an Anki user the wrong thing. The table now carries the term with the replacement wording so copy and support replies stop reaching for it.

## Testing
Docs only, no code. No changelog entry — internal writing guide.

Browser check: not applicable — markdown guide, no rendered surface.