### PR TITLE
feat: add an ops command to change a user's email

### DIFF
--- a/src/controllers/OpsController.test.ts
+++ b/src/controllers/OpsController.test.ts
@@ -11,6 +11,7 @@ import { GetPassUnlockMonitorUseCase } from '../usecases/ops/GetPassUnlockMonito
 import { GetCancelFunnelUseCase } from '../usecases/ops/GetCancelFunnelUseCase';
 import { GrantUnclaimedPassUseCase } from '../usecases/passes/GrantUnclaimedPassUseCase';
 import { SetBlockIdIdentityUseCase } from '../usecases/ops/SetBlockIdIdentityUseCase';
+import { ChangeUserEmailUseCase } from '../usecases/ops/ChangeUserEmailUseCase';
 
 const buildRes = () => {
   const json = jest.fn();
@@ -813,6 +814,140 @@ describe('OpsController.setBlockIdIdentity', () => {
     const res = buildRes();
 
     await controller.setBlockIdIdentity(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+});
+
+describe('OpsController.changeUserEmail', () => {
+  const buildController = (useCase?: ChangeUserEmailUseCase) =>
+    new OpsController(
+      {} as unknown as GetOpsMetricsUseCase,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      useCase
+    );
+
+  it('returns 200 with the account id on success', async () => {
+    const execute = jest.fn().mockResolvedValue({ success: true, userId: 42 });
+    const controller = buildController({
+      execute,
+    } as unknown as ChangeUserEmailUseCase);
+    const req = {
+      body: { currentEmail: ' old@example.com ', newEmail: 'new@example.com' },
+    } as unknown as express.Request;
+    const res = buildRes();
+
+    await controller.changeUserEmail(req, res);
+
+    expect(execute).toHaveBeenCalledWith({
+      currentEmail: 'old@example.com',
+      newEmail: 'new@example.com',
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ userId: 42 });
+  });
+
+  it('returns 404 when no account matches the current email', async () => {
+    const execute = jest
+      .fn()
+      .mockResolvedValue({ success: false, reason: 'user_not_found' });
+    const controller = buildController({
+      execute,
+    } as unknown as ChangeUserEmailUseCase);
+    const req = {
+      body: { currentEmail: 'ghost@example.com', newEmail: 'new@example.com' },
+    } as unknown as express.Request;
+    const res = buildRes();
+
+    await controller.changeUserEmail(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('returns 409 when the new email already belongs to another account', async () => {
+    const execute = jest
+      .fn()
+      .mockResolvedValue({ success: false, reason: 'new_email_taken' });
+    const controller = buildController({
+      execute,
+    } as unknown as ChangeUserEmailUseCase);
+    const req = {
+      body: { currentEmail: 'old@example.com', newEmail: 'taken@example.com' },
+    } as unknown as express.Request;
+    const res = buildRes();
+
+    await controller.changeUserEmail(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(409);
+  });
+
+  it('returns 409 when the new email matches the current one', async () => {
+    const execute = jest
+      .fn()
+      .mockResolvedValue({ success: false, reason: 'same_email' });
+    const controller = buildController({
+      execute,
+    } as unknown as ChangeUserEmailUseCase);
+    const req = {
+      body: { currentEmail: 'same@example.com', newEmail: 'same@example.com' },
+    } as unknown as express.Request;
+    const res = buildRes();
+
+    await controller.changeUserEmail(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(409);
+  });
+
+  it.each([
+    [{ currentEmail: 'not-an-email', newEmail: 'new@example.com' }],
+    [{ currentEmail: 'old@example.com', newEmail: 'not-an-email' }],
+    [{ newEmail: 'new@example.com' }],
+  ])('returns 400 without calling the use case for body %o', async (body) => {
+    const execute = jest.fn();
+    const controller = buildController({
+      execute,
+    } as unknown as ChangeUserEmailUseCase);
+    const req = { body } as unknown as express.Request;
+    const res = buildRes();
+
+    await controller.changeUserEmail(req, res);
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 500 when the use case is not configured', async () => {
+    const controller = buildController(undefined);
+    const req = {
+      body: { currentEmail: 'old@example.com', newEmail: 'new@example.com' },
+    } as unknown as express.Request;
+    const res = buildRes();
+
+    await controller.changeUserEmail(req, res);
 
     expect(res.status).toHaveBeenCalledWith(500);
   });

--- a/src/controllers/OpsController.ts
+++ b/src/controllers/OpsController.ts
@@ -29,6 +29,7 @@ import { GetAiUsageMetricsUseCase } from '../usecases/ops/GetAiUsageMetricsUseCa
 import { SetChatAttachmentsLifecycleUseCase } from '../usecases/ops/SetChatAttachmentsLifecycleUseCase';
 import { GrantUnclaimedPassUseCase } from '../usecases/passes/GrantUnclaimedPassUseCase';
 import { SetBlockIdIdentityUseCase } from '../usecases/ops/SetBlockIdIdentityUseCase';
+import { ChangeUserEmailUseCase } from '../usecases/ops/ChangeUserEmailUseCase';
 
 class OpsController {
   constructor(
@@ -57,8 +58,57 @@ class OpsController {
     private readonly getAiUsageMetricsUseCase?: GetAiUsageMetricsUseCase,
     private readonly setChatAttachmentsLifecycleUseCase?: SetChatAttachmentsLifecycleUseCase,
     private readonly grantUnclaimedPassUseCase?: GrantUnclaimedPassUseCase,
-    private readonly setBlockIdIdentityUseCase?: SetBlockIdIdentityUseCase
+    private readonly setBlockIdIdentityUseCase?: SetBlockIdIdentityUseCase,
+    private readonly changeUserEmailUseCase?: ChangeUserEmailUseCase
   ) {}
+
+  async changeUserEmail(req: express.Request, res: express.Response) {
+    if (this.changeUserEmailUseCase == null) {
+      res.status(500).json({ message: 'Email change not configured' });
+      return;
+    }
+    const { currentEmail, newEmail } = req.body as {
+      currentEmail?: unknown;
+      newEmail?: unknown;
+    };
+    const trimmedCurrent =
+      typeof currentEmail === 'string' ? currentEmail.trim() : '';
+    const trimmedNew = typeof newEmail === 'string' ? newEmail.trim() : '';
+    if (!trimmedCurrent.includes('@')) {
+      res.status(400).json({ message: 'A valid current email is required.' });
+      return;
+    }
+    if (!trimmedNew.includes('@')) {
+      res.status(400).json({ message: 'A valid new email is required.' });
+      return;
+    }
+    try {
+      const outcome = await this.changeUserEmailUseCase.execute({
+        currentEmail: trimmedCurrent,
+        newEmail: trimmedNew,
+      });
+      if (outcome.success) {
+        res.status(200).json({ userId: outcome.userId });
+        return;
+      }
+      if (outcome.reason === 'user_not_found') {
+        res.status(404).json({ message: 'No account found for that email.' });
+        return;
+      }
+      if (outcome.reason === 'new_email_taken') {
+        res
+          .status(409)
+          .json({ message: 'Another account already uses that email.' });
+        return;
+      }
+      res
+        .status(409)
+        .json({ message: 'The new email matches the current one.' });
+    } catch (error) {
+      console.error('[ops] changeUserEmail failed', error);
+      res.status(500).json({ message: 'Failed to change the account email.' });
+    }
+  }
 
   async setBlockIdIdentity(req: express.Request, res: express.Response) {
     if (this.setBlockIdIdentityUseCase == null) {

--- a/src/data_layer/UsersRepository.test.ts
+++ b/src/data_layer/UsersRepository.test.ts
@@ -246,6 +246,49 @@ describe('UsersRepository.createUserAndSeedFromTombstone', () => {
   });
 });
 
+describe('UsersRepository.changeEmailAndRelinkSubscriptions', () => {
+  function buildTrxKnex() {
+    const usersUpdate = jest.fn().mockResolvedValue(1);
+    const subsUpdate = jest.fn().mockResolvedValue(1);
+    const usersWhereRaw = jest.fn().mockReturnValue({ update: usersUpdate });
+    const subsWhere = jest.fn().mockReturnValue({ update: subsUpdate });
+    const trx: any = jest.fn().mockImplementation((table: string) => {
+      if (table === 'users') {
+        return { whereRaw: usersWhereRaw };
+      }
+      if (table === 'subscriptions') {
+        return { where: subsWhere };
+      }
+      return {};
+    });
+    const transaction = jest.fn().mockImplementation(async (cb) => cb(trx));
+    const knex: any = jest.fn();
+    knex.transaction = transaction;
+    return { knex, usersWhereRaw, usersUpdate, subsWhere, subsUpdate };
+  }
+
+  it('moves users.email and subscriptions.linked_email in one transaction', async () => {
+    const { knex, usersWhereRaw, usersUpdate, subsWhere, subsUpdate } =
+      buildTrxKnex();
+    const repo = new UsersRepository(knex as any);
+
+    await repo.changeEmailAndRelinkSubscriptions(
+      ' Old@Example.com ',
+      ' NEW@Example.com '
+    );
+
+    expect(usersWhereRaw).toHaveBeenCalledWith(
+      'LOWER(TRIM(email)) = LOWER(?)',
+      ['Old@Example.com']
+    );
+    expect(usersUpdate).toHaveBeenCalledWith({ email: 'new@example.com' });
+    expect(subsWhere).toHaveBeenCalledWith({ email: 'old@example.com' });
+    expect(subsUpdate).toHaveBeenCalledWith({
+      linked_email: 'new@example.com',
+    });
+  });
+});
+
 describe('UsersRepository.deleteUser', () => {
   it('snapshots usage to the tombstone before deleting the user', async () => {
     const userRow = {

--- a/src/data_layer/UsersRepository.ts
+++ b/src/data_layer/UsersRepository.ts
@@ -283,6 +283,22 @@ class UsersRepository {
       .update({ linked_email: newEmail.toLowerCase() });
   }
 
+  changeEmailAndRelinkSubscriptions(
+    currentEmail: string,
+    newEmail: string
+  ): Promise<void> {
+    const current = currentEmail.trim();
+    const next = newEmail.trim().toLowerCase();
+    return this.database.transaction(async (trx) => {
+      await trx(this.table)
+        .whereRaw('LOWER(TRIM(email)) = LOWER(?)', [current])
+        .update({ email: next });
+      await trx('subscriptions')
+        .where({ email: current.toLowerCase() })
+        .update({ linked_email: next });
+    });
+  }
+
   async getSubscriptionLinkedEmail(owner: string) {
     const user = await this.database(this.table).where({ id: owner }).first();
     if (!user) {

--- a/src/routes/OpsRouter.ts
+++ b/src/routes/OpsRouter.ts
@@ -26,6 +26,7 @@ import { ReEngagementFeedbackRepository } from '../data_layer/ReEngagementFeedba
 import UsersRepository from '../data_layer/UsersRepository';
 import { UserPreferencesRepository } from '../data_layer/UserPreferencesRepository';
 import { SetBlockIdIdentityUseCase } from '../usecases/ops/SetBlockIdIdentityUseCase';
+import { ChangeUserEmailUseCase } from '../usecases/ops/ChangeUserEmailUseCase';
 import { UserDeletionService } from '../services/UserDeletionService';
 import { SubscriptionsSourceRepository } from '../data_layer/SubscriptionsSourceRepository';
 import SuppressionEventsRepository from '../data_layer/SuppressionEventsRepository';
@@ -233,7 +234,8 @@ const OpsRouter = () => {
     new SetBlockIdIdentityUseCase(
       new UsersRepository(database),
       new UserPreferencesRepository(database)
-    )
+    ),
+    new ChangeUserEmailUseCase(new UsersRepository(database), getEventsSink())
   );
 
   /**
@@ -518,6 +520,44 @@ const OpsRouter = () => {
    */
   router.post('/api/ops/set-block-id-identity', RequireOpsAccess, (req, res) =>
     controller.setBlockIdIdentity(req, res)
+  );
+
+  /**
+   * @swagger
+   * /api/ops/change-user-email:
+   *   post:
+   *     summary: Change an account's login email and re-link its subscriptions
+   *     description: |
+   *       Moves a user's login email to a new address, matched case-insensitively,
+   *       and re-links their subscriptions' linked_email in the same transaction so
+   *       the unlinked-subscription sweep does not cancel a paying user. Replaces the
+   *       manual SQL run support did for lockout cases where the old inbox is lost.
+   *       Does not touch subscriptions.email (the Stripe payer, possibly a different
+   *       person), sends no confirmation emails, and does not sign the user out.
+   *       Internal endpoint locked to the ops owner — returns 404 for everyone else.
+   *     tags: [Ops]
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required: [currentEmail, newEmail]
+   *             properties:
+   *               currentEmail: { type: string }
+   *               newEmail: { type: string }
+   *     responses:
+   *       200:
+   *         description: Email changed — returns userId
+   *       400:
+   *         description: Missing or invalid current or new email
+   *       404:
+   *         description: Not the ops owner, or no account for the current email
+   *       409:
+   *         description: The new email is already taken, or matches the current one
+   */
+  router.post('/api/ops/change-user-email', RequireOpsAccess, (req, res) =>
+    controller.changeUserEmail(req, res)
   );
 
   /**

--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -125,6 +125,7 @@ export const KNOWN_EVENTS = new Set([
   'ai_usage_recorded',
   'pass_claim_email_sent',
   'anonymous_pass_claimed',
+  'ops_user_email_changed',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;

--- a/src/usecases/ops/ChangeUserEmailUseCase.test.ts
+++ b/src/usecases/ops/ChangeUserEmailUseCase.test.ts
@@ -1,0 +1,161 @@
+import {
+  ChangeUserEmailRepository,
+  ChangeUserEmailUseCase,
+} from './ChangeUserEmailUseCase';
+import type { EventsSink } from '../../services/events/EventsSink';
+
+interface FakeUser {
+  id: number;
+  email: string;
+}
+
+interface FakeSubscription {
+  email: string;
+  linked_email: string | null;
+}
+
+class FakeUsersRepository implements ChangeUserEmailRepository {
+  constructor(
+    public users: FakeUser[],
+    public subscriptions: FakeSubscription[]
+  ) {}
+
+  async getByEmail(email: string): Promise<{ id: number } | undefined> {
+    const normalized = email.trim().toLowerCase();
+    return this.users.find((u) => u.email.trim().toLowerCase() === normalized);
+  }
+
+  async changeEmailAndRelinkSubscriptions(
+    currentEmail: string,
+    newEmail: string
+  ): Promise<void> {
+    const current = currentEmail.trim().toLowerCase();
+    const next = newEmail.trim().toLowerCase();
+    for (const user of this.users) {
+      if (user.email.trim().toLowerCase() === current) {
+        user.email = next;
+      }
+    }
+    for (const subscription of this.subscriptions) {
+      if (subscription.email.toLowerCase() === current) {
+        subscription.linked_email = next;
+      }
+    }
+  }
+}
+
+function makeEventsSink(): Pick<EventsSink, 'record'> {
+  return { record: jest.fn() };
+}
+
+const NOW = new Date('2026-09-01T12:00:00Z');
+
+describe('ChangeUserEmailUseCase', () => {
+  it('moves the account email and re-links the subscription in one call', async () => {
+    const repo = new FakeUsersRepository(
+      [{ id: 42, email: 'old@example.com' }],
+      [{ email: 'old@example.com', linked_email: 'old@example.com' }]
+    );
+    const eventsSink = makeEventsSink();
+    const useCase = new ChangeUserEmailUseCase(repo, eventsSink);
+
+    const outcome = await useCase.execute(
+      { currentEmail: 'old@example.com', newEmail: 'new@example.com' },
+      NOW
+    );
+
+    expect(outcome).toEqual({ success: true, userId: 42 });
+    expect(repo.users[0].email).toBe('new@example.com');
+    expect(repo.subscriptions[0].linked_email).toBe('new@example.com');
+    expect(eventsSink.record).toHaveBeenCalledWith({
+      name: 'ops_user_email_changed',
+      user_id: 42,
+      props: { method: 'ops' },
+      created_at: NOW,
+    });
+  });
+
+  it('leaves the subscription payer email (subscriptions.email) untouched', async () => {
+    const repo = new FakeUsersRepository(
+      [{ id: 7, email: 'learner@example.com' }],
+      [{ email: 'learner@example.com', linked_email: 'learner@example.com' }]
+    );
+    const useCase = new ChangeUserEmailUseCase(repo, makeEventsSink());
+
+    await useCase.execute(
+      { currentEmail: 'learner@example.com', newEmail: 'moved@example.com' },
+      NOW
+    );
+
+    expect(repo.subscriptions[0].email).toBe('learner@example.com');
+    expect(repo.subscriptions[0].linked_email).toBe('moved@example.com');
+  });
+
+  it('matches the current email case-insensitively and normalizes the new email', async () => {
+    const repo = new FakeUsersRepository(
+      [{ id: 9, email: 'Mixed@Example.com' }],
+      []
+    );
+    const useCase = new ChangeUserEmailUseCase(repo, makeEventsSink());
+
+    const outcome = await useCase.execute(
+      { currentEmail: '  MIXED@example.COM ', newEmail: '  NEW@Example.com ' },
+      NOW
+    );
+
+    expect(outcome).toEqual({ success: true, userId: 9 });
+    expect(repo.users[0].email).toBe('new@example.com');
+  });
+
+  it('returns user_not_found when no account matches the current email', async () => {
+    const repo = new FakeUsersRepository([], []);
+    const eventsSink = makeEventsSink();
+    const useCase = new ChangeUserEmailUseCase(repo, eventsSink);
+
+    const outcome = await useCase.execute(
+      { currentEmail: 'ghost@example.com', newEmail: 'new@example.com' },
+      NOW
+    );
+
+    expect(outcome).toEqual({ success: false, reason: 'user_not_found' });
+    expect(eventsSink.record).not.toHaveBeenCalled();
+  });
+
+  it('returns new_email_taken when another account already owns the new email (case-varied)', async () => {
+    const repo = new FakeUsersRepository(
+      [
+        { id: 1, email: 'moving@example.com' },
+        { id: 2, email: 'Taken@Example.com' },
+      ],
+      []
+    );
+    const eventsSink = makeEventsSink();
+    const useCase = new ChangeUserEmailUseCase(repo, eventsSink);
+
+    const outcome = await useCase.execute(
+      { currentEmail: 'moving@example.com', newEmail: 'taken@example.com' },
+      NOW
+    );
+
+    expect(outcome).toEqual({ success: false, reason: 'new_email_taken' });
+    expect(repo.users[0].email).toBe('moving@example.com');
+    expect(eventsSink.record).not.toHaveBeenCalled();
+  });
+
+  it('returns same_email when the new email normalizes to the current one', async () => {
+    const repo = new FakeUsersRepository(
+      [{ id: 3, email: 'same@example.com' }],
+      []
+    );
+    const eventsSink = makeEventsSink();
+    const useCase = new ChangeUserEmailUseCase(repo, eventsSink);
+
+    const outcome = await useCase.execute(
+      { currentEmail: 'same@example.com', newEmail: ' SAME@example.com ' },
+      NOW
+    );
+
+    expect(outcome).toEqual({ success: false, reason: 'same_email' });
+    expect(eventsSink.record).not.toHaveBeenCalled();
+  });
+});

--- a/src/usecases/ops/ChangeUserEmailUseCase.ts
+++ b/src/usecases/ops/ChangeUserEmailUseCase.ts
@@ -1,0 +1,69 @@
+import type { EventsSink } from '../../services/events/EventsSink';
+
+export interface ChangeUserEmailRepository {
+  getByEmail(email: string): Promise<{ id: number | string } | undefined>;
+  changeEmailAndRelinkSubscriptions(
+    currentEmail: string,
+    newEmail: string
+  ): Promise<void>;
+}
+
+export interface ChangeUserEmailInput {
+  currentEmail: string;
+  newEmail: string;
+}
+
+export type ChangeUserEmailOutcome =
+  | { success: true; userId: number }
+  | {
+      success: false;
+      reason: 'user_not_found' | 'new_email_taken' | 'same_email';
+    };
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+export class ChangeUserEmailUseCase {
+  constructor(
+    private readonly usersRepo: ChangeUserEmailRepository,
+    private readonly eventsSink?: Pick<EventsSink, 'record'>
+  ) {}
+
+  async execute(
+    input: ChangeUserEmailInput,
+    now: Date = new Date()
+  ): Promise<ChangeUserEmailOutcome> {
+    const currentEmail = normalizeEmail(input.currentEmail);
+    const newEmail = normalizeEmail(input.newEmail);
+
+    if (currentEmail === newEmail) {
+      return { success: false, reason: 'same_email' };
+    }
+
+    const user = await this.usersRepo.getByEmail(currentEmail);
+    if (user == null) {
+      return { success: false, reason: 'user_not_found' };
+    }
+    const userId = Number(user.id);
+
+    const existing = await this.usersRepo.getByEmail(newEmail);
+    if (existing != null && Number(existing.id) !== userId) {
+      return { success: false, reason: 'new_email_taken' };
+    }
+
+    await this.usersRepo.changeEmailAndRelinkSubscriptions(
+      currentEmail,
+      newEmail
+    );
+
+    this.eventsSink?.record({
+      name: 'ops_user_email_changed',
+      user_id: userId,
+      props: { method: 'ops' },
+      created_at: now,
+    });
+
+    return { success: true, userId };
+  }
+}

--- a/web/src/pages/OpsPage/CommandsTab.test.tsx
+++ b/web/src/pages/OpsPage/CommandsTab.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import CommandsTab from './CommandsTab';
 
 const BLOCK_ID_URL = '/api/ops/set-block-id-identity';
+const CHANGE_EMAIL_URL = '/api/ops/change-user-email';
 
 function mockFetch(handler: (url: string, init?: RequestInit) => unknown) {
   globalThis.fetch = vi
@@ -95,6 +96,64 @@ describe('CommandsTab — match cards to Notion blocks', () => {
     ).toBeInTheDocument();
     expect(globalThis.fetch).not.toHaveBeenCalledWith(
       BLOCK_ID_URL,
+      expect.anything()
+    );
+  });
+});
+
+describe('CommandsTab — change account email', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    mockFetch((url) => (url === CHANGE_EMAIL_URL ? { userId: 42 } : {}));
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  test('changes the email and reports the account stays linked', async () => {
+    renderTab();
+
+    fireEvent.change(screen.getByLabelText('Current account email'), {
+      target: { value: 'old@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText('New account email'), {
+      target: { value: 'new@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Change email' }));
+
+    expect(
+      await screen.findByText(
+        'Account 42 now signs in with new@example.com. Their subscription stays linked; no email was sent.'
+      )
+    ).toBeInTheDocument();
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      CHANGE_EMAIL_URL,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          currentEmail: 'old@example.com',
+          newEmail: 'new@example.com',
+        }),
+      })
+    );
+  });
+
+  test('asks for the new email before calling the server', async () => {
+    renderTab();
+
+    fireEvent.change(screen.getByLabelText('Current account email'), {
+      target: { value: 'old@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Change email' }));
+
+    expect(
+      await screen.findByText('Enter the new email first.')
+    ).toBeInTheDocument();
+    expect(globalThis.fetch).not.toHaveBeenCalledWith(
+      CHANGE_EMAIL_URL,
       expect.anything()
     );
   });

--- a/web/src/pages/OpsPage/CommandsTab.tsx
+++ b/web/src/pages/OpsPage/CommandsTab.tsx
@@ -5,6 +5,7 @@ import styles from './OpsPage.module.css';
 import { syncStripeSubscriptions } from './syncStripeSubscriptions';
 import { grantUnclaimedPass } from './grantUnclaimedPass';
 import { setBlockIdIdentity } from './setBlockIdIdentity';
+import { changeUserEmail } from './changeUserEmail';
 import { setChatAttachmentsLifecycle } from './setChatAttachmentsLifecycle';
 import { sendPassWinback } from './sendPassWinback';
 import {
@@ -75,6 +76,10 @@ export default function CommandsTab() {
   const [blockIdEmail, setBlockIdEmail] = useState('');
   const [blockIdStatus, setBlockIdStatus] = useState<Status>('idle');
   const [blockIdMessage, setBlockIdMessage] = useState('');
+  const [emailChangeCurrent, setEmailChangeCurrent] = useState('');
+  const [emailChangeNew, setEmailChangeNew] = useState('');
+  const [emailChangeStatus, setEmailChangeStatus] = useState<Status>('idle');
+  const [emailChangeMessage, setEmailChangeMessage] = useState('');
 
   const runWinback = async (dryRun: boolean) => {
     const campaign = winbackCampaign.trim();
@@ -151,6 +156,35 @@ export default function CommandsTab() {
     } catch (error) {
       setPassStatus('error');
       setPassMessage(error instanceof Error ? error.message : 'Unknown error');
+    }
+  };
+
+  const runChangeUserEmail = async () => {
+    const current = emailChangeCurrent.trim();
+    const next = emailChangeNew.trim();
+    if (!current.includes('@')) {
+      setEmailChangeStatus('error');
+      setEmailChangeMessage('Enter the current account email first.');
+      return;
+    }
+    if (!next.includes('@')) {
+      setEmailChangeStatus('error');
+      setEmailChangeMessage('Enter the new email first.');
+      return;
+    }
+    setEmailChangeStatus('loading');
+    setEmailChangeMessage('');
+    try {
+      const result = await changeUserEmail(current, next);
+      setEmailChangeStatus('success');
+      setEmailChangeMessage(
+        `Account ${result.userId} now signs in with ${next}. Their subscription stays linked; no email was sent.`
+      );
+    } catch (error) {
+      setEmailChangeStatus('error');
+      setEmailChangeMessage(
+        error instanceof Error ? error.message : 'Unknown error'
+      );
     }
   };
 
@@ -349,6 +383,53 @@ export default function CommandsTab() {
       {blockIdStatus === 'error' && blockIdMessage && (
         <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>
           {blockIdMessage}
+        </div>
+      )}
+
+      <section className={`${sharedStyles.surface} ${styles.card}`}>
+        <h2 className={styles.cardTitle}>Change account email</h2>
+        <p className={styles.panelSubtitle}>
+          Moves a user&apos;s login email to a new address (matched
+          case-insensitively) and re-links their subscription in one step. For
+          lockout cases where the old inbox is lost. Does not email either
+          address or sign the user out — the self-serve flow handles those.
+        </p>
+        <div className={styles.controls}>
+          <input
+            type="email"
+            aria-label="Current account email"
+            placeholder="current@example.com"
+            className={styles.textInput}
+            value={emailChangeCurrent}
+            onChange={(e) => setEmailChangeCurrent(e.target.value)}
+          />
+          <input
+            type="email"
+            aria-label="New account email"
+            placeholder="new@example.com"
+            className={styles.textInput}
+            value={emailChangeNew}
+            onChange={(e) => setEmailChangeNew(e.target.value)}
+          />
+          <button
+            type="button"
+            className={sharedStyles.btnSmall}
+            onClick={() => runChangeUserEmail()}
+            disabled={emailChangeStatus === 'loading'}
+          >
+            {emailChangeStatus === 'loading' ? 'Working…' : 'Change email'}
+          </button>
+        </div>
+      </section>
+
+      {emailChangeStatus === 'success' && emailChangeMessage && (
+        <div className={`${sharedStyles.alertSuccess} ${styles.banner}`}>
+          {emailChangeMessage}
+        </div>
+      )}
+      {emailChangeStatus === 'error' && emailChangeMessage && (
+        <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>
+          {emailChangeMessage}
         </div>
       )}
 

--- a/web/src/pages/OpsPage/changeUserEmail.test.ts
+++ b/web/src/pages/OpsPage/changeUserEmail.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { changeUserEmail } from './changeUserEmail';
+
+describe('changeUserEmail', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  test('POSTs the current and new email and returns the account id', async () => {
+    const payload = { userId: 42 };
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: () => Promise.resolve(payload),
+    });
+
+    const result = await changeUserEmail('old@example.com', 'new@example.com');
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      '/api/ops/change-user-email',
+      {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          currentEmail: 'old@example.com',
+          newEmail: 'new@example.com',
+        }),
+      }
+    );
+    expect(result).toEqual(payload);
+  });
+
+  test('surfaces the server message when the new email is taken', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 409,
+      statusText: 'Conflict',
+      json: () =>
+        Promise.resolve({
+          message: 'Another account already uses that email.',
+        }),
+    });
+
+    await expect(
+      changeUserEmail('old@example.com', 'taken@example.com')
+    ).rejects.toThrow('Another account already uses that email.');
+  });
+});

--- a/web/src/pages/OpsPage/changeUserEmail.ts
+++ b/web/src/pages/OpsPage/changeUserEmail.ts
@@ -1,0 +1,22 @@
+export interface ChangeUserEmailResponse {
+  userId: number;
+}
+
+export async function changeUserEmail(
+  currentEmail: string,
+  newEmail: string
+): Promise<ChangeUserEmailResponse> {
+  const response = await fetch('/api/ops/change-user-email', {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ currentEmail, newEmail }),
+  });
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(
+      data.message ?? `${response.status} ${response.statusText}`
+    );
+  }
+  return response.json();
+}


### PR DESCRIPTION
**Identity-mutating ops surface — review before merge; not auto-merged by the overnight run. /security-review requested.**

## What
Adds an ops-only command to change a user's login email. `POST /api/ops/change-user-email` (behind the existing `RequireOpsAccess` gate) moves `users.email` (matched case-insensitively) and re-links the subscription's `linked_email` to the new address in one transaction, with a matching button in the ops CommandsTab. Replaces the manual SQL run support does for lockout cases.

## Why
Part of #4303. A paying subscriber who lost access to their registered inbox is one forgotten password from permanent lockout — password reset mails the old address, and delete-then-reregister orphans their subscription linkage. Today the only path is a hand-written SQL statement by the maintainer. This is the cheap first half of #4303 (the ops command); the durable self-serve `/account` flow is the separate spec #4318 and is intentionally **not** built here.

The `users.email` + `subscriptions.linked_email` pair is load-bearing: without the `linked_email` update, `cancelUnlinkedSubscriptions` would sweep-cancel a paying user whose `subscriptions.email` still matches their old address. Both writes run in one Knex transaction so they never half-apply.

## How
- `src/usecases/ops/ChangeUserEmailUseCase.ts` — normalizes both emails (lowercase+trim); outcomes `success{userId}` / `same_email` / `user_not_found` / `new_email_taken` (case-insensitive collision against another account); emits server-side track event `ops_user_email_changed`.
- `src/data_layer/UsersRepository.ts` — `changeEmailAndRelinkSubscriptions(currentEmail, newEmail)`: one transaction, `users.email` via `LOWER(TRIM(email))` match + `subscriptions.linked_email` via the existing payer-email lookup. `subscriptions.email` is left untouched.
- `src/controllers/OpsController.ts` — `changeUserEmail`: 400 invalid emails, 404 not found, 409 taken/same, 200 `{userId}`.
- `src/routes/OpsRouter.ts` — route + swagger, wired through `RequireOpsAccess`.
- `web/src/pages/OpsPage/changeUserEmail.ts` + `CommandsTab.tsx` — fetch wrapper + two-input section (current / new email) with status line. `opsRouteButtonParity.test.ts` stays green.
- `src/types/AnalyticsEvents.ts` — adds `ops_user_email_changed` to the server `KNOWN_EVENTS`.

Note: `ops_user_email_changed` is server-emitted only, so it was added to the **server** allowlist only, not the web `events.ts` (that allowlist is for browser-fired events; the web→server parity test stays green).

## Measuring success
Prod: `select count(*) from events where name = 'ops_user_email_changed'` (or the `/api/ops/metrics` funnel) confirms the command fires when used. Secondary: fewer lockout/email-change support tickets, and no `cancelUnlinkedSubscriptions` cancellation of a user whose email was just changed via this path.

## Testing
- Unit tests added:
  - `ChangeUserEmailUseCase.test.ts` — moves both columns; case-insensitive current-email match + new-email normalization; `subscriptions.email` untouched; `user_not_found`; `new_email_taken` (case-varied collision); `same_email`; event fired only on success.
  - `UsersRepository.test.ts` — `changeEmailAndRelinkSubscriptions` runs the `users` update (`LOWER(TRIM(email))`) and the `subscriptions` `linked_email` update inside one transaction, with normalized values.
  - `OpsController.test.ts` — 200 / 404 / 409(taken) / 409(same) / 400 (each invalid email) / 500 unconfigured.
  - `changeUserEmail.test.ts` — wrapper POST shape + error surfacing.
  - `CommandsTab.test.tsx` — renders the section, changes the email and reports the account stays linked, and blocks on a missing new email.
- Full server suite: 6759 passed; the only failures are the documented worktree-environmental suites (DeckParser / golden / canary need the `create_deck` Python venv; `getPageCount` needs pdfinfo) — none in changed code. Full web suite: green in isolation (the files that fail under concurrent-run CPU starvation pass 126/126 alone).
- `pnpm format:check` clean tree-wide; `pnpm arch` 0 errors; web lint clean on changed files.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px

Notes: No dev server available in this agent worktree to run `test:golden-path` (Playwright needs the app running). The new CommandsTab section is an exact mirror of the adjacent grant-pass / block-id ops sections and is covered by `CommandsTab.test.tsx` (render + interaction + validation). Human verification on `pnpm dev` welcome before merge.

## Changelog
No entry — internal ops-only command, no user-visible surface.

## Sonar
Not run locally; PR decoration will report.

## Risks
- Mutates account identity + subscription linkage. Mitigations: single transaction (atomic), `subscriptions.email` (Stripe payer) untouched, uniqueness enforced against other accounts, ops-owner-only gate. Rollback: revert the PR; no migration, no schema change.
- Deliberately narrow: no confirmation email (the command exists precisely for users who lost the old inbox) and sessions are **not** invalidated (support cases usually have the user signed in mid-thread). The self-serve flow (#4318) owns verify + notify + session invalidation.

## Goal alignment
Retention lever: closes an involuntary-churn hole for paying subscribers locked out of their own account. Metric it should move: monthly paid churn % (business-baseline block / Stripe) and lockout/email-change ticket volume. Read at the weekly retro; usage read via the `ops_user_email_changed` event.

## Decisions made overnight (please review)
- Updates exactly the `users.email` + `subscriptions.linked_email` pair (the same two columns the recent manual lockout fix touched) in one transaction — `linked_email` prevents the unlinked-subscription sweep from cancelling a paying user. `subscriptions.email` (Stripe payer mirror) and historical log tables deliberately untouched.
- No confirmation emails on the ops path — it exists for users who have LOST the old inbox; the self-serve flow (#4318 spec) carries the full verify+notify shape.
- Sessions NOT invalidated on the ops path (support cases usually have the user actively signed in mid-thread); the self-serve flow will invalidate. Flag if you want `deleteAllForOwner` here too.
- `ops_user_email_changed` added to the server `KNOWN_EVENTS` only, not the web allowlist, since it is server-emitted (the plan listed both; web parity is web→server so this stays green). Flag if you'd prefer it mirrored into web anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TqUDQZHTnn6LkPHasw4C9f
