### PR TITLE
fix: run the auth middleware on the image occlusion download route

### DIFF
--- a/src/routes/ImageOcclusionRouter.test.ts
+++ b/src/routes/ImageOcclusionRouter.test.ts
@@ -1,0 +1,169 @@
+import express from 'express';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { AddressInfo } from 'node:net';
+
+const mockExecute = jest.fn();
+
+jest.mock('../data_layer', () => ({
+  getDatabase: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock('../lib/storage/StorageHandler', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({})),
+}));
+
+jest.mock('../data_layer/IoDraftRepository', () => ({
+  IoDraftRepository: jest.fn().mockImplementation(() => ({})),
+}));
+
+jest.mock('../data_layer/NotionRespository', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({})),
+}));
+
+jest.mock('../data_layer/EventsRepository', () => ({
+  EventsRepository: jest.fn().mockImplementation(() => ({})),
+}));
+
+jest.mock('../usecases/imageOcclusion/PhotoToFlashcardsUseCase', () => ({
+  PhotoToFlashcardsUseCase: jest.fn().mockImplementation(() => ({})),
+}));
+
+jest.mock('../usecases/imageOcclusion/CreateImageOcclusionDeckUseCase', () => ({
+  CreateImageOcclusionDeckUseCase: jest.fn().mockImplementation(() => ({
+    execute: mockExecute,
+  })),
+}));
+
+let mockLocals: {
+  owner: number | null;
+  patreon: boolean;
+  subscriber: boolean;
+} = { owner: 42, patreon: false, subscriber: false };
+
+// The real middleware reads the session cookie and the subscriptions table;
+// here it only has to do what it does on every other route in this router:
+// put the resolved paying state onto res.locals before the handler runs.
+jest.mock('./middleware/RequireAuthentication', () => {
+  const attach = (res: express.Response) => {
+    res.locals.owner = mockLocals.owner ?? undefined;
+    res.locals.patreon = mockLocals.patreon;
+    res.locals.subscriber = mockLocals.subscriber;
+  };
+  const OptionalAuthentication = (
+    _req: express.Request,
+    res: express.Response,
+    next: express.NextFunction
+  ) => {
+    attach(res);
+    next();
+  };
+  const RequireAuthentication = (
+    _req: express.Request,
+    res: express.Response,
+    next: express.NextFunction
+  ) => {
+    if (mockLocals.owner == null) {
+      res.status(401).json({ message: 'Authentication required' });
+      return;
+    }
+    attach(res);
+    next();
+  };
+  return {
+    __esModule: true,
+    default: RequireAuthentication,
+    OptionalAuthentication,
+  };
+});
+
+import ImageOcclusionRouter from './ImageOcclusionRouter';
+
+describe('ImageOcclusionRouter — POST /api/image-occlusion paying gate', () => {
+  let server: http.Server;
+  let baseUrl: string;
+  let apkgPath: string;
+
+  beforeAll((done) => {
+    const app = express();
+    app.use(ImageOcclusionRouter());
+    server = app.listen(0, () => {
+      const { port } = server.address() as AddressInfo;
+      baseUrl = `http://127.0.0.1:${port}`;
+      done();
+    });
+  });
+
+  afterAll((done) => {
+    server.close(done);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLocals = { owner: 42, patreon: false, subscriber: false };
+    apkgPath = path.join(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'io-router-')),
+      'deck.apkg'
+    );
+    fs.writeFileSync(apkgPath, 'apkg');
+    mockExecute.mockResolvedValue(apkgPath);
+  });
+
+  const postDeck = (imageCount: number) => {
+    const form = new FormData();
+    form.append(
+      'data',
+      JSON.stringify({
+        deckName: 'Anatomy',
+        mode: 'hide_all',
+        images: Array.from({ length: imageCount }, (_, index) => ({
+          imageName: `page-${index + 1}.png`,
+          header: '',
+          rects: [{ x: 0, y: 0, w: 10, h: 10 }],
+          s3Key: `drafts/page-${index + 1}.png`,
+        })),
+      })
+    );
+    return fetch(`${baseUrl}/api/image-occlusion`, {
+      method: 'POST',
+      body: form,
+    });
+  };
+
+  it('hands the subscriber flag from the session to the use case', async () => {
+    mockLocals = { owner: 42, patreon: false, subscriber: true };
+
+    const response = await postDeck(4);
+
+    expect(response.status).toBe(200);
+    expect(mockExecute).toHaveBeenCalledWith(
+      expect.objectContaining({ isPaying: true })
+    );
+  });
+
+  it('hands the lifetime flag from the session to the use case', async () => {
+    mockLocals = { owner: 42, patreon: true, subscriber: false };
+
+    const response = await postDeck(4);
+
+    expect(response.status).toBe(200);
+    expect(mockExecute).toHaveBeenCalledWith(
+      expect.objectContaining({ isPaying: true })
+    );
+  });
+
+  it('keeps the download open to a guest, who stays on the free tier', async () => {
+    mockLocals = { owner: null, patreon: false, subscriber: false };
+
+    const response = await postDeck(2);
+
+    expect(response.status).toBe(200);
+    expect(mockExecute).toHaveBeenCalledWith(
+      expect.objectContaining({ isPaying: false })
+    );
+  });
+});

--- a/src/routes/ImageOcclusionRouter.ts
+++ b/src/routes/ImageOcclusionRouter.ts
@@ -1,6 +1,8 @@
 import express from 'express';
 import multer from 'multer';
-import RequireAuthentication from './middleware/RequireAuthentication';
+import RequireAuthentication, {
+  OptionalAuthentication,
+} from './middleware/RequireAuthentication';
 import ImageOcclusionController from '../controllers/ImageOcclusionController';
 import { IoDraftController } from '../controllers/IoDraftController';
 import { PhotoToFlashcardsController } from '../controllers/PhotoToFlashcardsController';
@@ -56,8 +58,14 @@ const ImageOcclusionRouter = () => {
    *       200:
    *         description: Anki deck generated
    */
-  router.post('/api/image-occlusion', upload.array('images', 20), (req, res) =>
-    oc.create(req, res)
+  // Open to guests, but the paying gate in the controller reads res.locals,
+  // which only the auth middleware populates. Without it every download was
+  // free-capped at 3 images, subscribers included (#4287).
+  router.post(
+    '/api/image-occlusion',
+    OptionalAuthentication,
+    upload.array('images', 20),
+    (req, res) => oc.create(req, res)
   );
 
   /**

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-29-image-occlusion-paid-download.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-29-image-occlusion-paid-download.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-29-image-occlusion-paid-download",
+  "date": "2026-08-29",
+  "type": "fix",
+  "title": "Image occlusion downloads honour your plan again: subscribers, lifetime members, and pass holders get every image, not the free 3"
+}


### PR DESCRIPTION
Closes #4287

## Why

A paying subscriber (user 11196) could not download an image-occlusion deck: `POST /api/image-occlusion` answered 403 `image_limit` ("Upgrade to process more than 3 images") while the sidebar in the same session showed **Unlimited**. The first support reply diagnosed a wrong-account mix-up; prod rows and the reporter's screenshot show the paying account was in use.

`src/routes/ImageOcclusionRouter.ts` mounted the download route with only multer:

```ts
router.post('/api/image-occlusion', upload.array('images', 20), (req, res) => oc.create(req, res));
```

Every other route in the file runs `RequireAuthentication` → `configureUserLocal`, which sets `res.locals.subscriber` / `patreon`. This one never did, so `ImageOcclusionController.create` computed `isPaying = false` for **every** request and `CreateImageOcclusionDeckUseCase` free-capped everyone at 3 images. The client gate reads `locals` from a GET that does run the middleware, so a subscriber could add 20 images and only fail at download. The `isPaying` gate dates from #2190 (2026-05-13); across retained prod logs no download with more than 3 images ever returned 200.

## What

- `OptionalAuthentication` (existing export) in front of `upload.array` on the route. Guests stay allowed; subscribers, lifetime, and pass holders now reach the use case with `isPaying = true`.
- `src/routes/ImageOcclusionRouter.test.ts`: mounts the real router with the auth middleware mocked the way `ChatRouter.test.ts` does, posts a multipart 4-image payload, asserts the use case receives `isPaying: true` for subscriber and lifetime sessions and `false` for a guest (2 of 3 red on `main`).
- Changelog entry.

## Decisions

- `OptionalAuthentication`, not `RequireAuthentication`: `/image-occlusion` supports anonymous use (`isLoggedIn` is optional in the page); a 401 here would break the free path that works today.
- Middleware before multer so an auth lookup never leaves temp uploads behind.
- No change to the cap, the paywall copy, or `src/lib/isPaying.ts` (rail).
- Follow-up (not in this PR): a test that every handler reading `res.locals` in `src/routes/*` sits behind one of the three locals-populating middlewares — this class of bug is invisible to controller unit tests, which set `res.locals` by hand.

## Expected impact

Paid-perk reachability → retention; `paywall_shown` / 403 `image_limit` for subscriber sessions should drop to zero. Read: prod log `POST /api/image-occlusion` status mix, and the reporter's own retry.

## Checks

- `pnpm test src/routes/ImageOcclusionRouter.test.ts src/controllers/ImageOcclusionController.test.ts` — 6/6.
- Full server suite: 692 suites / 6,718 tests passed; 9 suites / 79 tests failed, all the two documented worktree-environment classes — 77 `PythonExitError` (no `create_deck/venv`: DeckParser, golden, canary suites) + 2 `getPageCount` pdfinfo. CI runs them with the venv.
- `npx tsc -p . --noEmit` clean; `pnpm format:check` clean; `pnpm lint` 0 errors.
- Browser check: not applicable — the only `web/src` change is a changelog JSON; the route fix is verified by the router test and will be verified on prod against the reporter's session after deploy.
- Sonar: not run locally; PR decoration will report.
