### PR TITLE
fix: keep a signed-in sync deck when the download response is lost

### DIFF
--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -3750,3 +3750,117 @@ describe('UploadService.handleUpload — stored card options', () => {
     expect(guidLedger.reissue).not.toHaveBeenCalled();
   });
 });
+
+describe('UploadService.handleSyncUpload — persisted copy for a signed-in owner', () => {
+  const originalWorkspaceBase = process.env.WORKSPACE_BASE;
+
+  beforeAll(() => {
+    process.env.WORKSPACE_BASE = path.join(os.tmpdir(), 'upload-service-test');
+  });
+
+  afterAll(() => {
+    process.env.WORKSPACE_BASE = originalWorkspaceBase;
+  });
+
+  beforeEach(() => {
+    MockGeneratePackagesUseCase.mockClear();
+    mockStorageUploadFile.mockClear();
+    trackMock.mockClear();
+    mockFirstApkg = Buffer.from('fake-apkg');
+    mockWorkspaceId = 'test-ws-id';
+    MockGeneratePackagesUseCase.mockImplementation(
+      () =>
+        ({
+          execute: jest.fn().mockResolvedValue({
+            packages: [{ name: 'deck', cardCount: 12 }],
+            warnings: [],
+          }),
+        }) as unknown as InstanceType<typeof GeneratePackagesUseCase>
+    );
+  });
+
+  function exposedHeaders(res: express.Response): string {
+    const call = (res.set as jest.Mock).mock.calls.find(
+      ([name]) => name === 'Access-Control-Expose-Headers'
+    );
+    return call?.[1] ?? '';
+  }
+
+  it('persists the built deck, records an uploads row, and advertises the key', async () => {
+    const update = jest.fn().mockResolvedValue([]);
+    const usersRepo = buildUsersRepo();
+    const service = new UploadService(
+      { ...buildRepository(), update },
+      {} as JobRepository,
+      usersRepo,
+      ...fakeUploadServiceDeps()
+    );
+    const req = buildRequest();
+    const { res, capturedSend } = buildResponse();
+    res.locals.owner = 42;
+    res.locals.requestId = 'req-4271';
+
+    await service.handleUpload(req, res);
+
+    expect(mockStorageUploadFile).toHaveBeenCalledTimes(1);
+    const [key, body] = mockStorageUploadFile.mock.calls[0] as [string, Buffer];
+    expect(key).toMatch(/\.apkg$/);
+    expect(body).toEqual(Buffer.from('fake-apkg'));
+    expect(update).toHaveBeenCalledWith(
+      42,
+      'deck',
+      key,
+      expect.any(Number),
+      null
+    );
+    expect(res.set).toHaveBeenCalledWith('X-Download-Key', key);
+    expect(exposedHeaders(res)).toContain('X-Download-Key');
+    expect(capturedSend()).toEqual(Buffer.from('fake-apkg'));
+    expect(usersRepo.incrementCardUsage).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps streaming for an anonymous upload without persisting or advertising a key', async () => {
+    const update = jest.fn().mockResolvedValue([]);
+    const service = new UploadService(
+      { ...buildRepository(), update },
+      {} as JobRepository,
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
+    );
+    const req = buildRequest();
+    const { res, capturedSend } = buildResponse();
+
+    await service.handleUpload(req, res);
+
+    expect(mockStorageUploadFile).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+    expect(res.set).not.toHaveBeenCalledWith(
+      'X-Download-Key',
+      expect.anything()
+    );
+    expect(exposedHeaders(res)).not.toContain('X-Download-Key');
+    expect(capturedSend()).toEqual(Buffer.from('fake-apkg'));
+  });
+
+  it('still sends the deck when the copy cannot be persisted', async () => {
+    mockStorageUploadFile.mockRejectedValueOnce(new Error('storage down'));
+    const service = new UploadService(
+      buildRepository(),
+      {} as JobRepository,
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
+    );
+    const req = buildRequest();
+    const { res, capturedStatus, capturedSend } = buildResponse();
+    res.locals.owner = 42;
+
+    await service.handleUpload(req, res);
+
+    expect(capturedStatus()).toBe(200);
+    expect(capturedSend()).toEqual(Buffer.from('fake-apkg'));
+    expect(res.set).not.toHaveBeenCalledWith(
+      'X-Download-Key',
+      expect.anything()
+    );
+  });
+});

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import fs from 'node:fs';
 import path from 'node:path';
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 
 import { IUploadRepository } from '../data_layer/UploadRespository';
 import JobRepository from '../data_layer/JobRepository';
@@ -73,7 +73,7 @@ import {
 import CustomExporter from '../lib/parser/exporters/CustomExporter';
 import Deck from '../lib/parser/Deck';
 import { isHTMLFile, isMarkdownFile } from '../lib/storage/checks';
-import { FileSizeInMegaBytes } from '../lib/misc/file';
+import { BytesToMegaBytes, FileSizeInMegaBytes } from '../lib/misc/file';
 import {
   isWorkerTerminationError,
   WORKER_INTERRUPTED_REASON,
@@ -702,6 +702,44 @@ class UploadService {
     );
   }
 
+  /**
+   * A signed-in sync upload used to exist only as the response body: when the
+   * client's body read failed the built deck was gone and the only recourse
+   * was a full re-upload (#4271). Persist it the way the async path does so
+   * the response can carry a key the client falls back to. A failed persist
+   * never fails a conversion that already succeeded — the stream still goes
+   * out, just without a recovery key.
+   */
+  private async persistSyncDeck(
+    owner: string,
+    filename: string,
+    apkg: Buffer,
+    source: UploadSource | null,
+    requestId: string | undefined
+  ): Promise<string | null> {
+    try {
+      const storage = new StorageHandler();
+      const key = storage.uniqify(
+        requestId ?? randomUUID(),
+        owner,
+        200,
+        'apkg'
+      );
+      await storage.uploadFile(key, apkg);
+      await this.uploadRepository.update(
+        Number(owner),
+        filename,
+        key,
+        BytesToMegaBytes(apkg.byteLength),
+        source
+      );
+      return key;
+    } catch (error) {
+      console.error('[UploadService] could not persist the sync deck', error);
+      return null;
+    }
+  }
+
   async deleteUpload(owner: number, key: string) {
     const upload = await this.uploadRepository.findByKey(owner, key);
     const s = new StorageHandler();
@@ -1238,6 +1276,16 @@ class UploadService {
         throw new Error(`Could not produce APKG for ${name}`);
       }
       const plen = Buffer.byteLength(apkg);
+      const downloadKey =
+        owner == null
+          ? null
+          : await this.persistSyncDeck(
+              owner,
+              first.name,
+              apkg,
+              this.resolvePersistedSource(req),
+              res.locals.requestId
+            );
       const totalMcqCount = packages.reduce(
         (sum, p) => sum + (p.mcqCount ?? 0),
         0
@@ -1287,6 +1335,10 @@ class UploadService {
       if (warningText) {
         res.set('X-Warning', warningText);
         exposedHeaders.push('X-Warning');
+      }
+      if (downloadKey != null) {
+        res.set('X-Download-Key', downloadKey);
+        exposedHeaders.push('X-Download-Key');
       }
       res.set('Access-Control-Expose-Headers', exposedHeaders.join(', '));
       first.name = toText(first.name);

--- a/web/src/lib/i18n/locales/de/common.json
+++ b/web/src/lib/i18n/locales/de/common.json
@@ -124,6 +124,8 @@
       "fetching": "{{filename}} wird von {{source}} geladen",
       "deckReady": "Dein Stapel ist fertig",
       "savedToDownloads": "{{deckName}} wurde in deinen Downloads gespeichert",
+      "downloadRecoveredNote": "Dein Download wurde nicht fertig — der Stapel ist in deinen Downloads gespeichert.",
+      "downloadDeck": "Stapel herunterladen",
       "makeAnother": "Noch einen Stapel erstellen",
       "fallbackDownload": "Datei nicht erhalten? Lade sie hier herunter.",
       "feedbackLabel": "Wie war deine Erfahrung?",

--- a/web/src/lib/i18n/locales/en/common.json
+++ b/web/src/lib/i18n/locales/en/common.json
@@ -124,6 +124,8 @@
       "fetching": "Fetching {{filename}} from {{source}}",
       "deckReady": "Your deck is ready",
       "savedToDownloads": "{{deckName}} was saved to your downloads",
+      "downloadRecoveredNote": "Your download didn't finish — the deck is saved to your downloads.",
+      "downloadDeck": "Download deck",
       "makeAnother": "Make another deck",
       "fallbackDownload": "Didn't get the file? Download it here.",
       "feedbackLabel": "How was your experience?",

--- a/web/src/lib/i18n/locales/es/common.json
+++ b/web/src/lib/i18n/locales/es/common.json
@@ -124,6 +124,8 @@
       "fetching": "Obteniendo {{filename}} de {{source}}",
       "deckReady": "Tu mazo está listo",
       "savedToDownloads": "{{deckName}} se guardó en tus descargas",
+      "downloadRecoveredNote": "Tu descarga no terminó — el mazo está guardado en tus descargas.",
+      "downloadDeck": "Descargar mazo",
       "makeAnother": "Crear otro mazo",
       "fallbackDownload": "¿No recibiste el archivo? Descárgalo aquí.",
       "feedbackLabel": "¿Qué tal tu experiencia?",

--- a/web/src/lib/i18n/locales/fr/common.json
+++ b/web/src/lib/i18n/locales/fr/common.json
@@ -124,6 +124,8 @@
       "fetching": "Récupération de {{filename}} depuis {{source}}",
       "deckReady": "Ton paquet est prêt",
       "savedToDownloads": "{{deckName}} a été enregistré dans tes téléchargements",
+      "downloadRecoveredNote": "Ton téléchargement ne s'est pas terminé — le paquet est enregistré dans tes téléchargements.",
+      "downloadDeck": "Télécharger le paquet",
       "makeAnother": "Créer un autre paquet",
       "fallbackDownload": "Tu n'as pas reçu le fichier ? Télécharge-le ici.",
       "feedbackLabel": "Comment s'est passée ton expérience ?",

--- a/web/src/lib/i18n/locales/it/common.json
+++ b/web/src/lib/i18n/locales/it/common.json
@@ -124,6 +124,8 @@
       "fetching": "Sto recuperando {{filename}} da {{source}}",
       "deckReady": "Il tuo mazzo è pronto",
       "savedToDownloads": "{{deckName}} è stato salvato nei tuoi download",
+      "downloadRecoveredNote": "Il download non è stato completato — il mazzo è salvato nei tuoi download.",
+      "downloadDeck": "Scarica il mazzo",
       "makeAnother": "Crea un altro mazzo",
       "fallbackDownload": "Non hai ricevuto il file? Scaricalo qui.",
       "feedbackLabel": "Com'è andata?",

--- a/web/src/lib/i18n/locales/ja/common.json
+++ b/web/src/lib/i18n/locales/ja/common.json
@@ -123,6 +123,8 @@
       "fetching": "{{source}} から {{filename}} を取得しています",
       "deckReady": "デッキの準備ができました",
       "savedToDownloads": "{{deckName}} をダウンロードに保存しました",
+      "downloadRecoveredNote": "ダウンロードが完了しませんでしたが、デッキはダウンロード一覧に保存されています。",
+      "downloadDeck": "デッキをダウンロード",
       "makeAnother": "別のデッキを作る",
       "fallbackDownload": "ファイルが届きませんでしたか？こちらからダウンロードできます。",
       "feedbackLabel": "使い心地はいかがでしたか？",

--- a/web/src/lib/i18n/locales/nl/common.json
+++ b/web/src/lib/i18n/locales/nl/common.json
@@ -124,6 +124,8 @@
       "fetching": "{{filename}} ophalen van {{source}}",
       "deckReady": "Je deck is klaar",
       "savedToDownloads": "{{deckName}} is opgeslagen in je downloads",
+      "downloadRecoveredNote": "Je download is niet afgerond — het deck staat opgeslagen bij je downloads.",
+      "downloadDeck": "Deck downloaden",
       "makeAnother": "Nog een deck maken",
       "fallbackDownload": "Bestand niet ontvangen? Download het hier.",
       "feedbackLabel": "Hoe was je ervaring?",

--- a/web/src/lib/i18n/locales/pl/common.json
+++ b/web/src/lib/i18n/locales/pl/common.json
@@ -126,6 +126,8 @@
       "fetching": "Pobieranie {{filename}} z {{source}}",
       "deckReady": "Twoja talia jest gotowa",
       "savedToDownloads": "{{deckName}} zapisano w pobranych",
+      "downloadRecoveredNote": "Pobieranie nie zostało ukończone — talia jest zapisana w Twoich pobranych plikach.",
+      "downloadDeck": "Pobierz talię",
       "makeAnother": "Utwórz kolejną talię",
       "fallbackDownload": "Nie dostałeś pliku? Pobierz go tutaj.",
       "feedbackLabel": "Jak Ci poszło?",

--- a/web/src/lib/i18n/locales/pt/common.json
+++ b/web/src/lib/i18n/locales/pt/common.json
@@ -124,6 +124,8 @@
       "fetching": "Buscando {{filename}} em {{source}}",
       "deckReady": "Seu baralho está pronto",
       "savedToDownloads": "{{deckName}} foi salvo nos seus downloads",
+      "downloadRecoveredNote": "Seu download não terminou — o baralho está salvo nos seus downloads.",
+      "downloadDeck": "Baixar baralho",
       "makeAnother": "Criar outro baralho",
       "fallbackDownload": "Não recebeu o arquivo? Baixe aqui.",
       "feedbackLabel": "Como foi sua experiência?",

--- a/web/src/lib/i18n/locales/ru/common.json
+++ b/web/src/lib/i18n/locales/ru/common.json
@@ -126,6 +126,8 @@
       "fetching": "Загружаем {{filename}} из {{source}}",
       "deckReady": "Твоя колода готова",
       "savedToDownloads": "{{deckName}} сохранена в твои загрузки",
+      "downloadRecoveredNote": "Загрузка не завершилась — колода сохранена в твоих загрузках.",
+      "downloadDeck": "Скачать колоду",
       "makeAnother": "Создать ещё колоду",
       "fallbackDownload": "Файл не пришёл? Скачай его здесь.",
       "feedbackLabel": "Как впечатления?",

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
@@ -1480,6 +1480,85 @@ describe('UploadForm analytics events', () => {
     );
     expect(successCopy).toHaveAttribute('data-hj-suppress');
   });
+
+  it('recovers a dropped download from the server copy when the response carries a key', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        redirected: false,
+        status: 200,
+        headers: new Headers({
+          'Content-Type': 'application/octet-stream',
+          'File-Name': encodeURIComponent('private-notes.apkg'),
+          'X-Card-Count': '5',
+          'X-Download-Key': 'owner-1-123-req.apkg',
+        }),
+        blob: () => Promise.reject(new TypeError('Load failed')),
+      })
+    );
+    const trackMock = vi.mocked(track);
+    trackMock.mockClear();
+
+    renderUploadForm(<UploadForm setErrorMessage={vi.fn()} />);
+    const form = document.querySelector('form')!;
+    await act(async () => {
+      form.dispatchEvent(
+        new Event('submit', { bubbles: true, cancelable: true })
+      );
+    });
+
+    expect(
+      await screen.findByText(
+        "Your download didn't finish — the deck is saved to your downloads."
+      )
+    ).toBeInTheDocument();
+    const download = screen.getByRole('link', { name: 'Download deck' });
+    expect(download).toHaveAttribute(
+      'href',
+      '/api/download/u/owner-1-123-req.apkg'
+    );
+    expect(screen.queryByText(/was saved to your downloads/)).toBeNull();
+    expect(trackMock).toHaveBeenCalledWith(
+      'upload_failed',
+      expect.objectContaining({ reason: 'network', recovered: true })
+    );
+  });
+
+  it('still fails the upload when the body read fails without a download key', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        redirected: false,
+        status: 200,
+        headers: new Headers({
+          'Content-Type': 'application/octet-stream',
+          'File-Name': encodeURIComponent('private-notes.apkg'),
+          'X-Card-Count': '5',
+        }),
+        blob: () => Promise.reject(new TypeError('Load failed')),
+      })
+    );
+    const trackMock = vi.mocked(track);
+    trackMock.mockClear();
+
+    renderUploadForm(<UploadForm setErrorMessage={vi.fn()} />);
+    const form = document.querySelector('form')!;
+    await act(async () => {
+      form.dispatchEvent(
+        new Event('submit', { bubbles: true, cancelable: true })
+      );
+    });
+
+    expect(screen.queryByRole('link', { name: 'Download deck' })).toBeNull();
+    expect(trackMock).toHaveBeenCalledWith(
+      'upload_failed',
+      expect.objectContaining({ reason: 'network' })
+    );
+    expect(trackMock).not.toHaveBeenCalledWith(
+      'upload_failed',
+      expect.objectContaining({ recovered: true })
+    );
+  });
 });
 
 describe('UploadForm multi-deck batch', () => {

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -276,6 +276,8 @@ function UploadForm({
     setBatchResult,
     downloadLink,
     setDownloadLink,
+    downloadRecovered,
+    setDownloadRecovered,
     deckName,
     setDeckName,
     cardCount,
@@ -378,6 +380,18 @@ function UploadForm({
     setBatchResult,
     setZoneState,
     setStructureRescuedRule,
+    recoverDownload: (recoveryUrl, errorMessage) => {
+      setDownloadLink(recoveryUrl);
+      setDownloadRecovered(true);
+      // Same shape as the failure it replaces, so the 30-day baseline of
+      // lost downloads stays comparable; `recovered` splits the two.
+      track('upload_failed', {
+        reason: 'network',
+        recovered: true,
+        message: errorMessage.slice(0, 200),
+        fileSizeBytes: fileInputRef.current?.files?.[0]?.size ?? null,
+      });
+    },
   };
 
   const { data: userLocals } = useUserLocals();
@@ -520,6 +534,11 @@ function UploadForm({
     if (zoneState === 'success' && downloadLink && !showFallback) {
       globalThis.sessionStorage?.removeItem('upload_pending_filename');
       queryClient.invalidateQueries({ queryKey: CARD_USAGE_QUERY_KEY });
+      // A recovered download is a server copy behind a visible button: the
+      // user just watched one download fail, so it waits for their click.
+      if (downloadRecovered) {
+        return;
+      }
       if (cardCount !== 0) {
         fireAnalyticsEvent('deck_downloaded');
         track('deck_downloaded');
@@ -1015,10 +1034,29 @@ function UploadForm({
           {mcqDrawerOpen && renderMcqDrawer()}
         </>
       )}
-      {successOffer !== 'anon_signup' && (
-        <p className={formStyles.successSecondary} data-hj-suppress>
-          {t('upload.form.savedToDownloads', { deckName })}
-        </p>
+      {downloadRecovered && downloadLink ? (
+        <>
+          <p className={formStyles.successSecondary}>
+            {t('upload.form.downloadRecoveredNote')}
+          </p>
+          <a
+            href={downloadLink}
+            download={getDownloadFileName(deckName || 'Untitled')}
+            className={`${sharedStyles.btnPrimary} ${sharedStyles.btnInline}`}
+            onClick={() => {
+              fireAnalyticsEvent('deck_downloaded');
+              track('deck_downloaded', { source: 'key_fallback' });
+            }}
+          >
+            {t('upload.form.downloadDeck')}
+          </a>
+        </>
+      ) : (
+        successOffer !== 'anon_signup' && (
+          <p className={formStyles.successSecondary} data-hj-suppress>
+            {t('upload.form.savedToDownloads', { deckName })}
+          </p>
+        )
       )}
       {warningMessage && (
         <p className={formStyles.warningInline}>{warningMessage}</p>

--- a/web/src/pages/UploadPage/components/UploadForm/hooks/useUploadFormState.ts
+++ b/web/src/pages/UploadPage/components/UploadForm/hooks/useUploadFormState.ts
@@ -48,6 +48,7 @@ export function useUploadFormState(onReset: () => void) {
   const [zoneState, setZoneState] = useState<ZoneState>('idle');
   const [batchResult, setBatchResult] = useState<BatchResult | null>(null);
   const [downloadLink, setDownloadLink] = useState<string | null>(null);
+  const [downloadRecovered, setDownloadRecovered] = useState(false);
   const [deckName, setDeckName] = useState('');
   const [cardCount, setCardCount] = useState<number | null>(null);
   const [mcqCount, setMcqCount] = useState<number>(0);
@@ -88,6 +89,7 @@ export function useUploadFormState(onReset: () => void) {
     setZoneState('idle');
     setBatchResult(null);
     setDownloadLink(null);
+    setDownloadRecovered(false);
     setDeckName('');
     setCardCount(null);
     setMcqCount(0);
@@ -127,6 +129,8 @@ export function useUploadFormState(onReset: () => void) {
     setBatchResult,
     downloadLink,
     setDownloadLink,
+    downloadRecovered,
+    setDownloadRecovered,
     deckName,
     setDeckName,
     cardCount,

--- a/web/src/pages/UploadPage/components/UploadForm/uploadResponse.test.ts
+++ b/web/src/pages/UploadPage/components/UploadForm/uploadResponse.test.ts
@@ -25,6 +25,7 @@ function buildHandlers(): ConversionSuccessHandlers {
     setBatchResult: vi.fn(),
     setZoneState: vi.fn(),
     setStructureRescuedRule: vi.fn(),
+    recoverDownload: vi.fn(),
   };
 }
 
@@ -302,5 +303,57 @@ describe('applyConversionSuccess', () => {
     await applyConversionSuccess(response, handlers);
 
     expect(handlers.setExpiredNotionImageCount).toHaveBeenCalledWith(3);
+  });
+
+  it('falls back to the server copy when the body read fails and a download key came with the headers', async () => {
+    const handlers = buildHandlers();
+    const response = {
+      headers: new Headers({
+        'Content-Type': 'application/octet-stream',
+        'X-Card-Count': '5',
+        'X-Download-Key': 'owner-1-123-req.apkg',
+      }),
+      blob: () => Promise.reject(new TypeError('Load failed')),
+    } as unknown as Response;
+
+    await applyConversionSuccess(response, handlers);
+
+    expect(handlers.recoverDownload).toHaveBeenCalledWith(
+      '/api/download/u/owner-1-123-req.apkg',
+      'Load failed'
+    );
+    expect(handlers.setDownloadLink).not.toHaveBeenCalled();
+    expect(handlers.setZoneState).toHaveBeenCalledWith('success');
+  });
+
+  it('rethrows a failed body read when the response carried no download key', async () => {
+    const handlers = buildHandlers();
+    const response = {
+      headers: new Headers({
+        'Content-Type': 'application/octet-stream',
+        'X-Card-Count': '5',
+      }),
+      blob: () => Promise.reject(new TypeError('Load failed')),
+    } as unknown as Response;
+
+    await expect(applyConversionSuccess(response, handlers)).rejects.toThrow(
+      'Load failed'
+    );
+    expect(handlers.recoverDownload).not.toHaveBeenCalled();
+    expect(handlers.setZoneState).not.toHaveBeenCalledWith('success');
+  });
+
+  it('keeps the streamed body when it reads fine, key or no key', async () => {
+    const handlers = buildHandlers();
+    const response = singleDeckResponse({
+      'X-Download-Key': 'owner-1-123-req.apkg',
+    });
+
+    await applyConversionSuccess(response, handlers);
+
+    expect(handlers.setDownloadLink).toHaveBeenCalledWith(
+      expect.stringMatching(/^blob:/)
+    );
+    expect(handlers.recoverDownload).not.toHaveBeenCalled();
   });
 });

--- a/web/src/pages/UploadPage/components/UploadForm/uploadResponse.ts
+++ b/web/src/pages/UploadPage/components/UploadForm/uploadResponse.ts
@@ -46,6 +46,15 @@ export interface ConversionSuccessHandlers {
   setBatchResult: (value: BatchResult) => void;
   setZoneState: (value: ZoneState) => void;
   setStructureRescuedRule: (value: StructureRescueRule | null) => void;
+  /**
+   * The body read failed but the server kept a copy: point the download at
+   * it and let the form record what happened.
+   */
+  recoverDownload: (recoveryUrl: string, errorMessage: string) => void;
+}
+
+export function recoveryDownloadUrl(downloadKey: string): string {
+  return `/api/download/u/${encodeURIComponent(downloadKey)}`;
 }
 
 export function parseStructureRescuedValue(
@@ -110,8 +119,20 @@ export async function applyConversionSuccess(
   handlers.setStructureRescuedRule(
     parseStructureRescuedValue(response.headers.get('X-Structure-Rescued'))
   );
-  const blob = await response.blob();
-  handlers.setDownloadLink(globalThis.URL.createObjectURL(blob));
+  // Read before the body: once blob() throws the headers are all we have.
+  const downloadKey = response.headers.get('X-Download-Key');
+  try {
+    const blob = await response.blob();
+    handlers.setDownloadLink(globalThis.URL.createObjectURL(blob));
+  } catch (error) {
+    if (downloadKey == null) {
+      throw error;
+    }
+    handlers.recoverDownload(
+      recoveryDownloadUrl(downloadKey),
+      error instanceof Error ? error.message : String(error)
+    );
+  }
   handlers.setProgressWidth(100);
   if (count === 0) {
     handlers.setZoneState('emptyDeck');

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-29-recover-dropped-download.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-29-recover-dropped-download.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-29-recover-dropped-download",
+  "date": "2026-08-29",
+  "type": "fix",
+  "title": "A signed-in upload keeps its deck when the download drops — one button gets it back, and it's under My decks"
+}


### PR DESCRIPTION
**Draft on purpose (Tier 3).** The code is complete and tested, but it changes two things on the hot path that should be your call, not an overnight agent's: (1) every signed-in sync upload now persists its `.apkg` to S3 and appears under My decks, with an awaited PUT before the response streams; (2) storage grows with every signed-in conversion (the 2 h reaper never touched S3, so these persist like async decks). Please confirm both, or say which to change, before this leaves draft.

Closes #4271

## Why

`POST /api/upload/file` (sync path) streams the built `.apkg` as the response body and that body is the only copy. When the client's `response.blob()` fails — Safari "Load failed", big files, flaky mobile — the deck the server already built is gone and the user re-uploads a multi-MB file or gives up. Last 30 days: 320 `upload_failed reason=network` from 179 people; 51 of them had a `conversion_succeeded` in the previous 3 minutes (the deck existed and never arrived); 102 involved files over 10 MB.

## What

- Server (`UploadService.handleSyncUpload`, single-deck branch): for a signed-in owner the built buffer is persisted exactly as the async path does — `StorageHandler.uploadFile` + an `uploads` row (`persistSyncDeck`) — and the response carries `X-Download-Key` (exposed for CORS). Anonymous uploads are unchanged. A failed persist logs and still streams the deck without a key.
- Client (`uploadResponse.ts`): reads `X-Download-Key` **before** `response.blob()`; if the body read throws and a key exists, `recoverDownload(url, message)` points the download at `GET /api/download/u/<key>` and the form lands in the **success** state with one honest line and a visible native "Download deck" anchor (no auto-click — the user just watched one download fail). No key → the failure propagates exactly as today.
- Analytics: no new event names. `upload_failed { reason: 'network', recovered: true }` when the fallback engages (keeps the 320/30d baseline comparable); `deck_downloaded { source: 'key_fallback' }` when the recovery anchor is clicked.
- i18n: `upload.form.downloadRecoveredNote` / `downloadDeck` in all 10 locales.
- Tests: 3 Jest cases (signed-in persists + advertises + one `incrementCardUsage`; anonymous untouched; persist failure still streams), 3 Vitest cases on `applyConversionSuccess`, 2 on `UploadForm` (recovered state renders with the server link and fires `recovered: true`; no key still fails). Changelog entry.

## Decisions made overnight (please review)

- Scope (a) over the JSON `{downloadUrl}` rewrite: persist + header on the streamed response only touches the failure path; the 99 % happy path is byte-identical (pm + engineer). Assumption: an extra awaited S3 PUT (~1–3 s for a 37 MB deck, in-region) after conversion is acceptable for signed-in users. If not, switch `persistSyncDeck` to fire-and-forget and only set the header when it resolves — the engineer's rejected-for-now alternative.
- Await-persist-before-send (engineer): race-free key. Assumption: latency read on day 1 (p50/p95 of the signed-in single-deck POST) stays acceptable.
- Single-deck branch only: the multi-deck zip branch already answers with JSON + per-deck `GET` URLs, so it does not have this bug; persisting N decks + N rows is a follow-up.
- Recovery UI (designer): success state + note `Your download didn't finish — the deck is saved to your downloads.` + `Download deck`, not the red error chat and not "Download again" (they never got it once). The normal auto-download and the 3 s "Didn't get the file?" fallback are skipped on this path.
- Anonymous (pm): unchanged — `GET /api/download/u/:key` is `RequireAuthentication`; an unauthenticated keyed download or a mid-flow sign-in would be a bigger change. The designer's dedicated "deck is ready, download didn't finish — try again / create a free account" state for anonymous users is a documented follow-up, not built.
- Events (engineer over pm): props on existing events rather than a new `download_recovered` — no parity churn; `deck_downloaded { source: 'key_fallback' }` is the recovery numerator.
- Key seed: `res.locals.requestId` (or a UUID) rather than the filename, so same-owner-same-name uploads in one millisecond cannot collide on S3.
- Translations written by the agent in each file's register (fr `tu` like its neighbours, de `Stapel` like `makeAnother`); flag for a native pass.

## What Alexander should decide

1. Is "every signed-in sync deck appears under My decks" desired product behaviour? (It makes "saved to your downloads" true for sync uploads for the first time.)
2. S3 growth: OK without a lifecycle rule, or should a bucket lifecycle / reaper come first?
3. Awaited PUT on the hot path vs fire-and-forget.

## Expected impact

Retention / first-conversion: the ~51/month "deck existed and never arrived" losses become one click. Read at `/api/ops/metrics`: `upload_failed` split by `recovered`, `deck_downloaded` split by `source`; day-1/day-2 latency read on the signed-in sync POST.

## Checks

- `pnpm test src/services/UploadService.test.ts` — 94/94 (3 new); full server suite: see comment.
- `vitest run` upload form + response + parity — 456/456 (5 new); full web suite: see comment.
- `npx tsc -p . --noEmit`, `pnpm --filter 2anki-web typecheck`, `pnpm format:check`, lint (0 errors) — clean.
- Browser check: the recovery state cannot be reproduced against a real dev server without a body-read failure the browser will not fake; the full form with a rejecting `blob()` and the real i18n is exercised in `UploadForm.test.tsx`. Happy path unchanged. Marked as a draft for that reason too — walk it on prod with a throttled Safari once merged.
- Sonar: not run locally; PR decoration will report.
