### PR TITLE
refactor: raise InvalidApkgError from extractApkg instead of message text

### DIFF
--- a/src/controllers/ApkgController.test.ts
+++ b/src/controllers/ApkgController.test.ts
@@ -13,6 +13,7 @@ import ExportApkgToCsvUseCase, {
   EmptyDeckError as CsvEmptyDeckError,
 } from '../usecases/apkg/ExportApkgToCsvUseCase';
 import { track } from '../services/events/track';
+import { InvalidApkgError } from '../services/ApkgPreviewService/extractApkg';
 
 jest.mock('../usecases/apkg/ImportApkgToNotionUseCase');
 jest.mock('../usecases/apkg/ExportApkgToPdfUseCase');
@@ -323,13 +324,13 @@ describe('ApkgController.exportPdf — pdf_print_options_used event', () => {
   }
 
   it('answers 400 Invalid .apkg file when the upload is not a zip at all', async () => {
-    // yauzl's message for a renamed PDF/HTML; used to fall through to a logged
-    // 500 "PDF generation failed." (prod, 2026-08-27).
+    // extractApkg wraps yauzl's "End of central directory…" for a renamed
+    // PDF/HTML; this used to fall through to a logged 500 (prod, 2026-08-27).
     (ExportApkgToPdfUseCase as jest.Mock).mockImplementation(() => ({
       execute: jest
         .fn()
         .mockRejectedValue(
-          new Error(
+          new InvalidApkgError(
             'End of central directory record signature not found. Either not a zip file, or file is truncated.'
           )
         ),

--- a/src/controllers/ApkgController.ts
+++ b/src/controllers/ApkgController.ts
@@ -26,7 +26,10 @@ import PackEditedApkgUseCase from '../usecases/apkg/PackEditedApkgUseCase';
 import ResolveImportParentPageUseCase from '../usecases/apkg/ResolveImportParentPageUseCase';
 import NoNotionPagesError from '../usecases/apkg/NoNotionPagesError';
 import { CardEdit } from '../services/ApkgPreviewService/applyEditsToCards';
-import { ApkgTooLargeError } from '../services/ApkgPreviewService/extractApkg';
+import {
+  ApkgTooLargeError,
+  InvalidApkgError,
+} from '../services/ApkgPreviewService/extractApkg';
 import { NotionService } from '../services/NotionService/NotionService';
 import JobRepository from '../data_layer/JobRepository';
 import sendErrorResponse from '../lib/sendErrorResponse';
@@ -557,11 +560,7 @@ function sendCsvDownload(
 }
 
 function isInvalidApkgError(error: unknown): boolean {
-  return (
-    error instanceof Error &&
-    (error.message.includes('No Anki collection') ||
-      error.message.includes('open failed'))
-  );
+  return error instanceof InvalidApkgError;
 }
 
 // Three tiers: no account, free account, paid. Null means unlimited.
@@ -578,12 +577,7 @@ function sendPdfExportError(res: Response, error: unknown): void {
     res.status(400).json({ message: error.message });
     return;
   }
-  if (
-    error instanceof Error &&
-    (error.message.includes('No Anki collection') ||
-      error.message.includes('open failed') ||
-      error.message.includes('End of central directory'))
-  ) {
+  if (isInvalidApkgError(error)) {
     res.status(400).json({ message: 'Invalid .apkg file' });
     return;
   }

--- a/src/services/ApkgPreviewService/extractApkg.test.ts
+++ b/src/services/ApkgPreviewService/extractApkg.test.ts
@@ -1,7 +1,7 @@
 import JSZip from 'jszip';
 import Database from 'better-sqlite3';
 
-import { extractApkg } from './extractApkg';
+import { extractApkg, InvalidApkgError } from './extractApkg';
 import { parseCollection } from './parseCollection';
 
 function buildLegacyCollectionBuffer(): Buffer {
@@ -111,6 +111,31 @@ describe('extractApkg + parseCollection composition', () => {
     expect(archive.collectionName).toBe('collection.anki21b');
     expect(collection.notes.size).toBe(1);
     expect(collection.notes.get(10)?.fields).toEqual(['hello', 'world']);
+  });
+});
+
+describe('extractApkg on files that are not Anki packages', () => {
+  it('rejects a file that is not a zip with InvalidApkgError', async () => {
+    await expect(
+      extractApkg(Buffer.from('%PDF-1.4 definitely not a zip'))
+    ).rejects.toBeInstanceOf(InvalidApkgError);
+  });
+
+  it('keeps the zip reader message on the error for the server log', async () => {
+    await expect(
+      extractApkg(Buffer.from('%PDF-1.4 definitely not a zip'))
+    ).rejects.toThrow(/end of central directory/i);
+  });
+
+  it('rejects a zip with no collection file with InvalidApkgError', async () => {
+    const zip = new JSZip();
+    zip.file('media', '{}');
+    zip.file('notes.txt', 'front;back');
+    const notAnApkg = await zip.generateAsync({ type: 'nodebuffer' });
+
+    await expect(extractApkg(notAnApkg)).rejects.toBeInstanceOf(
+      InvalidApkgError
+    );
   });
 });
 

--- a/src/services/ApkgPreviewService/extractApkg.ts
+++ b/src/services/ApkgPreviewService/extractApkg.ts
@@ -31,6 +31,16 @@ export class ApkgTooLargeError extends Error {
   }
 }
 
+// The upload is not something Anki exported: not a zip at all, a zip yauzl
+// cannot open, or a zip with no collection file. Callers answer 400 on this
+// class instead of matching yauzl's message text.
+export class InvalidApkgError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidApkgError';
+  }
+}
+
 const COLLECTION_CANDIDATES = [
   'collection.anki21b',
   'collection.anki21',
@@ -96,7 +106,9 @@ export async function extractApkg(
 
   return new Promise((resolve, reject) => {
     yauzl.fromBuffer(bytes, { lazyEntries: true }, (err, zipfile) => {
-      if (err || !zipfile) return reject(err ?? new Error('open failed'));
+      if (err || !zipfile) {
+        return reject(new InvalidApkgError(err?.message ?? 'open failed'));
+      }
 
       const collections: Map<string, Buffer> = new Map();
       const mediaEntries: Map<string, Buffer> = new Map();
@@ -153,7 +165,9 @@ export async function extractApkg(
           collections.has(candidate)
         );
         if (!name) {
-          fail(new Error('No Anki collection file found in archive'));
+          fail(
+            new InvalidApkgError('No Anki collection file found in archive')
+          );
           return;
         }
         let collectionBuffer = collections.get(name) as Buffer;


### PR DESCRIPTION
## Why

Follow-up to https://github.com/2anki/server/pull/4297 (review nit). `ApkgController` decided "not an Anki package" by matching three message strings — yauzl's `End of central directory…`, our own `open failed`, and `No Anki collection file found in archive` — at two sites (`isInvalidApkgError` for CSV, inline in `sendPdfExportError`). A yauzl wording change on a bump would silently turn the `/print` 400 back into a logged 500 with no test going red.

## What

- `extractApkg.ts`: new `InvalidApkgError` beside `ApkgTooLargeError`; thrown for the yauzl open failure (message preserved for the server log), the no-zipfile case, and the missing-collection case. All three not-an-apkg messages originated here; nothing else in `src/` matched them.
- `ApkgController.ts`: `isInvalidApkgError` is `instanceof InvalidApkgError`; `sendPdfExportError` uses it (string matches removed).
- Tests: `extractApkg.test.ts` — not-a-zip → `InvalidApkgError` (with the reader's message kept), zip without a collection → `InvalidApkgError` (both watched failing first); controller test rejects with the class.
- No changelog: no user-visible change — the responses are the same `400 Invalid .apkg file`.

## Expected impact

None — internal. Drift-proofs the `/print` and CSV not-an-apkg 400s.

## Checks

- `pnpm test src/services/ApkgPreviewService src/controllers/ApkgController.test.ts src/usecases/apkg` — 19 suites / 184 tests.
- Full server suite: 2 failed, 25 skipped, 7 todo, 6817 passed, 6851 total — failing suites: FAIL src/lib/pdf/getPageCount.test.ts  (the documented pdfinfo environment case). Ran on the revision before the `cause` option was dropped and the formatter pass; the two touched files were re-run after (38/38).
- `npx tsc -p . --noEmit` clean; `pnpm format:check` clean; `pnpm lint` 0 errors.
- Sonar: not run locally; PR decoration will report.

## Browser check

Browser check: not applicable — server-only change, no `web/src` files.
