### PR TITLE
fix: answer 400 on /print when the upload is not a zip at all

### DIFF
--- a/src/controllers/ApkgController.test.ts
+++ b/src/controllers/ApkgController.test.ts
@@ -322,6 +322,31 @@ describe('ApkgController.exportPdf — pdf_print_options_used event', () => {
     return res as Response;
   }
 
+  it('answers 400 Invalid .apkg file when the upload is not a zip at all', async () => {
+    // yauzl's message for a renamed PDF/HTML; used to fall through to a logged
+    // 500 "PDF generation failed." (prod, 2026-08-27).
+    (ExportApkgToPdfUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest
+        .fn()
+        .mockRejectedValue(
+          new Error(
+            'End of central directory record signature not found. Either not a zip file, or file is truncated.'
+          )
+        ),
+    }));
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const controller = makeController();
+    const req = makeReq({ body: {} }) as Request;
+    const res = makePdfRes({ owner: 42 });
+
+    await controller.exportPdf(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Invalid .apkg file' });
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
   it('fires the event with all four booleans false when every option is default', async () => {
     const controller = makeController();
     const req = makeReq({ body: {} }) as Request;

--- a/src/controllers/ApkgController.ts
+++ b/src/controllers/ApkgController.ts
@@ -581,7 +581,8 @@ function sendPdfExportError(res: Response, error: unknown): void {
   if (
     error instanceof Error &&
     (error.message.includes('No Anki collection') ||
-      error.message.includes('open failed'))
+      error.message.includes('open failed') ||
+      error.message.includes('End of central directory'))
   ) {
     res.status(400).json({ message: 'Invalid .apkg file' });
     return;

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-30-print-not-an-apkg.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-30-print-not-an-apkg.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-30-print-not-an-apkg",
+  "date": "2026-08-30",
+  "type": "fix",
+  "title": "Printing a file that isn't really an .apkg now says so, instead of \"PDF generation failed\""
+}


### PR DESCRIPTION
## Why

Prod, 2026-08-27 15:30: `POST /api/apkg/pdf` answered `500` and the error log carried a bare yauzl stack — `End of central directory record signature not found. Either not a zip file, or file is truncated.` The user had picked a file that was an `.apkg` by name only. `sendPdfExportError` recognises two not-a-deck messages (`No Anki collection`, `open failed`) and treats everything else as a server fault, so a bad input became "PDF generation failed." plus a logged 500.

## What

- `sendPdfExportError`: the yauzl not-a-zip message joins the existing allowlist → `400 { message: 'Invalid .apkg file' }`, no `console.error`.
- Test: use case rejects with the yauzl message → 400 + no error log (watched failing first: 500).
- Changelog entry.

## Expected impact

One fewer false 500 on `/print`; the error-log sweep stops surfacing user input as a server fault. Read: `500 POST /api/apkg/pdf` count in the access log.

## Checks

- `pnpm test src/controllers/ApkgController.test.ts` — 28/28.
- `npx tsc -p . --noEmit` clean; `pnpm format:check` clean; `pnpm lint` 0 errors.
- Full server suite not re-run for this controller-only branch line; PR #4296's full run (702 suites green minus the documented pdfinfo case) covers the same base.
- Sonar: not run locally; PR decoration will report.

## Browser check

Browser check: not applicable — server-only change; the only `web/src` file is the changelog JSON.
