### PR TITLE
ci: set merge_logs so pm2 keeps the fixed per-color log paths

### DIFF
--- a/ecosystem.blue-green.config.js
+++ b/ecosystem.blue-green.config.js
@@ -51,9 +51,14 @@ const MAX_OLD_SPACE_MB = 16384;
 const PM2_LOG_DIR = path.join(os.homedir(), '.pm2', 'logs');
 const LOG_DATE_FORMAT = 'YYYY-MM-DDTHH:mm:ss.SSSZ';
 
+// merge_logs is not optional here: without it pm2 rewrites every log path,
+// custom or default, to `…-<pm_id>.log` (lib/God.js "If merge option, dont
+// separate the logs"), which is exactly how the first deploy of the fixed
+// paths still produced server-green-out-46.log.
 const logFiles = (name) => ({
   out_file: path.join(PM2_LOG_DIR, `${name}-out.log`),
   error_file: path.join(PM2_LOG_DIR, `${name}-error.log`),
+  merge_logs: true,
   log_date_format: LOG_DATE_FORMAT,
 });
 

--- a/src/lib/ecosystemLogFiles.test.ts
+++ b/src/lib/ecosystemLogFiles.test.ts
@@ -18,6 +18,7 @@ const config = require(
     out_file?: string;
     error_file?: string;
     log_date_format?: string;
+    merge_logs?: boolean;
   }>;
 };
 
@@ -31,6 +32,18 @@ describe('blue-green ecosystem config — log files', () => {
 
       expect(app.out_file).toBe(path.join(PM2_LOG_DIR, `${name}-out.log`));
       expect(app.error_file).toBe(path.join(PM2_LOG_DIR, `${name}-error.log`));
+    }
+  );
+
+  // pm2 rewrites every log path to `…-<pm_id>.log` unless merge_logs is set
+  // (lib/God.js), so out_file alone still produced server-green-out-46.log on
+  // prod after #4279 deployed. This flag is what makes the fixed path stick.
+  it.each(['server-blue', 'server-green'])(
+    'sets merge_logs on %s so pm2 does not append the pm_id to the fixed paths',
+    (name) => {
+      const app = config.apps.find((candidate) => candidate.name === name)!;
+
+      expect(app.merge_logs).toBe(true);
     }
   );
 


### PR DESCRIPTION
## Why

#4279 deployed as `c2c8adcab473` and did not take effect: `pm2 describe server-green` still shows `~/.pm2/logs/server-green-out-46.log`. The ecosystem config was read (the process env carries `log_date_format`) and `out_file` was consumed (pm2 resolves it into `pm_out_log_path` and deletes the key), but pm2 then applies a second rule in `lib/God.js:208-212`:

```js
// If merge option, dont separate the logs
if (!env_copy['merge_logs']) {
  ['', '_out', '_err'].forEach(function(k){
    var key = 'pm' + k + '_log_path';
    env_copy[key] && (env_copy[key] = env_copy[key].replace(/-[0-9]+\.log$|\.log$/g, '-' + env_copy['pm_id'] + '.log'));
  });
}
```

So every log path, custom or default, gets `-<pm_id>` inserted before `.log` unless `merge_logs: true`. Verified against the installed pm2 6.0.6 on the box.

## What

- `ecosystem.blue-green.config.js`: `merge_logs: true` in `logFiles()`, with the reason.
- `src/lib/ecosystemLogFiles.test.ts`: pins `merge_logs === true` for both colors (red on `main`). The existing path test could not catch this — it checks what we pass to pm2, not what pm2 does with it; the new test pins the one flag that controls the rewrite.

## Verify after deploy

`pm2 describe server-<live color> | grep 'log path'` → `/home/alemayhu/.pm2/logs/server-<color>-out.log` (no id), and `tail -2 ~/.pm2/logs/server-<color>-out.log` lines start with a `2026-…T…` stamp.

## Checks

- `pnpm test src/lib/ecosystemLogFiles.test.ts src/lib/ecosystemHeapLimit.test.ts` — green (1 new, red on `main`).
- `pnpm format:check` clean; `npx tsc -p . --noEmit` clean.
- Browser check: n/a — no `web/src` change.
- Sonar: not run locally; PR decoration will report.
- Rail (ecosystem config) — Alexander merges from the UI.
