### PR TITLE
ci: finish every required job early on docs-only pushes

### DIFF
--- a/.claude/docs/autonomous-shipping.md
+++ b/.claude/docs/autonomous-shipping.md
@@ -43,7 +43,7 @@ One GitHub issue per UTC day, `Shipped YYYY-MM-DD`, label `shipped-digest`, one 
 
 ## Throughput
 
-Docs-only pushes (`.claude/**`, `Documentation/**`, `*.md` outside `web/`) still run every required job, but each job asks `.github/actions/changes` first and finishes in seconds when nothing needs building — a `paths-ignore` would leave the required checks unreported and the PR blocked forever. `strict: true` means a PR behind `main` must rebase and re-run CI before it can merge; two concurrent `/ship` runs serialize at roughly ten minutes per PR. Dependabot PRs behind `main` need `@dependabot rebase`. If this hurts, the next step is GitHub's merge queue (workflows would need the `merge_group` trigger) — not loosening `strict`.
+Docs-only pushes (`.claude/**`, `Documentation/**`, `*.md` outside `src/` and `web/` — oxfmt formats Markdown under both, so those stay code) still run every required job, but each job asks `.github/actions/changes` first and finishes in seconds when nothing needs building — a `paths-ignore` would leave the required checks unreported and the PR blocked forever. `strict: true` means a PR behind `main` must rebase and re-run CI before it can merge; two concurrent `/ship` runs serialize at roughly ten minutes per PR. Dependabot PRs behind `main` need `@dependabot rebase`. If this hurts, the next step is GitHub's merge queue (workflows would need the `merge_group` trigger) — not loosening `strict`.
 
 ## Rolling it out / rolling it back
 

--- a/.claude/docs/autonomous-shipping.md
+++ b/.claude/docs/autonomous-shipping.md
@@ -43,7 +43,7 @@ One GitHub issue per UTC day, `Shipped YYYY-MM-DD`, label `shipped-digest`, one 
 
 ## Throughput
 
-`strict: true` means a PR behind `main` must rebase and re-run CI before it can merge; two concurrent `/ship` runs serialize at roughly ten minutes per PR. Dependabot PRs behind `main` need `@dependabot rebase`. If this hurts, the next step is GitHub's merge queue (workflows would need the `merge_group` trigger) — not loosening `strict`.
+Docs-only pushes (`.claude/**`, `Documentation/**`, `*.md` outside `web/`) still run every required job, but each job asks `.github/actions/changes` first and finishes in seconds when nothing needs building — a `paths-ignore` would leave the required checks unreported and the PR blocked forever. `strict: true` means a PR behind `main` must rebase and re-run CI before it can merge; two concurrent `/ship` runs serialize at roughly ten minutes per PR. Dependabot PRs behind `main` need `@dependabot rebase`. If this hurts, the next step is GitHub's merge queue (workflows would need the `merge_group` trigger) — not loosening `strict`.
 
 ## Rolling it out / rolling it back
 

--- a/.github/actions/changes/action.yml
+++ b/.github/actions/changes/action.yml
@@ -1,0 +1,14 @@
+name: Classify the diff
+description: Outputs code=true unless the push only touches docs and the agent harness
+outputs:
+  code:
+    description: "'true' when any changed file needs the full CI run"
+    value: ${{ steps.classify.outputs.code }}
+runs:
+  using: composite
+  steps:
+    - id: classify
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: bash "${GITHUB_ACTION_PATH}/classify.sh"

--- a/.github/actions/changes/classify.sh
+++ b/.github/actions/changes/classify.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Decide whether a push needs the full CI run. Branch protection requires
+# every check, so a docs-only push cannot skip a job; it runs the job and
+# lets it finish early instead. Anything unexpected counts as code.
+set -u
+
+code=true
+count=0
+if [ "${GITHUB_REF:-}" != "refs/heads/main" ] && [ -n "${GITHUB_SHA:-}" ]; then
+  files=$(gh api "repos/${GITHUB_REPOSITORY}/compare/main...${GITHUB_SHA}" \
+    --jq '.files[].filename' 2>/dev/null) || files=""
+  count=$(printf '%s\n' "$files" | grep -c . || true)
+  if [ "$count" -gt 0 ] && [ "$count" -lt 300 ]; then
+    code=false
+    while IFS= read -r file; do
+      case "$file" in
+        .claude/*|Documentation/*) ;;
+        web/*) code=true; break ;;
+        *.md) ;;
+        *) code=true; break ;;
+      esac
+    done <<< "$files"
+  fi
+fi
+
+echo "code=$code" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+echo "changes: code=$code (${count} changed files vs main)"

--- a/.github/actions/changes/classify.sh
+++ b/.github/actions/changes/classify.sh
@@ -15,7 +15,7 @@ if [ "${GITHUB_REF:-}" != "refs/heads/main" ] && [ -n "${GITHUB_SHA:-}" ]; then
     while IFS= read -r file; do
       case "$file" in
         .claude/*|Documentation/*) ;;
-        web/*) code=true; break ;;
+        src/*|web/*) code=true; break ;;
         *.md) ;;
         *) code=true; break ;;
       esac

--- a/.github/actions/changes/classify.test.sh
+++ b/.github/actions/changes/classify.test.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Runs classify.sh against a stub gh that returns a fixed file list.
+# Usage: bash .github/actions/changes/classify.test.sh
+set -u
+here=$(cd "$(dirname "$0")" && pwd)
+stub=$(mktemp -d)
+fail=0
+
+expect() {
+  local want=$1 ref=$2; shift 2
+  printf '%s\n' "$@" > "$stub/files"
+  cat > "$stub/gh" <<'STUB'
+#!/usr/bin/env bash
+cat "$(dirname "$0")/files"
+STUB
+  chmod +x "$stub/gh"
+  local out
+  out=$(cd "$here" && PATH="$stub:$PATH" GITHUB_REF="$ref" GITHUB_SHA=abc GITHUB_REPOSITORY=x/y GITHUB_OUTPUT=/dev/null bash ./classify.sh)
+  if [ "$out" = "changes: code=$want ($# changed files vs main)" ]; then
+    echo "ok   $want <- $*"
+  else
+    echo "FAIL want code=$want for [$*], got: $out"; fail=1
+  fi
+}
+
+expect false refs/heads/feature .claude/commands/ship.md CLAUDE.md Documentation/specs/x.md
+expect false refs/heads/feature VOICE.md
+expect true  refs/heads/feature web/src/pages/DocsPage/content/cards/mind-maps.md
+expect true  refs/heads/feature .github/workflows/server.yml
+expect true  refs/heads/feature src/lib/parser/FEATURE.md src/lib/parser/DeckParser.ts
+expect true  refs/heads/feature package.json
+out=$(cd "$here" && PATH="$stub:$PATH" GITHUB_REF=refs/heads/main GITHUB_SHA=abc GITHUB_REPOSITORY=x/y GITHUB_OUTPUT=/dev/null bash ./classify.sh)
+[ "$out" = "changes: code=true (0 changed files vs main)" ] && echo "ok   true <- (push to main, gh never consulted)" || { echo "FAIL main push: $out"; fail=1; }
+
+# main, and an empty compare, always run the full suite
+printf '' > "$stub/files"
+out=$(cd "$here" && PATH="$stub:$PATH" GITHUB_REF=refs/heads/feature GITHUB_SHA=abc GITHUB_REPOSITORY=x/y GITHUB_OUTPUT=/dev/null bash ./classify.sh)
+[ "$out" = "changes: code=true (0 changed files vs main)" ] && echo "ok   true <- (empty compare)" || { echo "FAIL empty compare: $out"; fail=1; }
+
+rm -rf "$stub"
+exit $fail

--- a/.github/actions/changes/classify.test.sh
+++ b/.github/actions/changes/classify.test.sh
@@ -28,6 +28,7 @@ expect false refs/heads/feature VOICE.md
 expect true  refs/heads/feature web/src/pages/DocsPage/content/cards/mind-maps.md
 expect true  refs/heads/feature .github/workflows/server.yml
 expect true  refs/heads/feature src/lib/parser/FEATURE.md src/lib/parser/DeckParser.ts
+expect true  refs/heads/feature src/lib/parser/FEATURE.md
 expect true  refs/heads/feature package.json
 out=$(cd "$here" && PATH="$stub:$PATH" GITHUB_REF=refs/heads/main GITHUB_SHA=abc GITHUB_REPOSITORY=x/y GITHUB_OUTPUT=/dev/null bash ./classify.sh)
 [ "$out" = "changes: code=true (0 changed files vs main)" ] && echo "ok   true <- (push to main, gh never consulted)" || { echo "FAIL main push: $out"; fail=1; }

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,32 +17,38 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
+      - id: changes
+        uses: ./.github/actions/changes
       - uses: ./.github/actions/setup
+        if: steps.changes.outputs.code == 'true'
       - name: Cache Playwright browsers
+        if: steps.changes.outputs.code == 'true'
         id: playwright-cache
         uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Install Playwright Browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        if: steps.changes.outputs.code == 'true' && steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm --filter 2anki-web exec playwright install --with-deps chromium
       - name: Cache dist
+        if: steps.changes.outputs.code == 'true'
         id: dist-cache
         uses: actions/cache@v6
         with:
           path: web/build
           key: dist-${{ runner.os }}-${{ hashFiles('web/src/**', 'web/public/**', 'web/index.html', 'web/vite.config.*', 'web/tsconfig*', 'pnpm-lock.yaml') }}
       - name: Build the application
-        if: steps.dist-cache.outputs.cache-hit != 'true'
+        if: steps.changes.outputs.code == 'true' && steps.dist-cache.outputs.cache-hit != 'true'
         run: pnpm --filter 2anki-web build
       - name: Run Playwright tests
+        if: steps.changes.outputs.code == 'true'
         working-directory: web
         run: pnpm exec playwright test
         env:
           PLAYWRIGHT_WITH_MOCK: true
       - uses: actions/upload-artifact@v7
-        if: always()
+        if: always() && steps.changes.outputs.code == 'true'
         with:
           name: playwright-report
           path: web/playwright-report/

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -16,20 +16,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - id: changes
+        uses: ./.github/actions/changes
       - uses: ./.github/actions/setup
+        if: steps.changes.outputs.code == 'true'
       - name: Typecheck
+        if: steps.changes.outputs.code == 'true'
         run: pnpm typecheck
         env:
           CI: true
       - name: Lint
+        if: steps.changes.outputs.code == 'true'
         run: pnpm lint
         env:
           CI: true
       - name: Format check
+        if: steps.changes.outputs.code == 'true'
         run: pnpm format:check
         env:
           CI: true
       - name: Architecture
+        if: steps.changes.outputs.code == 'true'
         run: pnpm arch
         env:
           CI: true
@@ -39,8 +46,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - id: changes
+        uses: ./.github/actions/changes
       - uses: ./.github/actions/setup
+        if: steps.changes.outputs.code == 'true'
       - name: Test
+        if: steps.changes.outputs.code == 'true'
         run: pnpm test
         env:
           CI: true

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -16,23 +16,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - id: changes
+        uses: ./.github/actions/changes
       - uses: ./.github/actions/setup
+        if: steps.changes.outputs.code == 'true'
       - name: Lint
+        if: steps.changes.outputs.code == 'true'
         run: pnpm --filter 2anki-web lint
         env:
           CI: true
       - name: Typecheck
+        if: steps.changes.outputs.code == 'true'
         run: pnpm --filter 2anki-web typecheck
         env:
           CI: true
       - name: Cache dist
+        if: steps.changes.outputs.code == 'true'
         id: dist-cache
         uses: actions/cache@v6
         with:
           path: web/build
           key: dist-${{ runner.os }}-${{ hashFiles('web/src/**', 'web/public/**', 'web/index.html', 'web/vite.config.*', 'web/tsconfig*', 'pnpm-lock.yaml') }}
       - name: Build
-        if: steps.dist-cache.outputs.cache-hit != 'true'
+        if: steps.changes.outputs.code == 'true' && steps.dist-cache.outputs.cache-hit != 'true'
         run: pnpm --filter 2anki-web build
         env:
           CI: true
@@ -42,8 +48,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - id: changes
+        uses: ./.github/actions/changes
       - uses: ./.github/actions/setup
+        if: steps.changes.outputs.code == 'true'
       - name: Test
+        if: steps.changes.outputs.code == 'true'
         run: pnpm --filter 2anki-web test
         env:
           CI: true


### PR DESCRIPTION
## What
- New composite action `.github/actions/changes` (`action.yml` + `classify.sh`): asks `gh api repos/<repo>/compare/main...<sha>` for the changed files and outputs `code=false` only when every file is under `.claude/`, `Documentation/`, or is a `*.md` outside `src/` and `web/` (oxfmt formats Markdown under both, so those stay code). Pushes to `main`, anything under `.github/`, `src/` or `web/`, an empty compare, an API error, or a diff of 300+ files all yield `code=true`.
- `server.yml`, `web.yml`, `playwright.yml`: every job runs `changes` right after checkout and gates setup, install, build, test, and artifact-upload steps on `steps.changes.outputs.code == 'true'`. Job names and the five required contexts are unchanged.
- `classify.test.sh`: nine cases against a stub `gh` (run with `bash .github/actions/changes/classify.test.sh`; passes locally and in the reviewer's checkout).
- `.claude/docs/autonomous-shipping.md`: one sentence on why this is a short-circuit and not a `paths-ignore`.

## Why
Branch protection requires all five checks with `strict: true`. A `paths-ignore` filter would leave those checks unreported on a `.claude/`-only PR, which GitHub treats as pending, so the PR could never merge (the reason #4244 removed path filters). Today's docs-only rail PR #4269 cost a full ~10-minute CI cycle for a change that builds nothing. With this, the same push reports five green checks in about 20 seconds.

## Decisions
- Docs paths are a closed allowlist (`.claude/**`, `Documentation/**`, root-level and other `*.md` outside `src/` and `web/`); `web/src/pages/DocsPage/content/*.md` renders in the app and `src/**/FEATURE.md` is inside `pnpm format:check`'s scope, so both stay code (the latter was a round-1 review catch).
- Compare API instead of a deep clone or a third-party paths-filter action: no new dependency, no `fetch-depth: 0`, and `GITHUB_REPOSITORY` is already the canonical name so the rename does not bite.
- Fail-safe direction is always `code=true`.

Hard rail (`.github/`, `.claude/`) — waits for Alexander. First proof is this PR's own CI: it touches `.github/`, so all five jobs must run in full and stay green. The docs-only path gets exercised by the next `.claude/`-only PR. No changelog entry — CI only. Browser check: not applicable — no `web/src/` change. Sonar: not run locally; PR decoration will report.
