### PR TITLE
fix: name the file cap on over-count uploads, revive the byte snapshot

### DIFF
--- a/src/controllers/Upload/UploadController.test.ts
+++ b/src/controllers/Upload/UploadController.test.ts
@@ -154,6 +154,55 @@ describe('Upload file — multer error handling', () => {
     jest.clearAllMocks();
   });
 
+  test('returns 400 with code=too_many_files when multer LIMIT_FILE_COUNT fires, without converting', async () => {
+    // multer has already deleted every temp file by the time it reports the
+    // count limit; running the conversion on the dead placeholders used to
+    // answer "your upload didn't finish" instead of naming the cap.
+    const multerError = new multer.MulterError('LIMIT_FILE_COUNT');
+    (getUploadHandler as jest.Mock).mockImplementation(
+      () =>
+        (
+          req: express.Request,
+          _res: express.Response,
+          cb: (err?: unknown) => void
+        ) => {
+          req.files = [{ path: '/gone/1' }, { path: '/gone/2' }] as never;
+          cb(multerError);
+        }
+    );
+
+    const uploadService = {
+      handleUpload: jest.fn(),
+    } as unknown as UploadService;
+    const notionService = new NotionService({} as INotionRepository);
+    const controller = new UploadController(uploadService, notionService);
+
+    const jsonSpy = jest.fn();
+    let capturedStatus = 0;
+    await new Promise<void>((resolve) => {
+      const fakeRes = {
+        locals: { patreon: false, subscriber: false },
+        status: (code: number) => {
+          capturedStatus = code;
+          return {
+            json: (body: unknown) => {
+              jsonSpy(body);
+              resolve();
+            },
+          };
+        },
+      } as unknown as express.Response;
+      controller.file({} as express.Request, fakeRes);
+    });
+
+    expect(capturedStatus).toBe(400);
+    expect(jsonSpy).toHaveBeenCalledWith({
+      code: 'too_many_files',
+      message: expect.stringContaining('21'),
+    });
+    expect(uploadService.handleUpload).not.toHaveBeenCalled();
+  });
+
   test('returns 413 with code=too_large when multer LIMIT_FILE_SIZE fires', async () => {
     const multerError = new multer.MulterError('LIMIT_FILE_SIZE');
     (getUploadHandler as jest.Mock).mockImplementation(

--- a/src/controllers/Upload/UploadController.test.ts
+++ b/src/controllers/Upload/UploadController.test.ts
@@ -154,53 +154,102 @@ describe('Upload file — multer error handling', () => {
     jest.clearAllMocks();
   });
 
-  test('returns 400 with code=too_many_files when multer LIMIT_FILE_COUNT fires, without converting', async () => {
-    // multer has already deleted every temp file by the time it reports the
-    // count limit; running the conversion on the dead placeholders used to
-    // answer "your upload didn't finish" instead of naming the cap.
-    const multerError = new multer.MulterError('LIMIT_FILE_COUNT');
+  test.each([
+    // `.array('pakker', 21)` reports the 22nd file this way (multer index.js).
+    new multer.MulterError('LIMIT_UNEXPECTED_FILE', 'pakker'),
+    // `limits.files`, if it were ever set, reports it this way.
+    new multer.MulterError('LIMIT_FILE_COUNT'),
+  ])(
+    'returns 400 with code=too_many_files on the multer count error %s, without converting',
+    async (multerError) => {
+      // multer has already deleted every temp file by the time it reports the
+      // count limit; running the conversion on the dead placeholders used to
+      // answer "your upload didn't finish" instead of naming the cap.
+      (getUploadHandler as jest.Mock).mockImplementation(
+        () =>
+          (
+            req: express.Request,
+            _res: express.Response,
+            cb: (err?: unknown) => void
+          ) => {
+            req.files = [{ path: '/gone/1' }, { path: '/gone/2' }] as never;
+            cb(multerError);
+          }
+      );
+
+      const uploadService = new UploadService(
+        {} as IUploadRepository,
+        {} as JobRepository,
+        buildUsersRepo(),
+        ...fakeUploadServiceDeps()
+      );
+      const handleUpload = jest
+        .spyOn(uploadService, 'handleUpload')
+        .mockResolvedValue(undefined);
+      const notionService = new NotionService({} as INotionRepository);
+      const controller = new UploadController(uploadService, notionService);
+
+      const jsonSpy = jest.fn();
+      let capturedStatus = 0;
+      await new Promise<void>((resolve) => {
+        const fakeRes = {
+          locals: { patreon: false, subscriber: false },
+          status: (code: number) => {
+            capturedStatus = code;
+            return {
+              json: (body: unknown) => {
+                jsonSpy(body);
+                resolve();
+              },
+            };
+          },
+        } as unknown as express.Response;
+        controller.file({} as express.Request, fakeRes);
+      });
+
+      expect(capturedStatus).toBe(400);
+      expect(jsonSpy).toHaveBeenCalledWith({
+        code: 'too_many_files',
+        message: expect.stringContaining('21'),
+      });
+      expect(handleUpload).not.toHaveBeenCalled();
+    }
+  );
+
+  test('a stray field name is not the file cap and still reaches the service', async () => {
     (getUploadHandler as jest.Mock).mockImplementation(
       () =>
         (
-          req: express.Request,
+          _req: express.Request,
           _res: express.Response,
           cb: (err?: unknown) => void
         ) => {
-          req.files = [{ path: '/gone/1' }, { path: '/gone/2' }] as never;
-          cb(multerError);
+          cb(new multer.MulterError('LIMIT_UNEXPECTED_FILE', 'avatar'));
         }
     );
+    const uploadService = new UploadService(
+      {} as IUploadRepository,
+      {} as JobRepository,
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
+    );
+    const handleUpload = jest
+      .spyOn(uploadService, 'handleUpload')
+      .mockResolvedValue(undefined);
+    const controller = new UploadController(
+      uploadService,
+      new NotionService({} as INotionRepository)
+    );
 
-    const uploadService = {
-      handleUpload: jest.fn(),
-    } as unknown as UploadService;
-    const notionService = new NotionService({} as INotionRepository);
-    const controller = new UploadController(uploadService, notionService);
+    controller.file(
+      {} as express.Request,
+      {
+        locals: {},
+      } as unknown as express.Response
+    );
+    await new Promise((r) => setImmediate(r));
 
-    const jsonSpy = jest.fn();
-    let capturedStatus = 0;
-    await new Promise<void>((resolve) => {
-      const fakeRes = {
-        locals: { patreon: false, subscriber: false },
-        status: (code: number) => {
-          capturedStatus = code;
-          return {
-            json: (body: unknown) => {
-              jsonSpy(body);
-              resolve();
-            },
-          };
-        },
-      } as unknown as express.Response;
-      controller.file({} as express.Request, fakeRes);
-    });
-
-    expect(capturedStatus).toBe(400);
-    expect(jsonSpy).toHaveBeenCalledWith({
-      code: 'too_many_files',
-      message: expect.stringContaining('21'),
-    });
-    expect(uploadService.handleUpload).not.toHaveBeenCalled();
+    expect(handleUpload).toHaveBeenCalledTimes(1);
   });
 
   test('returns 413 with code=too_large when multer LIMIT_FILE_SIZE fires', async () => {

--- a/src/controllers/Upload/UploadController.ts
+++ b/src/controllers/Upload/UploadController.ts
@@ -11,6 +11,7 @@ import { hashIp, resolveClientIp } from '../../lib/rateLimit/ipHelpers';
 import NotionService from '../../services/NotionService';
 import UploadService from '../../services/UploadService';
 import { getUploadHandler } from '../../lib/misc/GetUploadHandler';
+import { getMaxUploadCount } from '../../lib/misc/getMaxUploadCount';
 import { isLimitError } from '../../lib/misc/isLimitError';
 import { handleUploadLimitError } from './helpers/handleUploadLimitError';
 import { handleDropbox } from './helpers/handleDropbox';
@@ -105,6 +106,16 @@ class UploadController {
             code: 'too_large',
             message:
               'Upload failed — the file is over your plan’s size limit. Try splitting it.',
+          });
+        }
+        if (
+          error instanceof multer.MulterError &&
+          error.code === 'LIMIT_FILE_COUNT'
+        ) {
+          const cap = getMaxUploadCount(isPaying(res.locals));
+          return res.status(400).json({
+            code: 'too_many_files',
+            message: `Upload failed — that’s more than ${cap} files at once. Send them in smaller batches.`,
           });
         }
         if (isLimitError(error)) {

--- a/src/controllers/Upload/UploadController.ts
+++ b/src/controllers/Upload/UploadController.ts
@@ -10,7 +10,10 @@ import {
 import { hashIp, resolveClientIp } from '../../lib/rateLimit/ipHelpers';
 import NotionService from '../../services/NotionService';
 import UploadService from '../../services/UploadService';
-import { getUploadHandler } from '../../lib/misc/GetUploadHandler';
+import {
+  getUploadHandler,
+  UPLOAD_FIELD,
+} from '../../lib/misc/GetUploadHandler';
 import { getMaxUploadCount } from '../../lib/misc/getMaxUploadCount';
 import { isLimitError } from '../../lib/misc/isLimitError';
 import { handleUploadLimitError } from './helpers/handleUploadLimitError';
@@ -30,6 +33,17 @@ import { toText } from '../../services/NotionService/BlockHandler/helpers/deckNa
 const DROPBOX_PAGE_SIZE = 10;
 const GOOGLE_DRIVE_PAGE_SIZE = 10;
 const GOOGLE_DRIVE_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+// `.array(field, maxCount)` reports an over-count file as LIMIT_UNEXPECTED_FILE
+// on that field; LIMIT_FILE_COUNT only fires from `limits.files`, which the
+// upload handler does not set. Both mean "more files than the plan takes".
+function isFileCountError(error: unknown): boolean {
+  if (!(error instanceof multer.MulterError)) return false;
+  return (
+    error.code === 'LIMIT_FILE_COUNT' ||
+    (error.code === 'LIMIT_UNEXPECTED_FILE' && error.field === UPLOAD_FIELD)
+  );
+}
 
 const RETRY_PDF_WINDOW_MS = 60_000;
 const RETRY_PDF_PER_IP_MAX = 10;
@@ -108,10 +122,7 @@ class UploadController {
               'Upload failed — the file is over your plan’s size limit. Try splitting it.',
           });
         }
-        if (
-          error instanceof multer.MulterError &&
-          error.code === 'LIMIT_FILE_COUNT'
-        ) {
+        if (isFileCountError(error)) {
           const cap = getMaxUploadCount(isPaying(res.locals));
           return res.status(400).json({
             code: 'too_many_files',

--- a/src/lib/misc/GetUploadHandler.test.ts
+++ b/src/lib/misc/GetUploadHandler.test.ts
@@ -77,6 +77,25 @@ describe('withNormalizedFilenames', () => {
     expect(file.buffer).toEqual(Buffer.from('disk-bytes'));
   });
 
+  it('still snapshots after Node auto-destroys the fully read request', () => {
+    // Node 16+ marks IncomingMessage destroyed once its body has been read, so
+    // by the time multer calls back every healthy request reads as destroyed.
+    const file = makeDiskFile(tmpPath);
+    const req = {
+      files: [file],
+      destroyed: true,
+      aborted: false,
+    } as unknown as express.Request;
+    const res = {} as express.Response;
+    const wrapped = withNormalizedFilenames((_req, _res, next) => next());
+
+    const callback = jest.fn();
+    wrapped(req, res, callback);
+
+    expect(callback).toHaveBeenCalledWith();
+    expect(file.buffer).toEqual(Buffer.from('disk-bytes'));
+  });
+
   it('skips the snapshot entirely when the request already aborted', () => {
     fs.rmSync(tmpPath); // multer 2.x removes temp files when the client aborts
     const file = makeDiskFile(tmpPath);

--- a/src/lib/misc/GetUploadHandler.ts
+++ b/src/lib/misc/GetUploadHandler.ts
@@ -55,6 +55,8 @@ export function withNormalizedFilenames(
   };
 }
 
+export const UPLOAD_FIELD = 'pakker';
+
 export const getUploadHandler = (res: express.Response): UploadHandler => {
   const paying = isPaying(res.locals);
   const maxUploadCount = getMaxUploadCount(paying);
@@ -62,7 +64,7 @@ export const getUploadHandler = (res: express.Response): UploadHandler => {
   const handler = multer({
     limits: getUploadLimits(paying),
     dest: process.env.UPLOAD_BASE,
-  }).array('pakker', maxUploadCount);
+  }).array(UPLOAD_FIELD, maxUploadCount);
 
   return withNormalizedFilenames(handler);
 };

--- a/src/lib/misc/GetUploadHandler.ts
+++ b/src/lib/misc/GetUploadHandler.ts
@@ -30,9 +30,11 @@ export function withNormalizedFilenames(
       }
       // A dead request has nothing to convert, and multer 2.x has already
       // removed its temp files — snapshotting would only ENOENT-spam the log
-      // once per file (#4173).
-      const requestDead =
-        req.aborted || req.destroyed || res.writableEnded || res.destroyed;
+      // once per file (#4173). `req.destroyed` is deliberately not consulted:
+      // Node auto-destroys IncomingMessage once its body is read, so it is
+      // true for every healthy request by the time multer calls back and
+      // would disable the snapshot everywhere.
+      const requestDead = req.aborted || res.writableEnded || res.destroyed;
       const files = req.files as UploadedFile[] | undefined;
       if (files) {
         for (const file of files) {

--- a/src/types/UploadErrorBody.ts
+++ b/src/types/UploadErrorBody.ts
@@ -1,6 +1,7 @@
 export type UploadErrorCode =
   | 'unsupported_format'
   | 'too_large'
+  | 'too_many_files'
   | 'invalid_markup'
   | 'malformed_notion'
   | 'corrupted_apkg'

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-30-upload-file-cap-message.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-30-upload-file-cap-message.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-30-upload-file-cap-message",
+  "date": "2026-08-30",
+  "type": "fix",
+  "title": "Dropping in more files than your plan takes at once now says the limit, instead of \"your upload didn't finish\""
+}


### PR DESCRIPTION
## Why

Prod error log, 2026-08-29 21:07 (twice, same signed-in free user): `[upload] could not snapshot upload bytes { count: 21, … ENOENT }` followed by a `400 upload_incomplete` ("Your upload didn't finish, so there was nothing to convert"). The user had dropped in more than 21 files. Two faults, one log line:

1. **Over-count uploads got the wrong error and lost the batch.** `getMaxUploadCount(free) = 21`; multer 2.2.0's `.array('pakker', 21)` rejects the 22nd file with `LIMIT_UNEXPECTED_FILE` on that field (`LIMIT_FILE_COUNT` only comes from `limits.files`, which the handler never sets — review catch) and deletes the 21 temp files it already wrote. `UploadController.file` only special-cased `LIMIT_FILE_SIZE` and then called `handleUpload` anyway, with `req.files` still holding the 21 dead placeholders → ENOENT → `UploadFileUnavailableError` → "your upload didn't finish".
2. **The receipt-time byte snapshot (#3414) has been dead since #4180 (2026-08-22).** Its guard consulted `req.destroyed`, which Node marks `true` on every `IncomingMessage` once the body is read — verified on Node 22.20.0 — so the multer-time snapshot was skipped for every upload and only the late copy in `GeneratePackagesUseCase` remained (the placement #3414 replaced because it lost the reaper race).

## What

- `UploadController.file`: `isFileCountError` — a `MulterError` that is `LIMIT_UNEXPECTED_FILE` on the upload field (`UPLOAD_FIELD`, exported from `GetUploadHandler`) or `LIMIT_FILE_COUNT` — now answers `400 { code: 'too_many_files', message: "Upload failed — that's more than N files at once. Send them in smaller batches." }` with the caller's plan cap, and never starts a conversion. The client already renders an unknown-code message as the error title (`classifyUploadError`), so no web change beyond the changelog.
- `withNormalizedFilenames`: `requestDead` drops `req.destroyed`, keeps `req.aborted || res.writableEnded || res.destroyed`.
- `UploadErrorCode` gains `too_many_files`.
- Tests: controller cases (both count errors → 400 with the cap, real `UploadService` with `handleUpload` spied and never called; a stray-field `LIMIT_UNEXPECTED_FILE` still reaches the service); snapshot case (`destroyed: true, aborted: false` still captures bytes) — both watched failing first.
- Changelog entry.

## Expected impact

Fewer "upload didn't finish" dead ends: `conversion_failed reason=upload_incomplete` at `/api/ops/metrics` should drop for multi-file uploads, and the reaper-race protection for small uploads is back.

## Checks

- `pnpm test src/lib/misc/GetUploadHandler.test.ts src/controllers/Upload/UploadController.test.ts` — 14/14.
- Full server suite: 702 suites / 6,811 tests passed; 1 suite / 2 tests failed — the documented `getPageCount` pdfinfo environment case.
- `npx tsc -p . --noEmit` clean; `pnpm format:check` clean; `pnpm lint` 0 errors.
- Sonar: not run locally; PR decoration will report.

## Browser check

Browser check: not applicable — server-only change; the only `web/src` file is the changelog JSON.
