### PR TITLE
fix: carry the request id through Notion conversion logs

### DIFF
--- a/src/controllers/NotionController.test.ts
+++ b/src/controllers/NotionController.test.ts
@@ -316,6 +316,17 @@ describe('NotionController', () => {
       );
     });
 
+    it('threads res.locals.requestId into the runConversion payload so worker logs join the request', async () => {
+      setupConvertMocks();
+      res.locals = { owner: 'owner1', requestId: 'req-abc-123' };
+
+      await controller.convert(req as express.Request, res as express.Response);
+
+      expect(runConversion).toHaveBeenCalledWith(
+        expect.objectContaining({ requestId: 'req-abc-123' })
+      );
+    });
+
     it('emits upload_started so the Notion path enters the upload→download funnel', async () => {
       setupConvertMocks();
 

--- a/src/controllers/NotionController.ts
+++ b/src/controllers/NotionController.ts
@@ -338,6 +338,7 @@ class NotionController {
         backField: safeString(backField),
         anonId: safeString(anonId),
         signupOrigin: parseFirstTouch(cookies?.first_touch).signupOrigin,
+        requestId: safeString(res.locals.requestId),
       }).catch((err: unknown) => {
         console.error('notion convert worker:', err);
       });

--- a/src/lib/conversionPool.test.ts
+++ b/src/lib/conversionPool.test.ts
@@ -141,6 +141,18 @@ describe('runConversionInWorker', () => {
     expect(typeof request.api.getPage).toBe('function');
   });
 
+  it('forwards the originating requestId into performConversion so worker logs join the request', async () => {
+    const fakeKnex = {} as unknown as Parameters<typeof performConversion>[0];
+
+    await runConversionInWorker(
+      { ...baseRequest, requestId: 'req-xyz-789' },
+      () => fakeKnex
+    );
+
+    const [, request] = (performConversion as jest.Mock).mock.calls[0];
+    expect(request.requestId).toBe('req-xyz-789');
+  });
+
   it('sets job failed with notion_token_expired when owner has no Notion token', async () => {
     (NotionRepository as jest.Mock).mockImplementation(() => ({
       getNotionToken: jest.fn().mockResolvedValue(null),

--- a/src/lib/conversionPool.ts
+++ b/src/lib/conversionPool.ts
@@ -34,6 +34,7 @@ export interface ConversionWorkerRequest {
   backField?: string;
   anonId?: string;
   signupOrigin?: string | null;
+  requestId?: string;
 }
 
 let pool: Piscina | null = null;
@@ -241,5 +242,6 @@ export async function runConversionInWorker(
     backField: request.backField,
     anonId: request.anonId,
     signupOrigin: request.signupOrigin,
+    requestId: request.requestId,
   });
 }

--- a/src/lib/storage/jobs/helpers/performConversion.ts
+++ b/src/lib/storage/jobs/helpers/performConversion.ts
@@ -64,6 +64,7 @@ interface ConversionRequest {
   backField?: string;
   anonId?: string;
   signupOrigin?: string | null;
+  requestId?: string;
 }
 
 function toAnonymousId(anonId?: string): string | null {
@@ -217,9 +218,10 @@ export default async function performConversion(
     backField,
     anonId,
     signupOrigin,
+    requestId,
   }: ConversionRequest
 ) {
-  console.info(`Performing conversion for ${id}`);
+  console.info(`Performing conversion for ${id}`, { requestId, jobId: id });
   const resolvedSignupOrigin = signupOrigin ?? null;
 
   const storage = new StorageHandler();
@@ -420,12 +422,13 @@ export default async function performConversion(
     if (error instanceof PythonExitError) {
       console.error('[conversion] python crash', {
         jobId: id,
+        requestId,
         kind: error.kind,
         code: error.code,
         rawOutput: error.rawOutput,
       });
     } else {
-      console.error('[conversion] failed', { jobId: id, error });
+      console.error('[conversion] failed', { jobId: id, requestId, error });
     }
     if (isNotionUnauthorizedError(error)) {
       const ownerNum = Number(owner);
@@ -452,6 +455,7 @@ export default async function performConversion(
     if (isExpectedUserState) {
       console.info('[conversion] user-input state', {
         jobId: id,
+        requestId,
         kind: error instanceof Error ? error.name : 'unknown',
       });
     } else {
@@ -464,6 +468,7 @@ export default async function performConversion(
       } catch (cleanupError) {
         console.error('[conversion] workspace cleanup failed', {
           jobId: id,
+          requestId,
           message:
             cleanupError instanceof Error ? cleanupError.message : 'unknown',
         });


### PR DESCRIPTION
Finishes #4198. Most of the issue shipped earlier (#4219 request-correlation middleware, #4256 request id on Claude spend/chunk lines, upload path threaded end-to-end); this closes the last gap — the Notion conversion worker path.

- NotionController.convert now passes res.locals.requestId into the conversion worker request; conversionPool forwards it; performConversion stamps it on all five job lifecycle log lines.
- In-memory only: no DB column, no migration ("a helper, not a platform", per the issue).
- Not stamped: the Ankify 5-minute poll (no originating request exists there).

Tests: the three touched suites pass (NotionController 33/33, conversionPool 21/21, performConversion green); full suite run showed only load-induced timeouts (withStripeRetry, mountWebBuild) that pass in isolation, plus the documented environmental parser/pdfinfo failures. tsc --noEmit clean, format:check clean.

No changelog entry — internal observability, no user-visible behavior change.
Sonar: not run locally; PR decoration will report.

Process note: the implementing agent drifted from its worktree into the main checkout mid-run; the diff was verified coherent and moved onto this branch by explicit-path staging. No other main-checkout state was disturbed.
