### PR TITLE
chore: tidy the image occlusion route follow-ups from #4288

### DIFF
--- a/src/routes/ImageOcclusionRouter.test.ts
+++ b/src/routes/ImageOcclusionRouter.test.ts
@@ -87,6 +87,7 @@ describe('ImageOcclusionRouter — POST /api/image-occlusion paying gate', () =>
   let server: http.Server;
   let baseUrl: string;
   let apkgPath: string;
+  let tmpDir: string | null = null;
 
   beforeAll((done) => {
     const app = express();
@@ -105,19 +106,22 @@ describe('ImageOcclusionRouter — POST /api/image-occlusion paying gate', () =>
   beforeEach(() => {
     jest.clearAllMocks();
     mockLocals = { owner: 42, patreon: false, subscriber: false };
-    apkgPath = path.join(
-      fs.mkdtempSync(path.join(os.tmpdir(), 'io-router-')),
-      'deck.apkg'
-    );
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'io-router-'));
+    apkgPath = path.join(tmpDir, 'deck.apkg');
     fs.writeFileSync(apkgPath, 'apkg');
     mockExecute.mockResolvedValue(apkgPath);
   });
 
   afterEach(() => {
-    fs.rmSync(path.dirname(apkgPath), { recursive: true, force: true });
+    // Only ever remove the directory this test created — never a fallback
+    // like "." if mkdtemp threw before tmpDir was assigned.
+    if (tmpDir != null && tmpDir.startsWith(os.tmpdir())) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+    tmpDir = null;
   });
 
-  const postDeck = (imageCount: number) => {
+  const postDeck = async (imageCount: number) => {
     const form = new FormData();
     form.append(
       'data',
@@ -132,10 +136,14 @@ describe('ImageOcclusionRouter — POST /api/image-occlusion paying gate', () =>
         })),
       })
     );
-    return fetch(`${baseUrl}/api/image-occlusion`, {
+    const response = await fetch(`${baseUrl}/api/image-occlusion`, {
       method: 'POST',
       body: form,
     });
+    // Drain the body so the controller's stream-end unlink has run before
+    // afterEach removes the directory.
+    await response.arrayBuffer();
+    return response;
   };
 
   it('hands the subscriber flag from the session to the use case', async () => {

--- a/src/routes/ImageOcclusionRouter.test.ts
+++ b/src/routes/ImageOcclusionRouter.test.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import http from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
-import { AddressInfo } from 'node:net';
+import type { AddressInfo } from 'node:net';
 
 const mockExecute = jest.fn();
 
@@ -111,6 +111,10 @@ describe('ImageOcclusionRouter — POST /api/image-occlusion paying gate', () =>
     );
     fs.writeFileSync(apkgPath, 'apkg');
     mockExecute.mockResolvedValue(apkgPath);
+  });
+
+  afterEach(() => {
+    fs.rmSync(path.dirname(apkgPath), { recursive: true, force: true });
   });
 
   const postDeck = (imageCount: number) => {

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-29-image-occlusion-paid-download.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-29-image-occlusion-paid-download.json
@@ -2,5 +2,5 @@
   "id": "2026-08-29-image-occlusion-paid-download",
   "date": "2026-08-29",
   "type": "fix",
-  "title": "Image occlusion decks include every image on a paid plan — subscribers and lifetime members are no longer capped at 3"
+  "title": "Image occlusion decks include every image on a paid plan for subscribers and lifetime members"
 }

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-29-image-occlusion-paid-download.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-29-image-occlusion-paid-download.json
@@ -2,5 +2,5 @@
   "id": "2026-08-29-image-occlusion-paid-download",
   "date": "2026-08-29",
   "type": "fix",
-  "title": "Image occlusion downloads honour your plan again: subscribers, lifetime members, and pass holders get every image, not the free 3"
+  "title": "Image occlusion decks include every image on a paid plan — subscribers and lifetime members are no longer capped at 3"
 }


### PR DESCRIPTION
Follow-ups from the review on https://github.com/2anki/2anki.net/pull/4288, deferred so that merge wasn't delayed while a paying user waited.

## What

- `web/src/pages/WhatsNewPage/changelog/2026-08-29-image-occlusion-paid-download.json`: title shortened (129 → under 120), drops "again" (banned hedge per `.claude/docs/changelog.md`), drops "honour" (en locales are American), and no longer promises "pass holders" — an *anonymous* Day/Week pass holder still reaches this route with `isPaying = false` because the download fetch does not send `X-Pass-Token` (pre-existing; logged-in pass holders are covered). Same `id`, so the entry updates in place.
- `src/routes/ImageOcclusionRouter.test.ts`: remove the per-test temp dir in `afterEach` (the controller unlinks the fake apkg, but the `mkdtemp` dir stayed behind — 3 empty dirs per run), and `import type` for `AddressInfo`.

## Decisions

- Anonymous-pass gap left as a tracked follow-up rather than fixed here: it needs the client to send `X-Pass-Token` on the download fetch (mirroring `UploadForm.tsx`), which is a `web/src` change with its own browser check.
- No changelog entry for this PR — it edits an existing entry; nothing new is user-visible.

## Checks

- `pnpm test src/routes/ImageOcclusionRouter.test.ts` — 3/3, and `ls $TMPDIR | grep io-router-` count unchanged after the run.
- `pnpm format:check`, `npx tsc -p . --noEmit`, `pnpm lint` clean.
- Browser check: not applicable — the only `web/src` change is a changelog JSON title.
- Sonar: not run locally; PR decoration will report.
