### PR TITLE
fix: pay down instruction-preset review debt from #4324

### DIFF
--- a/web/src/components/CardOptionsForm/CardOptionsForm.module.css
+++ b/web/src/components/CardOptionsForm/CardOptionsForm.module.css
@@ -77,37 +77,11 @@
 }
 
 .instructionChip {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 1rem;
-  background: var(--color-bg-primary);
-  color: var(--color-text-primary);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  font-size: var(--text-sm);
-  font-weight: var(--font-medium);
-  cursor: pointer;
-  transition:
-    background var(--transition-fast),
-    border-color var(--transition-fast),
-    box-shadow var(--transition-fast);
-}
-
-.instructionChip:hover {
-  border-color: var(--color-text-tertiary);
-  background: var(--color-bg-secondary);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
-}
-
-.instructionChip:focus-visible {
-  outline: 2px solid var(--color-focus-ring);
-  outline-offset: 2px;
+  composes: toggleChip from '../../styles/shared.module.css';
 }
 
 .instructionChipActive {
-  border-color: var(--color-primary);
-  background: var(--color-primary-light);
+  composes: toggleChipActive from '../../styles/shared.module.css';
 }
 
 .loading {

--- a/web/src/components/CardOptionsForm/CardOptionsForm.presets.parity.test.ts
+++ b/web/src/components/CardOptionsForm/CardOptionsForm.presets.parity.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  DEFAULT_USER_INSTRUCTIONS,
+  INSTRUCTION_PRESETS,
+} from './CardOptionsForm';
+
+function readServerDefaultInstructions(): string {
+  const serverSource = readFileSync(
+    join(
+      __dirname,
+      '../../../../src/infrastracture/adapters/fileConversion/convertPDFToHTML.ts'
+    ),
+    'utf8'
+  );
+  const match = serverSource.match(
+    /const DEFAULT_PDF_TO_HTML_INSTRUCTIONS = `([\s\S]*?)`;/
+  );
+  if (!match) {
+    throw new Error(
+      'DEFAULT_PDF_TO_HTML_INSTRUCTIONS not found in convertPDFToHTML.ts'
+    );
+  }
+  return match[1];
+}
+
+describe('web/server default user instructions parity', () => {
+  it('matches the server default so a chip tap never freezes a drifted copy', () => {
+    expect(DEFAULT_USER_INSTRUCTIONS.trim()).toEqual(
+      readServerDefaultInstructions().trim()
+    );
+  });
+});
+
+describe('instruction preset sentence versioning', () => {
+  it('pins the exact sentences so a reword forces a stored-copy migration map', () => {
+    expect(INSTRUCTION_PRESETS.map((preset) => preset.sentence)).toEqual([
+      "Write multiple-choice questions. Put the question and all answer options (A, B, C, D) on the front of the card; put only the correct option's letter on the back.",
+      'Make a separate card for each list item instead of grouping a list onto one card.',
+    ]);
+  });
+});

--- a/web/src/components/CardOptionsForm/CardOptionsForm.test.tsx
+++ b/web/src/components/CardOptionsForm/CardOptionsForm.test.tsx
@@ -802,6 +802,21 @@ describe('CardOptionsForm user instructions disclosure', () => {
     });
     expect(summary.closest('details')).not.toHaveAttribute('open');
   });
+
+  it('opens the box when the pdf-ai anchor is reached on an already-mounted form', async () => {
+    renderForm(true, { onReset: vi.fn(), setError: vi.fn() });
+    const summary = await screen.findByText(/instructions/i, {
+      selector: 'summary',
+    });
+    expect(summary.closest('details')).not.toHaveAttribute('open');
+
+    window.location.hash = '#pdf-ai';
+    fireEvent(window, new Event('hashchange'));
+
+    await waitFor(() => {
+      expect(summary.closest('details')).toHaveAttribute('open');
+    });
+  });
 });
 
 describe('CardOptionsForm card style picker', () => {

--- a/web/src/components/CardOptionsForm/CardOptionsForm.tsx
+++ b/web/src/components/CardOptionsForm/CardOptionsForm.tsx
@@ -109,17 +109,17 @@ const MCQ_TTS_LANGUAGE_OPTIONS = [
   { label: 'Mandarin (Simplified)', value: 'zh_CN' },
   { label: 'Portuguese (Brazil)', value: 'pt_BR' },
 ] as const;
-const DEFAULT_USER_INSTRUCTIONS = `Some extra rules and explanations:
+export const DEFAULT_USER_INSTRUCTIONS = `Some extra rules and explanations:
 - Read the document from start to finish and identify any question and answers.
 - Use the same language as the document or infer the language based on what is mostly used.
-- Use the same text as the document and do not make up any questions or answers.
+- Use the same text as in the document and do not make up any questions or answers.
 - Cite the document as source for the text.
 - Be complete by finding all of the questions and answer in the document.
 - Do not limit the number of number of questions and answer but create all of them!
 - Do not make up any questions and use the questions in the document!
 - Create a ul for every question pair, not one ul for all of them with li!`;
 
-const INSTRUCTION_PRESETS = [
+export const INSTRUCTION_PRESETS = [
   {
     id: 'mcq_front',
     labelKey: 'cardOptions.userInstructions.presets.mcqOnFront.label',
@@ -448,6 +448,16 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
     const [justSaved, setJustSaved] = useState(false);
     const [saveFailed, setSaveFailed] = useState(false);
     const savingRef = useRef(false);
+
+    useEffect(() => {
+      const openOnPdfAiAnchor = () => {
+        if (window.location.hash === '#pdf-ai') {
+          setInstructionsOpen(true);
+        }
+      };
+      window.addEventListener('hashchange', openOnPdfAiAnchor);
+      return () => window.removeEventListener('hashchange', openOnPdfAiAnchor);
+    }, []);
 
     useEffect(() => {
       if (!options) return;

--- a/web/src/pages/UploadPage/components/UploadForm/UploadSourceChips.module.css
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadSourceChips.module.css
@@ -39,42 +39,11 @@
 }
 
 .chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 1rem;
-  background: var(--color-bg-primary);
-  color: var(--color-text-primary);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  font-size: var(--text-sm);
-  font-weight: var(--font-medium);
-  cursor: pointer;
-  transition:
-    background var(--transition-fast),
-    border-color var(--transition-fast),
-    box-shadow var(--transition-fast);
-}
-
-.chip:hover:not(:disabled) {
-  border-color: var(--color-text-tertiary);
-  background: var(--color-bg-secondary);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
-}
-
-.chip:focus-visible {
-  outline: 2px solid var(--color-focus-ring);
-  outline-offset: 2px;
-}
-
-.chip:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
+  composes: toggleChip from '../../../../styles/shared.module.css';
 }
 
 .chipActive {
-  border-color: var(--color-primary);
-  background: var(--color-primary-light);
+  composes: toggleChipActive from '../../../../styles/shared.module.css';
 }
 
 .dropboxIcon,

--- a/web/src/styles/shared.module.css
+++ b/web/src/styles/shared.module.css
@@ -1114,6 +1114,45 @@
   color: var(--color-primary);
 }
 
+.toggleChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast);
+}
+
+.toggleChip:hover:not(:disabled) {
+  border-color: var(--color-text-tertiary);
+  background: var(--color-bg-secondary);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+.toggleChip:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.toggleChip:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.toggleChipActive {
+  border-color: var(--color-primary);
+  background: var(--color-primary-light);
+}
+
 .marginTopSm {
   margin-top: 0.75rem;
 }


### PR DESCRIPTION
## What
Pays down the deferred review debt from the instruction-presets PR (#4324), tracked in #4330. Four actionable items land as code; two are recorded as documented decisions.

## Why
The presets shipped with five review findings recorded as debt so they'd be decisions, not accidents. This closes the loop: a latent navigation bug, a silent web/server default-copy drift, a versioning gap, and a third copy of the toggle-chip CSS.

## How
- **Hash-navigation fix**: a `hashchange` listener on `CardOptionsForm` reopens the PDF & AI instructions disclosure when back/forward lands on the `#pdf-ai` anchor. Previously `instructionsOpen` was captured once at mount, so an already-mounted form ignored the anchor.
- **Default-block drift**: the web `DEFAULT_USER_INSTRUCTIONS` seed differed from the server `DEFAULT_PDF_TO_HTML_INSTRUCTIONS` by one word ("as the document" vs "as in the document"). Aligned the web copy to the server, and added a parity tripwire test that reads the server source as text and fails if the two bodies ever diverge again.
- **Sentence versioning**: a tripwire test pins the exact preset sentences so any future reword fails loudly, forcing the author to ship a stored-copy migration map in the same PR (the chips match stored copies by verbatim equality).
- **CSS dedup**: the toggle-chip recipe hit its third copy, so it's promoted to `.toggleChip` / `.toggleChipActive` in `shared.module.css`; `UploadSourceChips` and `CardOptionsForm` now `composes` from it. Computed styles are byte-identical (same declarations, same hover specificity).

## Per-item status (from #4330)
1. **Preset-sentence versioning** — DONE (guard). Added a tripwire test pinning the sentences; a reword now fails CI and forces a migration-map decision. Did not build migration infrastructure (no sentence has changed — premature).
2. **Two MCQ mechanisms in one form** — DECISION (documented, no code change). See "Decisions made overnight".
3. **Default-block freeze** — PARTIAL + DECISION. Drift fixed and a parity tripwire added; the full delta-persistence redesign is deferred (documented below).
4. **Hash-navigation regression** — DONE (fixed with a `hashchange` listener + test).
5. **Chip CSS third copy** — DONE (promoted one shared class; both call sites compose from it).

## Decisions made overnight (please review)
- **Item 2 — keep the two MCQ mechanisms separate, do not couple the chip to the real option.** The `mcq_front` chip appends prose to the user instructions on the Claude PDF/AI path. The structured `mcq-enabled` checkbox + n2a-mcq template is a different pipeline (Notion → structured MCQ note type). Teaching the chip to flip `mcq-enabled` would enable structured MCQ output on conversions the user did not ask for and conflate two independent features. Kept them split; recording that as the decision rather than shipping the coupling.
- **Item 3 — fix the drift + add a tripwire, but do NOT persist only the delta.** The literal "persist only preset/user lines, not the default block" is not viable without a server-side change: the server applies its default via `input['user-instructions'] ?? getDefaultUserInstructions()` (nullish coalescing), so a stored delta would be sent as-is and the model would lose the entire default guidance block. Making it safe would require the server to *merge* default + user lines on a paid Claude inference path (cost/latency/token and prompt-caching implications, plus double-application risk for users who kept the default). That redesign is out of scope for a debt-paydown PR. The drift fix + parity tripwire neutralize the concrete named harm (the one-word divergence) and prevent recurrence: the two defaults are now identical and a test blocks any silent future drift. Limitation, stated plainly: users who already froze the old block in localStorage still won't retro-receive future server prompt improvements — only a server-side merge would fix that, and it wasn't worth the inference-path risk here.

## Measuring success
No new metric. The existing `ai_preset_applied` event (from #4324, read at `/api/ops/metrics`) is unchanged. The two tripwire tests are the measurable guard — a future default reword or preset reword turns the relevant parity/versioning test red in CI.

## Testing
- Unit tests added: `hashchange` reopens the disclosure on an already-mounted form (`CardOptionsForm.test.tsx`); web/server default-instructions parity + preset-sentence versioning tripwires (`CardOptionsForm.presets.parity.test.ts`).
- Full web vitest: 385 files / 3518 tests pass.
- Web `tsc --noEmit`: clean. `pnpm format:check` (tree-wide): clean. `pnpm --filter 2anki-web build`: succeeds (confirms the cross-file `composes` resolve).
- No `src/` source changed (the parity test only *reads* server source as text), so the server Jest suite is not in scope for this PR.
- Sonar: not run locally; PR decoration will report.

## Browser check
- [x] Golden path on localhost:3000 — `pnpm --filter 2anki-web test:golden-path`, 4/4 passed
- [x] No console errors at 375px — covered by the golden-path 375px specs (landing, dashboard, account), all green

## Changelog
No entry — internal debt-paydown (CSS dedup, drift + versioning tripwires). The one user-facing behavior fix (the instructions box reopening on back/forward to `#pdf-ai`) is an edge case a real user would not perceive, so per the changelog doc's "don't add one if they wouldn't" it gets no What's New line.

## Risks
- CSS dedup touches the high-traffic upload page's source chips. Mitigated: the promoted class carries byte-identical declarations and the same hover specificity, the web build compiles the composes, and both component test suites pass. Rollback is a one-commit revert.
- The parity tripwire couples a web test to a server-source string; if the server file is renamed the test's `readFileSync` path must move. Low likelihood, loud failure.

## Goal alignment
None — internal. Debt-paydown on an existing paid-user surface (the AI card-options form). No funnel/revenue metric moves; it lowers future maintenance cost and prevents a class of silent regression on the presets feature.

Closes #4330

no changelog entry — internal debt-paydown; the niche hash-navigation fix would not be perceived by users