### PR TITLE
fix: stamp Notion conversion logs and harden worker failures

### DIFF
--- a/src/controllers/NotionController.test.ts
+++ b/src/controllers/NotionController.test.ts
@@ -10,6 +10,7 @@ import { INotionRepository } from '../data_layer/NotionRespository';
 import { IEmailService } from '../services/EmailService/EmailService';
 import UsersRepository from '../data_layer/UsersRepository';
 import { buildNativeOAuthState } from '../services/NotionService/nativeOAuthState';
+import { WORKER_INTERRUPTED_REASON } from '../lib/workerTermination';
 
 jest.mock('../lib/conversionPool', () => ({
   __esModule: true,
@@ -392,8 +393,9 @@ describe('NotionController', () => {
       });
     });
 
-    it('fires runConversion without awaiting and catches worker rejections', async () => {
+    it('fires runConversion without awaiting and logs worker rejections with the request id, job id, and owner', async () => {
       setupConvertMocks();
+      res.locals = { owner: 'owner1', requestId: 'req-abc-123' };
       const consoleErrorSpy = jest
         .spyOn(console, 'error')
         .mockImplementation(() => undefined);
@@ -406,8 +408,63 @@ describe('NotionController', () => {
 
       await new Promise((resolve) => setTimeout(resolve, 10));
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        'notion convert worker:',
-        workerError
+        '[notion/convert] worker failed',
+        expect.objectContaining({
+          requestId: 'req-abc-123',
+          jobId: 77,
+          owner: 'owner1',
+          error: workerError,
+        })
+      );
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('marks the job interrupted when the worker is killed by a pool drain', async () => {
+      setupConvertMocks();
+      const updateJobStatus = jest.fn().mockResolvedValue(undefined);
+      (JobRepository as unknown as jest.Mock).mockImplementation(() => ({
+        updateJobStatus,
+      }));
+      const consoleInfoSpy = jest
+        .spyOn(console, 'info')
+        .mockImplementation(() => undefined);
+      (runConversion as jest.Mock).mockRejectedValue(
+        new Error('Terminating worker thread')
+      );
+
+      await controller.convert(req as express.Request, res as express.Response);
+
+      expect(res.status).toHaveBeenCalledWith(202);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(updateJobStatus).toHaveBeenCalledWith(
+        'page-abc',
+        'owner1',
+        'interrupted',
+        WORKER_INTERRUPTED_REASON
+      );
+      consoleInfoSpy.mockRestore();
+    });
+
+    it('logs the request id and owner when the enqueue itself fails', async () => {
+      setupConvertMocks();
+      res.locals = { owner: 'owner1', requestId: 'req-enqueue-9' };
+      (FindOrCreateJobUseCase as jest.Mock).mockImplementation(() => ({
+        execute: jest.fn().mockRejectedValue(new Error('db down')),
+      }));
+      const consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => undefined);
+
+      await controller.convert(req as express.Request, res as express.Response);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[notion/convert] enqueue failed',
+        expect.objectContaining({
+          requestId: 'req-enqueue-9',
+          owner: 'owner1',
+        })
       );
       consoleErrorSpy.mockRestore();
     });

--- a/src/controllers/NotionController.ts
+++ b/src/controllers/NotionController.ts
@@ -2,6 +2,10 @@ import { Request, Response } from 'express';
 
 import { runConversion } from '../lib/conversionPool';
 import {
+  isWorkerTerminationError,
+  WORKER_INTERRUPTED_REASON,
+} from '../lib/workerTermination';
+import {
   InProgressJobError,
   JobLimitError,
 } from '../lib/storage/jobs/helpers/errors';
@@ -292,6 +296,9 @@ class NotionController {
       },
     });
 
+    const safeString = (v: unknown): string | undefined =>
+      typeof v === 'string' && v.length > 0 ? v : undefined;
+
     try {
       if (!paying) {
         const usersRepository = new UsersRepository(database);
@@ -324,8 +331,11 @@ class NotionController {
 
       await this.enforceJobLimit(jobRepository, id, owner, paying);
 
-      const safeString = (v: unknown): string | undefined =>
-        typeof v === 'string' && v.length > 0 ? v : undefined;
+      const correlation = {
+        requestId: safeString(res.locals.requestId),
+        jobId: job.id,
+        owner,
+      };
 
       runConversion({
         id,
@@ -339,8 +349,25 @@ class NotionController {
         anonId: safeString(anonId),
         signupOrigin: parseFirstTouch(cookies?.first_touch).signupOrigin,
         requestId: safeString(res.locals.requestId),
-      }).catch((err: unknown) => {
-        console.error('notion convert worker:', err);
+      }).catch(async (err: unknown) => {
+        if (isWorkerTerminationError(err)) {
+          console.info('[notion/convert] worker interrupted by pool drain', {
+            ...correlation,
+            pageId: id,
+          });
+          await jobRepository.updateJobStatus(
+            id,
+            owner,
+            'interrupted',
+            WORKER_INTERRUPTED_REASON
+          );
+          return;
+        }
+        console.error('[notion/convert] worker failed', {
+          ...correlation,
+          pageId: id,
+          error: err,
+        });
       });
 
       return res.status(202).json({ jobId: job.id, restarted });
@@ -351,7 +378,12 @@ class NotionController {
       if (err instanceof JobLimitError) {
         return res.status(402).json({ reason: 'free_plan_one_at_a_time' });
       }
-      console.error('[notion/convert] enqueue failed:', err);
+      console.error('[notion/convert] enqueue failed', {
+        requestId: safeString(res.locals.requestId),
+        owner,
+        pageId: id,
+        error: err,
+      });
       return res.status(500).json({ error: 'conversion failed' });
     }
   }

--- a/src/lib/conversionPool.test.ts
+++ b/src/lib/conversionPool.test.ts
@@ -1,6 +1,11 @@
 jest.mock('./storage/jobs/helpers/performConversion', () => ({
   __esModule: true,
   default: jest.fn().mockResolvedValue(undefined),
+  conversionLogPrefix: jest.fn(
+    (fields: { jobDbId: string | number; requestId?: string }) =>
+      `[conversion] job=${fields.jobDbId} request=${fields.requestId ?? 'none'}`
+  ),
+  trackConversionFailed: jest.fn(),
 }));
 
 const mockPoolRun = jest.fn();
@@ -25,7 +30,9 @@ jest.mock('piscina', () => {
   return { __esModule: true, default: fakePiscina };
 });
 
-import performConversion from './storage/jobs/helpers/performConversion';
+import performConversion, {
+  trackConversionFailed,
+} from './storage/jobs/helpers/performConversion';
 import NotionRepository from '../data_layer/NotionRespository';
 import BlocksCacheRepository from '../data_layer/BlocksCacheRepository';
 import JobRepository from '../data_layer/JobRepository';
@@ -166,6 +173,67 @@ describe('runConversionInWorker', () => {
       baseRequest.id,
       baseRequest.owner,
       NOTION_TOKEN_EXPIRED_REASON
+    );
+  });
+
+  it('logs a stamped line and tracks conversion_failed when the Notion token has expired', async () => {
+    (NotionRepository as jest.Mock).mockImplementation(() => ({
+      getNotionToken: jest.fn().mockResolvedValue(null),
+    }));
+    const infoSpy = jest
+      .spyOn(console, 'info')
+      .mockImplementation(() => undefined);
+    const fakeKnex = {} as unknown as Parameters<typeof performConversion>[0];
+
+    await runConversionInWorker(
+      { ...baseRequest, requestId: 'req-expired-1' },
+      () => fakeKnex
+    );
+
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        '[conversion] job=99 request=req-expired-1 notion token expired'
+      ),
+      { pageId: baseRequest.id }
+    );
+    expect(trackConversionFailed).toHaveBeenCalledWith(
+      baseRequest.owner,
+      baseRequest.anonId,
+      baseRequest.type,
+      null,
+      { reason: 'notion_token_expired' }
+    );
+    infoSpy.mockRestore();
+  });
+
+  it('forwards every worker-request field into performConversion via a structural spread', async () => {
+    const fakeKnex = {} as unknown as Parameters<typeof performConversion>[0];
+    const fullRequest = {
+      ...baseRequest,
+      frontField: 'Front',
+      backField: 'Back',
+      anonId: 'anon-1',
+      signupOrigin: '/pricing',
+      requestId: 'req-spread-1',
+    };
+
+    await runConversionInWorker(fullRequest, () => fakeKnex);
+
+    const [, request] = (performConversion as jest.Mock).mock.calls[0];
+    expect(request).toEqual(
+      expect.objectContaining({
+        id: fullRequest.id,
+        owner: fullRequest.owner,
+        isPaying: fullRequest.isPaying,
+        type: fullRequest.type,
+        title: fullRequest.title,
+        jobDbId: fullRequest.jobDbId,
+        frontField: 'Front',
+        backField: 'Back',
+        anonId: 'anon-1',
+        signupOrigin: '/pricing',
+        requestId: 'req-spread-1',
+      })
     );
   });
 

--- a/src/lib/conversionPool.ts
+++ b/src/lib/conversionPool.ts
@@ -8,7 +8,10 @@ import {
   UploadGenerationResult,
   UploadGenerationTask,
 } from '../usecases/uploads/uploadGenerationTypes';
-import performConversion from './storage/jobs/helpers/performConversion';
+import performConversion, {
+  conversionLogPrefix,
+  trackConversionFailed,
+} from './storage/jobs/helpers/performConversion';
 import NotionAPIWrapper from '../services/NotionService/NotionAPIWrapper';
 import NotionRepository from '../data_layer/NotionRespository';
 import BlocksCacheRepository from '../data_layer/BlocksCacheRepository';
@@ -20,22 +23,10 @@ import {
   resolveConversionWorkerRecycleTasks,
 } from './pythonWorkerBudget';
 import { MAX_OLD_GENERATION_SIZE_MB } from './conversionMemoryLimits';
+import type { ConversionWorkerRequest } from './conversionRequestTypes';
 
 export { resolveConversionWorkers } from './pythonWorkerBudget';
-
-export interface ConversionWorkerRequest {
-  id: string;
-  owner: string;
-  isPaying: boolean;
-  type?: string;
-  title: string;
-  jobDbId: string | number;
-  frontField?: string;
-  backField?: string;
-  anonId?: string;
-  signupOrigin?: string | null;
-  requestId?: string;
-}
+export type { ConversionWorkerRequest } from './conversionRequestTypes';
 
 let pool: Piscina | null = null;
 
@@ -219,6 +210,13 @@ export async function runConversionInWorker(
   const notionRepo = new NotionRepository(database);
   const token = await notionRepo.getNotionToken(request.owner);
   if (token == null) {
+    console.info(
+      `${conversionLogPrefix({
+        jobDbId: request.jobDbId,
+        requestId: request.requestId,
+      })} notion token expired — marking job failed`,
+      { pageId: request.id }
+    );
     const jobRepo = new JobRepository(database);
     const setJobFailed = new SetJobFailedUseCase(jobRepo);
     await setJobFailed.execute(
@@ -226,22 +224,16 @@ export async function runConversionInWorker(
       request.owner,
       NOTION_TOKEN_EXPIRED_REASON
     );
+    trackConversionFailed(
+      request.owner,
+      request.anonId,
+      request.type,
+      request.signupOrigin ?? null,
+      { reason: 'notion_token_expired' }
+    );
     return;
   }
   const blocksCache = new BlocksCacheRepository(database);
   const api = new NotionAPIWrapper(token, request.owner, blocksCache);
-  await performConversion(database, {
-    api,
-    id: request.id,
-    owner: request.owner,
-    isPaying: request.isPaying,
-    type: request.type,
-    title: request.title,
-    jobDbId: request.jobDbId,
-    frontField: request.frontField,
-    backField: request.backField,
-    anonId: request.anonId,
-    signupOrigin: request.signupOrigin,
-    requestId: request.requestId,
-  });
+  await performConversion(database, { ...request, api });
 }

--- a/src/lib/conversionRequestTypes.ts
+++ b/src/lib/conversionRequestTypes.ts
@@ -1,0 +1,13 @@
+export interface ConversionWorkerRequest {
+  id: string;
+  owner: string;
+  isPaying: boolean;
+  type?: string;
+  title: string;
+  jobDbId: string | number;
+  frontField?: string;
+  backField?: string;
+  anonId?: string;
+  signupOrigin?: string | null;
+  requestId?: string;
+}

--- a/src/lib/storage/jobs/helpers/performConversion.test.ts
+++ b/src/lib/storage/jobs/helpers/performConversion.test.ts
@@ -162,7 +162,10 @@ describe('performConversion — heavy pipeline', () => {
       baseRequest.owner,
       expect.any(String)
     );
-    expect(errorSpy).toHaveBeenCalledWith(boom);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/^\[conversion\] job=42 request=none failed$/),
+      expect.objectContaining({ error: boom })
+    );
   });
 
   it('marks job as failed when no decks are created', async () => {
@@ -962,6 +965,146 @@ describe('performConversion — workspace cleanup', () => {
       expect.objectContaining({
         props: expect.objectContaining({ source: 'notion' }),
       })
+    );
+  });
+});
+
+describe('performConversion — log correlation', () => {
+  let errorSpy: jest.SpyInstance;
+  let infoSpy: jest.SpyInstance;
+  let setJobFailedExecute: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    infoSpy = jest.spyOn(console, 'info').mockImplementation(() => undefined);
+    setJobFailedExecute = jest.fn().mockResolvedValue(undefined);
+    (SetJobFailedUseCase as jest.Mock).mockImplementation(() => ({
+      execute: setJobFailedExecute,
+    }));
+    (NotionRepository as jest.Mock).mockImplementation(() => ({
+      markTokenInvalid: jest.fn().mockResolvedValue(undefined),
+      setReconnectEmailSent: jest.fn().mockResolvedValue(false),
+    }));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function mockSuccessfulPipeline(): void {
+    (CreateJobWorkSpaceUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue({
+        ws: {},
+        exporter: {},
+        settings: {},
+        bl: {},
+        rules: {},
+      }),
+    }));
+    (CreateFlashcardsForJobUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue([{ cards: [1, 2, 3] }]),
+    }));
+    (CheckMonthlyCardLimitUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue(undefined),
+    }));
+    (BuildDeckForJobUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest
+        .fn()
+        .mockResolvedValue({ size: 1, key: 'k', apkg: Buffer.from('') }),
+    }));
+    (NotifyUserUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue(undefined),
+    }));
+    (CompleteJobUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue(undefined),
+    }));
+  }
+
+  it('stamps the start line with the [conversion] prefix and the db job id, keeping the raw page id out of the message', async () => {
+    mockSuccessfulPipeline();
+    const injectionId = 'page\ninjected-log-line';
+
+    await performConversion(mockDatabase, {
+      ...baseRequest,
+      id: injectionId,
+      jobDbId: 42,
+      requestId: 'req-start-1',
+    });
+
+    const startCall = infoSpy.mock.calls.find(
+      (call) =>
+        typeof call[0] === 'string' &&
+        call[0].startsWith('[conversion] job=42') &&
+        call[0].endsWith('started')
+    );
+    expect(startCall).toBeDefined();
+    expect(startCall?.[0]).toBe(
+      '[conversion] job=42 request=req-start-1 started'
+    );
+    expect(startCall?.[0]).not.toContain('injected-log-line');
+    expect(startCall?.[1]).toEqual({ pageId: injectionId });
+  });
+
+  it('emits a completion line carrying the db job id and request id so duration can be derived', async () => {
+    mockSuccessfulPipeline();
+
+    await performConversion(mockDatabase, {
+      ...baseRequest,
+      jobDbId: 42,
+      requestId: 'req-done-2',
+    });
+
+    const completedCall = infoSpy.mock.calls.find(
+      (call) =>
+        typeof call[0] === 'string' &&
+        call[0].startsWith('[conversion] job=42 request=req-done-2 completed')
+    );
+    expect(completedCall).toBeDefined();
+    expect(completedCall?.[0]).toContain('cards=3');
+    expect(completedCall?.[0]).toContain('duration_ms=');
+  });
+
+  it('hoists the request id into the failure message string, not onto its own object key', async () => {
+    (CreateJobWorkSpaceUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockRejectedValue(new Error('random error')),
+    }));
+
+    await performConversion(mockDatabase, {
+      ...baseRequest,
+      jobDbId: 42,
+      requestId: 'req-fail-3',
+    });
+
+    const failedCall = errorSpy.mock.calls.find(
+      (call) =>
+        typeof call[0] === 'string' && call[0].startsWith('[conversion] job=42')
+    );
+    expect(failedCall?.[0]).toBe(
+      '[conversion] job=42 request=req-fail-3 failed'
+    );
+    expect(failedCall?.[1]).not.toHaveProperty('requestId');
+  });
+
+  it('still marks the job failed when marking the notion token invalid throws', async () => {
+    (CreateJobWorkSpaceUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockRejectedValue(makeUnauthorizedError()),
+    }));
+    (NotionRepository as jest.Mock).mockImplementation(() => ({
+      markTokenInvalid: jest.fn().mockRejectedValue(new Error('db blip')),
+      setReconnectEmailSent: jest.fn().mockResolvedValue(false),
+    }));
+
+    await performConversion(mockDatabase, {
+      ...baseRequest,
+      owner: '42',
+      jobDbId: 42,
+    });
+
+    expect(setJobFailedExecute).toHaveBeenCalledWith(
+      baseRequest.id,
+      '42',
+      NOTION_TOKEN_EXPIRED_REASON
     );
   });
 });

--- a/src/lib/storage/jobs/helpers/performConversion.ts
+++ b/src/lib/storage/jobs/helpers/performConversion.ts
@@ -43,28 +43,27 @@ import { ConversionOutputStatsRepository } from '../../../../data_layer/Conversi
 import { truncateDecksToCardLimit } from '../../../parser/truncateDecksToCardLimit';
 import { MonthlyLimitPartial } from '../../../../services/NotionService/helpers/conversionTruncation';
 import { toCardCountBucket } from '../../../analytics/cardCountBucket';
+import type { ConversionWorkerRequest } from '../../../conversionRequestTypes';
 
 type ConversionSource = 'notion' | 'upload' | 'google_drive';
 
-function toConversionSource(type?: string): ConversionSource {
+export function toConversionSource(type?: string): ConversionSource {
   if (type === 'google_drive') return 'google_drive';
   if (type === 'page') return 'notion';
   return 'upload';
 }
 
-interface ConversionRequest {
-  title: string;
-  api: NotionAPIWrapper;
-  id: string;
-  owner: string;
-  isPaying: boolean;
-  type?: string;
+export interface ConversionLogFields {
   jobDbId: string | number;
-  frontField?: string;
-  backField?: string;
-  anonId?: string;
-  signupOrigin?: string | null;
   requestId?: string;
+}
+
+export function conversionLogPrefix(fields: ConversionLogFields): string {
+  return `[conversion] job=${fields.jobDbId} request=${fields.requestId ?? 'none'}`;
+}
+
+interface ConversionRequest extends ConversionWorkerRequest {
+  api: NotionAPIWrapper;
 }
 
 function toAnonymousId(anonId?: string): string | null {
@@ -73,7 +72,8 @@ function toAnonymousId(anonId?: string): string | null {
 
 async function recordUnsupportedBlocks(
   database: Knex,
-  types: string[]
+  types: string[],
+  logPrefix: string
 ): Promise<void> {
   if (types == null || types.length === 0) {
     return;
@@ -81,13 +81,14 @@ async function recordUnsupportedBlocks(
   try {
     await new UnsupportedNotionBlockRepository(database).record(types);
   } catch (error) {
-    console.error('[conversion] failed to record unsupported blocks', error);
+    console.error(`${logPrefix} failed to record unsupported blocks`, error);
   }
 }
 
 async function recordConversionOutputStats(
   database: Knex,
-  delta: { decks: number; cards: number; emptyBack: number }
+  delta: { decks: number; cards: number; emptyBack: number },
+  logPrefix: string
 ): Promise<void> {
   try {
     await new ConversionOutputStatsRepository(database).record(
@@ -96,7 +97,7 @@ async function recordConversionOutputStats(
     );
   } catch (error) {
     console.error(
-      '[conversion] failed to record conversion output stats',
+      `${logPrefix} failed to record conversion output stats`,
       error
     );
   }
@@ -130,7 +131,8 @@ async function recordDeckScore(
     // below the floor, and — for a rejected rescue — the shape of the deck the
     // induction actually judged rather than the empty deck that ships.
     induced?: InducedRescue;
-  }
+  },
+  logPrefix: string
 ): Promise<void> {
   const ownerId = Number(entry.owner);
   const induced = entry.induced;
@@ -156,7 +158,7 @@ async function recordDeckScore(
         ),
     });
   } catch (error) {
-    console.error('[conversion] failed to record deck score', error);
+    console.error(`${logPrefix} failed to record deck score`, error);
   }
 }
 
@@ -165,13 +167,18 @@ async function recordConversionTelemetry(
   telemetry: {
     unsupportedBlockTypes: string[];
     stats: { decks: number; cards: number; emptyBack: number };
-  }
+  },
+  logPrefix: string
 ): Promise<void> {
-  await recordUnsupportedBlocks(database, telemetry.unsupportedBlockTypes);
-  await recordConversionOutputStats(database, telemetry.stats);
+  await recordUnsupportedBlocks(
+    database,
+    telemetry.unsupportedBlockTypes,
+    logPrefix
+  );
+  await recordConversionOutputStats(database, telemetry.stats, logPrefix);
 }
 
-function trackConversionFailed(
+export function trackConversionFailed(
   owner: string,
   anonId: string | undefined,
   type: string | undefined,
@@ -221,7 +228,9 @@ export default async function performConversion(
     requestId,
   }: ConversionRequest
 ) {
-  console.info(`Performing conversion for ${id}`, { requestId, jobId: id });
+  const logPrefix = conversionLogPrefix({ jobDbId, requestId });
+  const startedAt = Date.now();
+  console.info(`${logPrefix} started`, { pageId: id });
   const resolvedSignupOrigin = signupOrigin ?? null;
 
   const storage = new StorageHandler();
@@ -273,13 +282,17 @@ export default async function performConversion(
     const cardCount = decks.reduce((acc, d) => acc + d.cards.length, 0);
     // Recorded before the empty-deck return so a zero-card Notion conversion
     // still lands a row; without the failures the baseline is only the wins.
-    await recordDeckScore(database, {
-      owner,
-      type,
-      decks,
-      cardCount,
-      induced: bl.inducedRule,
-    });
+    await recordDeckScore(
+      database,
+      {
+        owner,
+        type,
+        decks,
+        cardCount,
+        induced: bl.inducedRule,
+      },
+      logPrefix
+    );
     if (cardCount === 0) {
       const setJobFailed = new SetJobFailedUseCase(jobRepository);
       await setJobFailed.execute(id, owner, EMPTY_DECK_FAILURE_REASON);
@@ -389,14 +402,18 @@ export default async function performConversion(
       })
     );
 
-    void recordConversionTelemetry(database, {
-      unsupportedBlockTypes: bl.unsupportedBlockTypes,
-      stats: {
-        decks: decks.length,
-        cards: cardLimitPartial ? deliveredCardCount : bl.cardCount,
-        emptyBack: bl.emptyBackCount,
+    void recordConversionTelemetry(
+      database,
+      {
+        unsupportedBlockTypes: bl.unsupportedBlockTypes,
+        stats: {
+          decks: decks.length,
+          cards: cardLimitPartial ? deliveredCardCount : bl.cardCount,
+          emptyBack: bl.emptyBackCount,
+        },
       },
-    });
+      logPrefix
+    );
 
     if (cardLimitPartial) {
       trackCardLimitPaywall(owner, anonId, type);
@@ -418,32 +435,41 @@ export default async function performConversion(
           : {}),
       },
     });
+    console.info(
+      `${logPrefix} completed cards=${deliveredCardCount} duration_ms=${Date.now() - startedAt}`
+    );
   } catch (error) {
     if (error instanceof PythonExitError) {
-      console.error('[conversion] python crash', {
-        jobId: id,
-        requestId,
+      console.error(`${logPrefix} python crash`, {
+        pageId: id,
         kind: error.kind,
         code: error.code,
         rawOutput: error.rawOutput,
       });
     } else {
-      console.error('[conversion] failed', { jobId: id, requestId, error });
+      console.error(`${logPrefix} failed`, { pageId: id, error });
     }
     if (isNotionUnauthorizedError(error)) {
       const ownerNum = Number(owner);
       if (Number.isFinite(ownerNum)) {
-        const notionRepo = new NotionRepository(database);
-        await new MarkNotionTokenInvalidUseCase(
-          notionRepo,
-          new UsersRepository(database),
-          getDefaultEmailService()
-        ).execute(ownerNum);
+        try {
+          const notionRepo = new NotionRepository(database);
+          await new MarkNotionTokenInvalidUseCase(
+            notionRepo,
+            new UsersRepository(database),
+            getDefaultEmailService()
+          ).execute(ownerNum);
+        } catch (markError) {
+          console.error(`${logPrefix} failed to mark notion token invalid`, {
+            error: markError,
+          });
+        }
       }
     }
     const failedJob = new SetJobFailedUseCase(jobRepository);
-    await persistJobFailureWithRetry(() =>
-      failedJob.execute(id, owner, jobFailureReasonFromError(error, id))
+    await persistJobFailureWithRetry(
+      () => failedJob.execute(id, owner, jobFailureReasonFromError(error, id)),
+      { logContext: logPrefix }
     );
     trackConversionFailed(owner, anonId, type, resolvedSignupOrigin, {
       reason: jobFailureReasonCode(error),
@@ -453,22 +479,17 @@ export default async function performConversion(
       isColumnsAmbiguousError(error) ||
       isNotionUnauthorizedError(error);
     if (isExpectedUserState) {
-      console.info('[conversion] user-input state', {
-        jobId: id,
-        requestId,
-        kind: error instanceof Error ? error.name : 'unknown',
-      });
-    } else {
-      console.error(error);
+      console.info(
+        `${logPrefix} user-input state kind=${error instanceof Error ? error.name : 'unknown'}`
+      );
     }
   } finally {
     if (workspaceLocation != null) {
       try {
         fs.rmSync(workspaceLocation, { recursive: true, force: true });
       } catch (cleanupError) {
-        console.error('[conversion] workspace cleanup failed', {
-          jobId: id,
-          requestId,
+        console.error(`${logPrefix} workspace cleanup failed`, {
+          pageId: id,
           message:
             cleanupError instanceof Error ? cleanupError.message : 'unknown',
         });

--- a/src/lib/storage/jobs/helpers/persistJobFailureWithRetry.test.ts
+++ b/src/lib/storage/jobs/helpers/persistJobFailureWithRetry.test.ts
@@ -77,4 +77,25 @@ describe('persistJobFailureWithRetry', () => {
     expect(write).toHaveBeenCalledTimes(4);
     expect(sleepFn).toHaveBeenCalledTimes(3);
   });
+
+  it('stamps the retry warning with the caller-supplied correlation prefix', async () => {
+    const write = jest
+      .fn()
+      .mockRejectedValueOnce(connectionError('ECONNREFUSED'))
+      .mockResolvedValueOnce(undefined);
+    const sleepFn = jest.fn().mockResolvedValue(undefined);
+    const warnSpy = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+
+    await persistJobFailureWithRetry(write, {
+      sleepFn,
+      logContext: '[conversion] job=42 request=req-9',
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[conversion] job=42 request=req-9 failure write')
+    );
+    warnSpy.mockRestore();
+  });
 });

--- a/src/lib/storage/jobs/helpers/persistJobFailureWithRetry.ts
+++ b/src/lib/storage/jobs/helpers/persistJobFailureWithRetry.ts
@@ -31,9 +31,13 @@ function sleep(ms: number): Promise<void> {
 
 export async function persistJobFailureWithRetry(
   write: () => Promise<unknown>,
-  options: { sleepFn?: (ms: number) => Promise<void> } = {}
+  options: {
+    sleepFn?: (ms: number) => Promise<void>;
+    logContext?: string;
+  } = {}
 ): Promise<void> {
   const doSleep = options.sleepFn ?? sleep;
+  const logPrefix = options.logContext ?? '[conversion]';
   let lastError: unknown;
   for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt++) {
     try {
@@ -48,7 +52,7 @@ export async function persistJobFailureWithRetry(
         throw error;
       }
       console.warn(
-        `[conversion] failure write hit a connection error; retrying in ${RETRY_DELAYS_MS[attempt]}ms`
+        `${logPrefix} failure write hit a connection error; retrying in ${RETRY_DELAYS_MS[attempt]}ms`
       );
       await doSleep(RETRY_DELAYS_MS[attempt]);
     }

--- a/src/usecases/jobs/CreateJobWorkSpaceUseCase.test.ts
+++ b/src/usecases/jobs/CreateJobWorkSpaceUseCase.test.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { CreateJobWorkSpaceUseCase } from './CreateJobWorkSpaceUseCase';
 import JobRepository from '../../data_layer/JobRepository';
 import { ISettingsRepository } from '../../data_layer/SettingsRepository';
@@ -77,6 +80,36 @@ describe('CreateJobWorkSpaceUseCase', () => {
       'user-7',
       'page-42'
     );
+  });
+
+  it('removes the created workspace directory when settings load rejects', async () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'cjws-orphan-'));
+    const previousBase = process.env.WORKSPACE_BASE;
+    process.env.WORKSPACE_BASE = base;
+    const rejectingSettings: ISettingsRepository = {
+      ...settingsRepository,
+      load: jest.fn().mockRejectedValue(new Error('settings db down')),
+    };
+    const useCase = new CreateJobWorkSpaceUseCase(
+      jobRepository,
+      rejectingSettings,
+      parserRulesRepository
+    );
+
+    await expect(
+      useCase.execute({
+        id: 'orphan-page',
+        owner: 'orphan-owner',
+        api: mockApi,
+        jobRepository,
+        isPaying: false,
+      })
+    ).rejects.toThrow('settings db down');
+
+    expect(fs.readdirSync(base)).toEqual([]);
+
+    process.env.WORKSPACE_BASE = previousBase;
+    fs.rmSync(base, { recursive: true, force: true });
   });
 
   it('throws when the job-status update fails', async () => {

--- a/src/usecases/jobs/CreateJobWorkSpaceUseCase.ts
+++ b/src/usecases/jobs/CreateJobWorkSpaceUseCase.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import NotionAPIWrapper from '../../services/NotionService/NotionAPIWrapper';
 import JobRepository from '../../data_layer/JobRepository';
 import { ISettingsRepository } from '../../data_layer/SettingsRepository';
@@ -50,20 +51,25 @@ export class CreateJobWorkSpaceUseCase {
     const ws = new Workspace(true, 'fs');
     console.debug(`using workspace ${ws.location}`);
 
-    const exporter = new CustomExporter('', ws.location);
-    const settings = await this.settingsRepository.load(owner, id);
-    console.debug(`using settings ${JSON.stringify(settings, null, 2)}`);
+    try {
+      const exporter = new CustomExporter('', ws.location);
+      const settings = await this.settingsRepository.load(owner, id);
+      console.debug(`using settings ${JSON.stringify(settings, null, 2)}`);
 
-    const bl = new BlockHandler(
-      exporter,
-      api,
-      settings,
-      this.settingsRepository,
-      owner
-    );
-    const rules = await this.parserRulesRepository.load(owner, id);
-    bl.useAll = input.isPaying;
+      const bl = new BlockHandler(
+        exporter,
+        api,
+        settings,
+        this.settingsRepository,
+        owner
+      );
+      const rules = await this.parserRulesRepository.load(owner, id);
+      bl.useAll = input.isPaying;
 
-    return { ws, exporter, settings, bl, rules };
+      return { ws, exporter, settings, bl, rules };
+    } catch (error) {
+      fs.rmSync(ws.location, { recursive: true, force: true });
+      throw error;
+    }
   }
 }

--- a/web/src/pages/WhatsNewPage/changelog/2026-09-01-notion-conversion-interrupted-retry.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-09-01-notion-conversion-interrupted-retry.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-09-01-notion-conversion-interrupted-retry",
+  "date": "2026-09-01",
+  "type": "fix",
+  "title": "A Notion conversion caught by a server restart now tells you to convert again right away"
+}


### PR DESCRIPTION
## What
Closes the correlation gaps and latent defects that the execution-verified review of #4317 recorded on the Notion conversion path. Every conversion lifecycle log line now carries `[conversion] job=<dbRowId> request=<id>`, and five pre-existing defects in the touched functions are fixed.

## Why
The #4198 request-id threading stopped short on exactly the catch paths that a failing conversion hits, so a user-reported job could not be joined to server logs. `Closes #4325`.

## How — per-item status

### Correlation gaps (all fixed)
- **NotionController fire-and-forget `.catch` + enqueue-failed catch** — both now log `requestId`, `jobId` (the DB row id from the 202), and `owner`. The worker `.catch` also classifies `isWorkerTerminationError` (see defect below).
- **conversionPool token-expired early return** — now emits a stamped `[conversion] job=… request=… notion token expired` line before failing the job.
- **performConversion bare `console.error(error)`** — removed. It was an unstamped duplicate of the stamped `[conversion] … failed` line, which already logs the error object (with stack). Nothing is lost; the unattributable dump is gone.
- **Start line + success/terminal line + hoisted requestId** — start line is now `[conversion] job=… request=… started`; a new `… completed cards=N duration_ms=M` line makes completion/duration derivable; every failure/state line hoists the ids into the message string (like `recordClaudeUsage`'s `request=`) instead of rendering `requestId` on its own object key.
- **persistJobFailureWithRetry warn + the three telemetry-helper error lines (`recordUnsupportedBlocks`/`recordConversionOutputStats`/`recordDeckScore`)** — all now receive and stamp the same `[conversion] job=… request=…` prefix.
- **`jobId` bound the Notion page UUID; users see the DB row id** — log key is now `job=<jobDbId>` (the id returned in the 202, i.e. the one a user can report); the raw Notion page id moves to a structured `pageId` field.

### Pre-existing defects in the touched functions (all fixed)
- **Killed Notion worker stranded the job `started`** — the controller `.catch` now marks it `interrupted` with the existing `WORKER_INTERRUPTED_REASON`, mirroring the upload path (UploadService.ts:562/1058).
- **Token-expired exit never fired `conversion_failed`** — now tracks it with `reason: notion_token_expired`, so the funnel stops under-counting to zero.
- **`MarkNotionTokenInvalidUseCase.execute` awaited unguarded inside the catch** — now wrapped so a DB blip can no longer escape past `persistJobFailureWithRetry` and strand the job non-terminal.
- **Raw `req.body.id` interpolated into the start log template (CWE-117)** — the page id is out of the format string; it goes to a structured field where `util.inspect` escapes control characters.
- **Workspace dir orphaned when settings/rules load rejects before `workspaceLocation` was assigned** — `CreateJobWorkSpaceUseCase` now cleans up the workspace it created if the load rejects, then rethrows.

### Hardening
- **Hand-transcribed `ConversionWorkerRequest` → `ConversionRequest`** — the request is now spread structurally (`{ ...request, api }`) and `ConversionRequest extends ConversionWorkerRequest`, so a dropped field can no longer compile clean and arrive `undefined` (the #4198 bug class). The shared shape moved to `src/lib/conversionRequestTypes.ts` so the two modules link through a type instead of a hand copy, with no runtime import cycle.
- **Tests asserted plumbing, not log output** — added assertions on the actual log lines (start prefix + no page-id injection, completion line, requestId hoisted into the failure message, stamped retry warning, stamped token-expired line) so a refactor that drops the ids from the log objects now goes red.

## Not actionable (observations, no change warranted)
- **Webhook routers mount above `requestIdMiddleware` (server.ts:163-165 vs 171).** Moving them is a middleware-order change on a hard-rail path (`src/server.ts`), for marginal benefit — webhook traffic is server-to-server, there is no user to report an echoed id — and it risks the raw-body ordering that HMAC verification depends on. It would also flip this otherwise-safe PR onto the manual hard-rail track. Deliberately out of scope; a separate PR if we ever want webhook correlation.
- **No client surface retains the echoed `X-Request-Id`.** Surfacing the id in the error UI so a user can quote it is a user-facing UX change that needs trio review; out of scope for an internal-correlation follow-up.
- **Inbound UUID-shaped `X-Request-Id` honored verbatim.** This is deliberate (a proxy or the native app threads its own id) and the value is UUID-validated, so it cannot carry a log-injection payload. Not a defect.

## Measuring success
- Grep prod logs for `[conversion] job=<id>` and join by `request=<uuid>` across controller, worker, and failure lines — previously the failure paths dropped out of the join. The new `… completed … duration_ms=` line makes per-job duration derivable.
- `/api/ops/metrics`: `conversion_failed` with `reason: notion_token_expired` should now be non-zero (it was structurally zero before).

## Testing
- Unit tests added/updated: NotionController (worker-failure log fields, interrupted-on-drain, enqueue-failed log fields), conversionPool (stamped token-expired line + `conversion_failed` track, structural spread), performConversion (start-line prefix + no page-id injection, completion line, hoisted-requestId failure line, mark-token-invalid guarded), persistJobFailureWithRetry (stamped retry warning), CreateJobWorkSpaceUseCase (orphan cleanup).
- Full server Jest suite: 697 suites / 6815 tests pass; the 9 failing suites are the documented environmental exclusions only — 8 parser/canary suites that spawn Python (no `create_deck/.venv` in the worktree) and `getPageCount` (pdfinfo). None of the five touched suites are among them.
- Full web Vitest suite: 384 files / 3505 tests pass (the changelog loader validated the new entry). `tsc -p . --noEmit` clean; web `tsc --noEmit` clean; `pnpm format:check` clean; `pnpm arch` 0 errors (no new circular warning).
- Sonar: not run locally; PR decoration will report.

## Browser check
Browser check: not applicable — the only `web/src` change is a changelog JSON data file; no component or rendered logic changed.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-09-01-notion-conversion-interrupted-retry.json` — "A Notion conversion caught by a server restart now tells you to convert again right away". Reuses the already-shipped `WORKER_INTERRUPTED_REASON` string, so no new i18n string. The rest of the PR is internal observability/hardening with no user-visible surface.

## Risks
Low. The changes are logging-format and error-handling within existing catch paths; the one behavioral change (marking a drained Notion worker `interrupted`) mirrors the upload path and guards against overwriting a `done` job. Rollback is a straight revert — no schema, no migration, no new env flag.

## Goal alignment
None on the acquisition funnel — internal reliability/observability. It does move the retention/quality lever: stuck-forever Notion jobs now resolve to a clear retry, the token-expired funnel stops mis-reading zero at `/api/ops/metrics`, and every failed conversion becomes joinable to a user-reported job id, which shortens support turnaround on the paid Notion path.
