### PR TITLE
feat: reprice passes ($6/$12/$29) and re-weight the pricing page

### DIFF
--- a/web/src/components/UpsellCard/UpsellCard.test.tsx
+++ b/web/src/components/UpsellCard/UpsellCard.test.tsx
@@ -69,7 +69,7 @@ describe('UpsellCard', () => {
     mockUseUserLocals.mockReturnValue(freeUser);
     renderCard(<UpsellCard surface="downloads_upsell" />);
     expect(
-      screen.getByRole('button', { name: 'Get Day Pass — $4' })
+      screen.getByRole('button', { name: 'Get Day Pass — $6' })
     ).toBeInTheDocument();
     const plans = screen.getByRole('link', { name: 'See plans' });
     expect(plans).toHaveAttribute('href', '/pricing');

--- a/web/src/lib/i18n/locales/de/common.json
+++ b/web/src/lib/i18n/locales/de/common.json
@@ -352,7 +352,7 @@
     "tryFree": "Kostenlos einen Stapel konvertieren",
     "socialProof": "Von über 15 000 Lernenden weltweit genutzt",
     "payOnceSection": "Einmal zahlen — kein Abo",
-    "monthlySection": "Monatliche Tarife",
+    "monthlySection": "Lieber ein Abo?",
     "pricesNote": "Preise in USD. Deine Karte wird beim Checkout in deiner lokalen Währung belastet.",
     "reassuranceCancel": "Jederzeit kündbar — ein Klick",
     "reassuranceOwn": "Deine Stapel gehören dir — natives .apkg, funktioniert in jedem Anki-Client",
@@ -368,17 +368,20 @@
       "nativeApkg": "Natives .apkg — funktioniert in jedem Anki-Client",
       "imageOcclusion": "Unbegrenzte Bildverdeckung",
       "mostPopular": "Am beliebtesten",
-      "payOnce": "Einmal zahlen",
       "day24": "— 24 Stunden",
       "week1": "— 1 Woche",
       "redirecting": "Weiterleitung…",
       "getDayPass": "Day Pass holen",
       "getWeekPass": "Week Pass holen",
       "semester4mo": "— 4 Monate",
-      "getSemesterPass": "Semester Pass holen"
+      "getSemesterPass": "Semester Pass holen",
+      "bestValue": "Bester Wert",
+      "horizonDay": "Ein Lerntag",
+      "horizonWeek": "Eine Prüfungswoche",
+      "horizonSemester": "Ein ganzes Semester",
+      "semesterPerWeek": "≈$2/Woche — 85 % weniger als der Week Pass"
     },
     "unlimited": {
-      "mostPopular": "Am beliebtesten",
       "perMonth": "/ Monat",
       "yearlyHint": "{{annualTotal}} heute fällig, dann jährlich · spare {{savings}} %",
       "monthlyHint": "{{monthlyTotal}} heute fällig, dann monatlich",
@@ -399,7 +402,8 @@
       "getUnlimitedMonthly": "Unlimited holen — monatliche Abrechnung",
       "termsYearly": "{{annualTotal}} heute fällig, verlängert sich jährlich. Jederzeit kündbar — der Zugang bleibt bis zum Ende des bezahlten Jahres.",
       "termsMonthly": "{{monthlyTotal}} heute fällig, verlängert sich monatlich. Jederzeit kündbar.",
-      "checkoutError": "Der Checkout konnte nicht gestartet werden. Versuch es erneut oder schreib an support@2anki.net."
+      "checkoutError": "Der Checkout konnte nicht gestartet werden. Versuch es erneut oder schreib an support@2anki.net.",
+      "pauseReassurance": "Jederzeit kündbar — oder zwischen den Semestern pausieren, kostenlos während deiner Abwesenheit."
     },
     "card": {
       "howSyncWorks": "So funktioniert die Synchronisierung"

--- a/web/src/lib/i18n/locales/de/landing.json
+++ b/web/src/lib/i18n/locales/de/landing.json
@@ -24,7 +24,7 @@
     "freeQuota": "Kostenlos · bis zu 1 000 Karten pro Import",
     "orPrefix": "oder ",
     "signUpFree": "kostenlos registrieren",
-    "getDayPass": "hol dir einen Day Pass für $4"
+    "getDayPass": "hol dir einen Day Pass für $6"
   },
   "footer": {
     "readyPrefix": "Bereit zum Ausprobieren? ",

--- a/web/src/lib/i18n/locales/de/search.json
+++ b/web/src/lib/i18n/locales/de/search.json
@@ -10,7 +10,7 @@
     "title": "Du hast diesen Monat alle {{limit}} Karten genutzt",
     "body": "{{used}} / {{limit}} Karten · Auffrischung am {{resetsOn}}, dann kommen deine kostenlosen Karten zurück",
     "startingCheckout": "Checkout wird gestartet",
-    "getDayPass": "Day Pass holen — $4",
+    "getDayPass": "Day Pass holen — $6",
     "seePlans": "Tarife ansehen"
   },
   "connect": {

--- a/web/src/lib/i18n/locales/en/common.json
+++ b/web/src/lib/i18n/locales/en/common.json
@@ -352,7 +352,7 @@
     "tryFree": "Convert a deck free",
     "socialProof": "Trusted by 15,000+ learners worldwide",
     "payOnceSection": "Pay once — no subscription",
-    "monthlySection": "Monthly plans",
+    "monthlySection": "Prefer a subscription?",
     "pricesNote": "Prices in USD. Your card is charged in your local currency at checkout.",
     "reassuranceCancel": "Cancel anytime — one click",
     "reassuranceOwn": "Your decks are yours — native .apkg, works in any Anki client",
@@ -368,17 +368,20 @@
       "nativeApkg": "Native .apkg — works in any Anki client",
       "imageOcclusion": "Unlimited image occlusion",
       "mostPopular": "Most popular",
-      "payOnce": "Pay once",
       "day24": "— 24 hours",
       "week1": "— 1 week",
       "redirecting": "Redirecting…",
       "getDayPass": "Get Day Pass",
       "getWeekPass": "Get Week Pass",
       "semester4mo": "— 4 months",
-      "getSemesterPass": "Get Semester Pass"
+      "getSemesterPass": "Get Semester Pass",
+      "bestValue": "Best value",
+      "horizonDay": "One study day",
+      "horizonWeek": "One exam week",
+      "horizonSemester": "A full term",
+      "semesterPerWeek": "≈$2/week — 85% less than the Week Pass"
     },
     "unlimited": {
-      "mostPopular": "Most popular",
       "perMonth": "/ mo",
       "yearlyHint": "{{annualTotal}} billed today, then yearly · save {{savings}}%",
       "monthlyHint": "{{monthlyTotal}} billed today, then monthly",
@@ -399,7 +402,8 @@
       "getUnlimitedMonthly": "Get Unlimited — billed monthly",
       "termsYearly": "{{annualTotal}} billed today, renews yearly. Cancel anytime — keeps access through the year you paid for.",
       "termsMonthly": "{{monthlyTotal}} billed today, renews monthly. Cancel anytime.",
-      "checkoutError": "Couldn't start checkout. Try again, or email support@2anki.net."
+      "checkoutError": "Couldn't start checkout. Try again, or email support@2anki.net.",
+      "pauseReassurance": "Cancel anytime — or pause between terms, no charge while you're away."
     },
     "card": {
       "howSyncWorks": "How sync works"

--- a/web/src/lib/i18n/locales/en/landing.json
+++ b/web/src/lib/i18n/locales/en/landing.json
@@ -24,7 +24,7 @@
     "freeQuota": "Free · up to 1 000 cards per import",
     "orPrefix": "or ",
     "signUpFree": "sign up free",
-    "getDayPass": "get a Day Pass for $4"
+    "getDayPass": "get a Day Pass for $6"
   },
   "footer": {
     "readyPrefix": "Ready to try it? ",

--- a/web/src/lib/i18n/locales/en/search.json
+++ b/web/src/lib/i18n/locales/en/search.json
@@ -10,7 +10,7 @@
     "title": "You've used all {{limit}} cards this month",
     "body": "{{used}} / {{limit}} cards · resets {{resetsOn}}, when your free cards come back",
     "startingCheckout": "Starting checkout",
-    "getDayPass": "Get Day Pass — $4",
+    "getDayPass": "Get Day Pass — $6",
     "seePlans": "See plans"
   },
   "connect": {

--- a/web/src/lib/i18n/locales/es/common.json
+++ b/web/src/lib/i18n/locales/es/common.json
@@ -352,7 +352,7 @@
     "tryFree": "Convierte un mazo gratis",
     "socialProof": "La confianza de más de 15 000 estudiantes en todo el mundo",
     "payOnceSection": "Paga una vez — sin suscripción",
-    "monthlySection": "Planes mensuales",
+    "monthlySection": "¿Prefieres una suscripción?",
     "pricesNote": "Precios en USD. Se cobra en tu moneda local al pagar.",
     "reassuranceCancel": "Cancela cuando quieras — con un clic",
     "reassuranceOwn": "Tus mazos son tuyos — .apkg nativo, funciona en cualquier cliente de Anki",
@@ -368,17 +368,20 @@
       "nativeApkg": ".apkg nativo — funciona en cualquier cliente de Anki",
       "imageOcclusion": "Oclusión de imágenes ilimitada",
       "mostPopular": "El más popular",
-      "payOnce": "Paga una vez",
       "day24": "— 24 horas",
       "week1": "— 1 semana",
       "redirecting": "Redirigiendo…",
       "getDayPass": "Consigue el Day Pass",
       "getWeekPass": "Consigue el Week Pass",
       "semester4mo": "— 4 meses",
-      "getSemesterPass": "Consigue el Semester Pass"
+      "getSemesterPass": "Consigue el Semester Pass",
+      "bestValue": "Mejor valor",
+      "horizonDay": "Un día de estudio",
+      "horizonWeek": "Una semana de exámenes",
+      "horizonSemester": "Un semestre completo",
+      "semesterPerWeek": "≈$2/semana — 85 % menos que el Week Pass"
     },
     "unlimited": {
-      "mostPopular": "El más popular",
       "perMonth": "/ mes",
       "yearlyHint": "{{annualTotal}} se cobra hoy, luego cada año · ahorra un {{savings}} %",
       "monthlyHint": "{{monthlyTotal}} se cobra hoy, luego cada mes",
@@ -399,7 +402,8 @@
       "getUnlimitedMonthly": "Consigue Unlimited — facturación mensual",
       "termsYearly": "{{annualTotal}} se cobra hoy, se renueva anualmente. Cancela cuando quieras — conservas el acceso durante el año que pagaste.",
       "termsMonthly": "{{monthlyTotal}} se cobra hoy, se renueva mensualmente. Cancela cuando quieras.",
-      "checkoutError": "No se pudo iniciar el pago. Inténtalo de nuevo, o escribe a support@2anki.net."
+      "checkoutError": "No se pudo iniciar el pago. Inténtalo de nuevo, o escribe a support@2anki.net.",
+      "pauseReassurance": "Cancela cuando quieras — o pausa entre semestres, sin cargos mientras no estás."
     },
     "card": {
       "howSyncWorks": "Cómo funciona la sincronización"

--- a/web/src/lib/i18n/locales/es/landing.json
+++ b/web/src/lib/i18n/locales/es/landing.json
@@ -24,7 +24,7 @@
     "freeQuota": "Gratis · hasta 1 000 tarjetas por importación",
     "orPrefix": "o ",
     "signUpFree": "regístrate gratis",
-    "getDayPass": "consigue un Day Pass por $4"
+    "getDayPass": "consigue un Day Pass por $6"
   },
   "footer": {
     "readyPrefix": "¿Listo para probarlo? ",

--- a/web/src/lib/i18n/locales/es/search.json
+++ b/web/src/lib/i18n/locales/es/search.json
@@ -10,7 +10,7 @@
     "title": "Has usado las {{limit}} tarjetas de este mes",
     "body": "{{used}} / {{limit}} tarjetas · se reinicia el {{resetsOn}}, cuando vuelven tus tarjetas gratis",
     "startingCheckout": "Abriendo el pago",
-    "getDayPass": "Consigue el Day Pass — $4",
+    "getDayPass": "Consigue el Day Pass — $6",
     "seePlans": "Ver planes"
   },
   "connect": {

--- a/web/src/lib/i18n/locales/fr/common.json
+++ b/web/src/lib/i18n/locales/fr/common.json
@@ -352,7 +352,7 @@
     "tryFree": "Convertir un paquet gratuitement",
     "socialProof": "Adopté par plus de 15 000 apprenants dans le monde",
     "payOnceSection": "Paie une seule fois — sans abonnement",
-    "monthlySection": "Offres mensuelles",
+    "monthlySection": "Tu préfères un abonnement ?",
     "pricesNote": "Prix en USD. Ta carte est débitée dans ta devise locale au moment du paiement.",
     "reassuranceCancel": "Annulable à tout moment — en un clic",
     "reassuranceOwn": "Tes paquets t'appartiennent — .apkg natif, fonctionne dans tous les clients Anki",
@@ -368,17 +368,20 @@
       "nativeApkg": ".apkg natif — fonctionne dans tous les clients Anki",
       "imageOcclusion": "Occlusion d'image illimitée",
       "mostPopular": "Le plus populaire",
-      "payOnce": "Paie une seule fois",
       "day24": "— 24 heures",
       "week1": "— 1 semaine",
       "redirecting": "Redirection…",
       "getDayPass": "Prendre un Day Pass",
       "getWeekPass": "Prendre un Week Pass",
       "semester4mo": "— 4 mois",
-      "getSemesterPass": "Prendre un Semester Pass"
+      "getSemesterPass": "Prendre un Semester Pass",
+      "bestValue": "Meilleure offre",
+      "horizonDay": "Une journée de révisions",
+      "horizonWeek": "Une semaine d'examens",
+      "horizonSemester": "Un semestre entier",
+      "semesterPerWeek": "≈$2/semaine — 85 % de moins que le Week Pass"
     },
     "unlimited": {
-      "mostPopular": "Le plus populaire",
       "perMonth": "/ mois",
       "yearlyHint": "{{annualTotal}} facturé aujourd'hui, puis chaque année · économise {{savings}} %",
       "monthlyHint": "{{monthlyTotal}} facturé aujourd'hui, puis chaque mois",
@@ -399,7 +402,8 @@
       "getUnlimitedMonthly": "Prendre Unlimited — facturation mensuelle",
       "termsYearly": "{{annualTotal}} facturé aujourd'hui, se renouvelle chaque année. Annulable à tout moment — l'accès est conservé jusqu'à la fin de l'année payée.",
       "termsMonthly": "{{monthlyTotal}} facturé aujourd'hui, se renouvelle chaque mois. Annulable à tout moment.",
-      "checkoutError": "Impossible de démarrer le paiement. Réessaie, ou écris à support@2anki.net."
+      "checkoutError": "Impossible de démarrer le paiement. Réessaie, ou écris à support@2anki.net.",
+      "pauseReassurance": "Annulable à tout moment — ou mets en pause entre les semestres, sans frais pendant ton absence."
     },
     "card": {
       "howSyncWorks": "Comment fonctionne la synchro"

--- a/web/src/lib/i18n/locales/fr/landing.json
+++ b/web/src/lib/i18n/locales/fr/landing.json
@@ -24,7 +24,7 @@
     "freeQuota": "Gratuit · jusqu'à 1 000 cartes par import",
     "orPrefix": "ou ",
     "signUpFree": "inscris-toi gratuitement",
-    "getDayPass": "prends un Day Pass à $4"
+    "getDayPass": "prends un Day Pass à $6"
   },
   "footer": {
     "readyPrefix": "Prêt à essayer ? ",

--- a/web/src/lib/i18n/locales/fr/search.json
+++ b/web/src/lib/i18n/locales/fr/search.json
@@ -10,7 +10,7 @@
     "title": "Tu as utilisé tes {{limit}} cartes ce mois-ci",
     "body": "{{used}} / {{limit}} cartes · réinitialisées le {{resetsOn}}, quand tes cartes gratuites reviennent",
     "startingCheckout": "Ouverture du paiement",
-    "getDayPass": "Prendre un Day Pass — $4",
+    "getDayPass": "Prendre un Day Pass — $6",
     "seePlans": "Voir les offres"
   },
   "connect": {

--- a/web/src/lib/i18n/locales/it/common.json
+++ b/web/src/lib/i18n/locales/it/common.json
@@ -352,7 +352,7 @@
     "tryFree": "Converti un mazzo gratis",
     "socialProof": "Scelto da oltre 15 000 studenti in tutto il mondo",
     "payOnceSection": "Paghi una volta — niente abbonamento",
-    "monthlySection": "Piani mensili",
+    "monthlySection": "Preferisci un abbonamento?",
     "pricesNote": "Prezzi in USD. La tua carta viene addebitata nella valuta locale al momento del pagamento.",
     "reassuranceCancel": "Disdici quando vuoi — con un clic",
     "reassuranceOwn": "I tuoi mazzi sono tuoi — .apkg nativo, funziona con qualsiasi client Anki",
@@ -368,17 +368,20 @@
       "nativeApkg": ".apkg nativo — funziona con qualsiasi client Anki",
       "imageOcclusion": "Occlusione immagini illimitata",
       "mostPopular": "Più scelto",
-      "payOnce": "Paghi una volta",
       "day24": "— 24 ore",
       "week1": "— 1 settimana",
       "redirecting": "Reindirizzamento…",
       "getDayPass": "Ottieni il Day Pass",
       "getWeekPass": "Ottieni il Week Pass",
       "semester4mo": "— 4 mesi",
-      "getSemesterPass": "Ottieni il Semester Pass"
+      "getSemesterPass": "Ottieni il Semester Pass",
+      "bestValue": "Miglior valore",
+      "horizonDay": "Un giorno di studio",
+      "horizonWeek": "Una settimana d'esami",
+      "horizonSemester": "Un intero semestre",
+      "semesterPerWeek": "≈$2/settimana — 85% in meno del Week Pass"
     },
     "unlimited": {
-      "mostPopular": "Più scelto",
       "perMonth": "/ mese",
       "yearlyHint": "{{annualTotal}} addebitato oggi, poi ogni anno · risparmi {{savings}}%",
       "monthlyHint": "{{monthlyTotal}} addebitato oggi, poi ogni mese",
@@ -399,7 +402,8 @@
       "getUnlimitedMonthly": "Ottieni Unlimited — fatturazione mensile",
       "termsYearly": "{{annualTotal}} addebitato oggi, si rinnova ogni anno. Disdici quando vuoi — mantieni l'accesso per l'anno che hai pagato.",
       "termsMonthly": "{{monthlyTotal}} addebitato oggi, si rinnova ogni mese. Disdici quando vuoi.",
-      "checkoutError": "Non siamo riusciti ad avviare il pagamento. Riprova, oppure scrivi a support@2anki.net."
+      "checkoutError": "Non siamo riusciti ad avviare il pagamento. Riprova, oppure scrivi a support@2anki.net.",
+      "pauseReassurance": "Disdici quando vuoi — o metti in pausa tra un semestre e l'altro, nessun addebito mentre sei via."
     },
     "card": {
       "howSyncWorks": "Come funziona la sincronizzazione"

--- a/web/src/lib/i18n/locales/it/landing.json
+++ b/web/src/lib/i18n/locales/it/landing.json
@@ -24,7 +24,7 @@
     "freeQuota": "Gratis · fino a 1 000 carte per importazione",
     "orPrefix": "oppure ",
     "signUpFree": "registrati gratis",
-    "getDayPass": "prendi un Day Pass a $4"
+    "getDayPass": "prendi un Day Pass a $6"
   },
   "footer": {
     "readyPrefix": "Pronto a provarlo? ",

--- a/web/src/lib/i18n/locales/it/search.json
+++ b/web/src/lib/i18n/locales/it/search.json
@@ -10,7 +10,7 @@
     "title": "Hai usato tutte le {{limit}} carte di questo mese",
     "body": "{{used}} / {{limit}} carte · si rinnovano il {{resetsOn}}, quando tornano le tue carte gratuite",
     "startingCheckout": "Avvio del pagamento",
-    "getDayPass": "Ottieni il Day Pass — $4",
+    "getDayPass": "Ottieni il Day Pass — $6",
     "seePlans": "Vedi i piani"
   },
   "connect": {

--- a/web/src/lib/i18n/locales/ja/common.json
+++ b/web/src/lib/i18n/locales/ja/common.json
@@ -349,7 +349,7 @@
     "tryFree": "デッキを無料で変換",
     "socialProof": "世界中の 15,000 人以上の学習者に利用されています",
     "payOnceSection": "一度だけのお支払い — サブスクリプションなし",
-    "monthlySection": "月額プラン",
+    "monthlySection": "サブスクリプションがお好みですか？",
     "pricesNote": "価格は米ドル表示です。チェックアウト時にお使いの地域通貨で請求されます。",
     "reassuranceCancel": "いつでも解約 — ワンクリック",
     "reassuranceOwn": "デッキはあなたのもの — ネイティブ .apkg で、どの Anki クライアントでも使えます",
@@ -365,17 +365,20 @@
       "nativeApkg": "ネイティブ .apkg — どの Anki クライアントでも使えます",
       "imageOcclusion": "無制限の画像で隠す問題",
       "mostPopular": "一番人気",
-      "payOnce": "一度だけのお支払い",
       "day24": "— 24 時間",
       "week1": "— 1 週間",
       "redirecting": "リダイレクト中…",
       "getDayPass": "Get Day Pass",
       "getWeekPass": "Get Week Pass",
       "semester4mo": "— 4 か月",
-      "getSemesterPass": "Get Semester Pass"
+      "getSemesterPass": "Get Semester Pass",
+      "bestValue": "一番お得",
+      "horizonDay": "学習1日分",
+      "horizonWeek": "試験1週間分",
+      "horizonSemester": "1学期まるごと",
+      "semesterPerWeek": "≈$2/週 — Week Pass より85%安い"
     },
     "unlimited": {
-      "mostPopular": "一番人気",
       "perMonth": "/ 月",
       "yearlyHint": "本日 {{annualTotal}} を請求、以降は年払い · {{savings}}% お得",
       "monthlyHint": "本日 {{monthlyTotal}} を請求、以降は月払い",
@@ -396,7 +399,8 @@
       "getUnlimitedMonthly": "Get Unlimited — 月払い",
       "termsYearly": "本日 {{annualTotal}} を請求、毎年更新。いつでも解約可能 — お支払い済みの 1 年間はご利用いただけます。",
       "termsMonthly": "本日 {{monthlyTotal}} を請求、毎月更新。いつでも解約可能。",
-      "checkoutError": "チェックアウトを開始できませんでした。もう一度お試しいただくか、support@2anki.net までご連絡ください。"
+      "checkoutError": "チェックアウトを開始できませんでした。もう一度お試しいただくか、support@2anki.net までご連絡ください。",
+      "pauseReassurance": "いつでも解約可能 — 学期の合間は一時停止でき、その間は料金がかかりません。"
     },
     "card": {
       "howSyncWorks": "同期の仕組み"

--- a/web/src/lib/i18n/locales/ja/landing.json
+++ b/web/src/lib/i18n/locales/ja/landing.json
@@ -24,7 +24,7 @@
     "freeQuota": "無料 · 1 回のインポートで最大 1 000 枚",
     "orPrefix": "または ",
     "signUpFree": "無料で登録",
-    "getDayPass": "$4 の Day Pass を購入"
+    "getDayPass": "$6 の Day Pass を購入"
   },
   "footer": {
     "readyPrefix": "試してみますか？ ",

--- a/web/src/lib/i18n/locales/ja/search.json
+++ b/web/src/lib/i18n/locales/ja/search.json
@@ -10,7 +10,7 @@
     "title": "今月の {{limit}} 枚のカードをすべて使い切りました",
     "body": "{{used}} / {{limit}} 枚 · {{resetsOn}} に無料カードが戻ってリセットされます",
     "startingCheckout": "チェックアウトを開始しています",
-    "getDayPass": "Get Day Pass — $4",
+    "getDayPass": "Get Day Pass — $6",
     "seePlans": "プランを見る"
   },
   "connect": {

--- a/web/src/lib/i18n/locales/nl/common.json
+++ b/web/src/lib/i18n/locales/nl/common.json
@@ -352,7 +352,7 @@
     "tryFree": "Zet gratis een deck om",
     "socialProof": "Vertrouwd door 15.000+ lerenden wereldwijd",
     "payOnceSection": "Betaal eenmalig — geen abonnement",
-    "monthlySection": "Maandabonnementen",
+    "monthlySection": "Liever een abonnement?",
     "pricesNote": "Prijzen in USD. Je kaart wordt bij het afrekenen in je lokale valuta belast.",
     "reassuranceCancel": "Altijd opzegbaar — met één klik",
     "reassuranceOwn": "Je decks zijn van jou — native .apkg, werkt in elke Anki-client",
@@ -368,17 +368,20 @@
       "nativeApkg": "Native .apkg — werkt in elke Anki-client",
       "imageOcclusion": "Onbeperkte image occlusion",
       "mostPopular": "Meest gekozen",
-      "payOnce": "Betaal eenmalig",
       "day24": "— 24 uur",
       "week1": "— 1 week",
       "redirecting": "Doorsturen…",
       "getDayPass": "Day Pass kopen",
       "getWeekPass": "Week Pass kopen",
       "semester4mo": "— 4 maanden",
-      "getSemesterPass": "Semester Pass kopen"
+      "getSemesterPass": "Semester Pass kopen",
+      "bestValue": "Beste waarde",
+      "horizonDay": "Eén studiedag",
+      "horizonWeek": "Eén tentamenweek",
+      "horizonSemester": "Een heel semester",
+      "semesterPerWeek": "≈$2/week — 85% minder dan de Week Pass"
     },
     "unlimited": {
-      "mostPopular": "Meest gekozen",
       "perMonth": "/ mnd",
       "yearlyHint": "{{annualTotal}} vandaag afgeschreven, daarna jaarlijks · bespaar {{savings}}%",
       "monthlyHint": "{{monthlyTotal}} vandaag afgeschreven, daarna maandelijks",
@@ -399,7 +402,8 @@
       "getUnlimitedMonthly": "Unlimited kopen — maandelijkse facturering",
       "termsYearly": "{{annualTotal}} vandaag afgeschreven, wordt jaarlijks verlengd. Altijd opzegbaar — je houdt toegang gedurende het jaar waarvoor je betaalde.",
       "termsMonthly": "{{monthlyTotal}} vandaag afgeschreven, wordt maandelijks verlengd. Altijd opzegbaar.",
-      "checkoutError": "Kon het afrekenen niet starten. Probeer het opnieuw, of mail support@2anki.net."
+      "checkoutError": "Kon het afrekenen niet starten. Probeer het opnieuw, of mail support@2anki.net.",
+      "pauseReassurance": "Altijd opzegbaar — of pauzeer tussen semesters, geen kosten zolang je weg bent."
     },
     "card": {
       "howSyncWorks": "Hoe sync werkt"

--- a/web/src/lib/i18n/locales/nl/landing.json
+++ b/web/src/lib/i18n/locales/nl/landing.json
@@ -24,7 +24,7 @@
     "freeQuota": "Gratis · tot 1 000 kaarten per import",
     "orPrefix": "of ",
     "signUpFree": "meld je gratis aan",
-    "getDayPass": "koop een Day Pass voor $4"
+    "getDayPass": "koop een Day Pass voor $6"
   },
   "footer": {
     "readyPrefix": "Klaar om het te proberen? ",

--- a/web/src/lib/i18n/locales/nl/search.json
+++ b/web/src/lib/i18n/locales/nl/search.json
@@ -10,7 +10,7 @@
     "title": "Je hebt alle {{limit}} kaarten deze maand gebruikt",
     "body": "{{used}} / {{limit}} kaarten · vernieuwt {{resetsOn}}, wanneer je gratis kaarten terugkomen",
     "startingCheckout": "Afrekenen starten",
-    "getDayPass": "Day Pass kopen — $4",
+    "getDayPass": "Day Pass kopen — $6",
     "seePlans": "Bekijk abonnementen"
   },
   "connect": {

--- a/web/src/lib/i18n/locales/pl/common.json
+++ b/web/src/lib/i18n/locales/pl/common.json
@@ -358,7 +358,7 @@
     "tryFree": "Przekonwertuj talię za darmo",
     "socialProof": "Zaufało nam ponad 15 000 uczących się na całym świecie",
     "payOnceSection": "Zapłać raz — bez subskrypcji",
-    "monthlySection": "Plany miesięczne",
+    "monthlySection": "Wolisz subskrypcję?",
     "pricesNote": "Ceny w USD. Twoja karta zostanie obciążona w Twojej walucie lokalnej przy płatności.",
     "reassuranceCancel": "Anuluj w każdej chwili — jednym kliknięciem",
     "reassuranceOwn": "Twoje talie należą do Ciebie — natywny .apkg, działa w każdym kliencie Anki",
@@ -374,17 +374,20 @@
       "nativeApkg": "Natywny .apkg — działa w każdym kliencie Anki",
       "imageOcclusion": "Nieograniczone zasłanianie obrazu",
       "mostPopular": "Najpopularniejszy",
-      "payOnce": "Zapłać raz",
       "day24": "— 24 godziny",
       "week1": "— 1 tydzień",
       "redirecting": "Przekierowywanie…",
       "getDayPass": "Kup Day Pass",
       "getWeekPass": "Kup Week Pass",
       "semester4mo": "— 4 miesiące",
-      "getSemesterPass": "Kup Semester Pass"
+      "getSemesterPass": "Kup Semester Pass",
+      "bestValue": "Najlepsza oferta",
+      "horizonDay": "Jeden dzień nauki",
+      "horizonWeek": "Jeden tydzień egzaminów",
+      "horizonSemester": "Cały semestr",
+      "semesterPerWeek": "≈$2/tydzień — 85% taniej niż Week Pass"
     },
     "unlimited": {
-      "mostPopular": "Najpopularniejszy",
       "perMonth": "/ mies.",
       "yearlyHint": "{{annualTotal}} pobierane dziś, potem co roku · oszczędzasz {{savings}}%",
       "monthlyHint": "{{monthlyTotal}} pobierane dziś, potem co miesiąc",
@@ -405,7 +408,8 @@
       "getUnlimitedMonthly": "Kup Unlimited — płatność miesięczna",
       "termsYearly": "{{annualTotal}} pobierane dziś, odnawia się co roku. Anuluj w każdej chwili — zachowujesz dostęp przez opłacony rok.",
       "termsMonthly": "{{monthlyTotal}} pobierane dziś, odnawia się co miesiąc. Anuluj w każdej chwili.",
-      "checkoutError": "Nie udało się rozpocząć płatności. Spróbuj ponownie albo napisz na support@2anki.net."
+      "checkoutError": "Nie udało się rozpocząć płatności. Spróbuj ponownie albo napisz na support@2anki.net.",
+      "pauseReassurance": "Anuluj w każdej chwili — albo wstrzymaj między semestrami, bez opłat, gdy Cię nie ma."
     },
     "card": {
       "howSyncWorks": "Jak działa synchronizacja"

--- a/web/src/lib/i18n/locales/pl/landing.json
+++ b/web/src/lib/i18n/locales/pl/landing.json
@@ -24,7 +24,7 @@
     "freeQuota": "Za darmo · do 1 000 kart na import",
     "orPrefix": "albo ",
     "signUpFree": "zarejestruj się za darmo",
-    "getDayPass": "kup Day Pass za $4"
+    "getDayPass": "kup Day Pass za $6"
   },
   "footer": {
     "readyPrefix": "Gotowy, aby spróbować? ",

--- a/web/src/lib/i18n/locales/pl/search.json
+++ b/web/src/lib/i18n/locales/pl/search.json
@@ -10,7 +10,7 @@
     "title": "Wykorzystałeś wszystkie {{limit}} kart w tym miesiącu",
     "body": "{{used}} / {{limit}} kart · odnawia się {{resetsOn}}, gdy wrócą Twoje darmowe karty",
     "startingCheckout": "Rozpoczynanie płatności",
-    "getDayPass": "Kup Day Pass — $4",
+    "getDayPass": "Kup Day Pass — $6",
     "seePlans": "Zobacz plany"
   },
   "connect": {

--- a/web/src/lib/i18n/locales/pt/common.json
+++ b/web/src/lib/i18n/locales/pt/common.json
@@ -352,7 +352,7 @@
     "tryFree": "Converter um baralho grátis",
     "socialProof": "Confiado por mais de 15.000 estudantes no mundo todo",
     "payOnceSection": "Pague uma vez — sem assinatura",
-    "monthlySection": "Planos mensais",
+    "monthlySection": "Prefere uma assinatura?",
     "pricesNote": "Preços em USD. Seu cartão é cobrado na sua moeda local no checkout.",
     "reassuranceCancel": "Cancele quando quiser — em um clique",
     "reassuranceOwn": "Seus baralhos são seus — .apkg nativo, funciona em qualquer cliente Anki",
@@ -368,17 +368,20 @@
       "nativeApkg": ".apkg nativo — funciona em qualquer cliente Anki",
       "imageOcclusion": "Oclusão de imagem ilimitada",
       "mostPopular": "Mais popular",
-      "payOnce": "Pague uma vez",
       "day24": "— 24 horas",
       "week1": "— 1 semana",
       "redirecting": "Redirecionando…",
       "getDayPass": "Obter Day Pass",
       "getWeekPass": "Obter Week Pass",
       "semester4mo": "— 4 meses",
-      "getSemesterPass": "Obter Semester Pass"
+      "getSemesterPass": "Obter Semester Pass",
+      "bestValue": "Melhor valor",
+      "horizonDay": "Um dia de estudo",
+      "horizonWeek": "Uma semana de provas",
+      "horizonSemester": "Um semestre inteiro",
+      "semesterPerWeek": "≈$2/semana — 85% menos que o Week Pass"
     },
     "unlimited": {
-      "mostPopular": "Mais popular",
       "perMonth": "/ mês",
       "yearlyHint": "{{annualTotal}} cobrado hoje, depois anualmente · economize {{savings}}%",
       "monthlyHint": "{{monthlyTotal}} cobrado hoje, depois mensalmente",
@@ -399,7 +402,8 @@
       "getUnlimitedMonthly": "Obter Unlimited — cobrança mensal",
       "termsYearly": "{{annualTotal}} cobrado hoje, renova anualmente. Cancele quando quiser — o acesso continua até o fim do ano pago.",
       "termsMonthly": "{{monthlyTotal}} cobrado hoje, renova mensalmente. Cancele quando quiser.",
-      "checkoutError": "Não foi possível iniciar o checkout. Tente de novo, ou envie um e-mail para support@2anki.net."
+      "checkoutError": "Não foi possível iniciar o checkout. Tente de novo, ou envie um e-mail para support@2anki.net.",
+      "pauseReassurance": "Cancele quando quiser — ou pause entre semestres, sem cobrança enquanto estiver fora."
     },
     "card": {
       "howSyncWorks": "Como funciona a sincronização"

--- a/web/src/lib/i18n/locales/pt/landing.json
+++ b/web/src/lib/i18n/locales/pt/landing.json
@@ -24,7 +24,7 @@
     "freeQuota": "Grátis · até 1 000 cartões por importação",
     "orPrefix": "ou ",
     "signUpFree": "cadastre-se grátis",
-    "getDayPass": "pegue um Day Pass por $4"
+    "getDayPass": "pegue um Day Pass por $6"
   },
   "footer": {
     "readyPrefix": "Pronto para testar? ",

--- a/web/src/lib/i18n/locales/pt/search.json
+++ b/web/src/lib/i18n/locales/pt/search.json
@@ -10,7 +10,7 @@
     "title": "Você usou todos os {{limit}} cartões deste mês",
     "body": "{{used}} / {{limit}} cartões · renova em {{resetsOn}}, quando seus cartões grátis voltam",
     "startingCheckout": "Iniciando o checkout",
-    "getDayPass": "Obter Day Pass — $4",
+    "getDayPass": "Obter Day Pass — $6",
     "seePlans": "Ver planos"
   },
   "connect": {

--- a/web/src/lib/i18n/locales/ru/common.json
+++ b/web/src/lib/i18n/locales/ru/common.json
@@ -358,7 +358,7 @@
     "tryFree": "Конвертировать колоду бесплатно",
     "socialProof": "Нам доверяют 15 000+ учащихся по всему миру",
     "payOnceSection": "Плати разово — без подписки",
-    "monthlySection": "Месячные планы",
+    "monthlySection": "Предпочитаете подписку?",
     "pricesNote": "Цены в долларах США. Твоя карта будет списана в местной валюте при оплате.",
     "reassuranceCancel": "Отмена в любой момент — в один клик",
     "reassuranceOwn": "Твои колоды принадлежат тебе — родной .apkg, работает в любом клиенте Anki",
@@ -374,17 +374,20 @@
       "nativeApkg": "Родной .apkg — работает в любом клиенте Anki",
       "imageOcclusion": "Безлимитное перекрытие изображений",
       "mostPopular": "Самый популярный",
-      "payOnce": "Плати разово",
       "day24": "— 24 часа",
       "week1": "— 1 неделя",
       "redirecting": "Перенаправляем…",
       "getDayPass": "Купить Day Pass",
       "getWeekPass": "Купить Week Pass",
       "semester4mo": "— 4 месяца",
-      "getSemesterPass": "Купить Semester Pass"
+      "getSemesterPass": "Купить Semester Pass",
+      "bestValue": "Выгоднее всего",
+      "horizonDay": "Один день учёбы",
+      "horizonWeek": "Одна неделя экзаменов",
+      "horizonSemester": "Целый семестр",
+      "semesterPerWeek": "≈$2/неделю — на 85% дешевле Week Pass"
     },
     "unlimited": {
-      "mostPopular": "Самый популярный",
       "perMonth": "/ мес",
       "yearlyHint": "{{annualTotal}} спишется сегодня, далее ежегодно · экономия {{savings}}%",
       "monthlyHint": "{{monthlyTotal}} спишется сегодня, далее ежемесячно",
@@ -405,7 +408,8 @@
       "getUnlimitedMonthly": "Купить Unlimited — помесячная оплата",
       "termsYearly": "{{annualTotal}} спишется сегодня, продлевается ежегодно. Отмена в любой момент — доступ сохраняется до конца оплаченного года.",
       "termsMonthly": "{{monthlyTotal}} спишется сегодня, продлевается ежемесячно. Отмена в любой момент.",
-      "checkoutError": "Не удалось открыть оплату. Попробуй ещё раз или напиши на support@2anki.net."
+      "checkoutError": "Не удалось открыть оплату. Попробуй ещё раз или напиши на support@2anki.net.",
+      "pauseReassurance": "Отмена в любой момент — или пауза между семестрами без списаний, пока вас нет."
     },
     "card": {
       "howSyncWorks": "Как работает синхронизация"

--- a/web/src/lib/i18n/locales/ru/landing.json
+++ b/web/src/lib/i18n/locales/ru/landing.json
@@ -24,7 +24,7 @@
     "freeQuota": "Бесплатно · до 1 000 карт за один импорт",
     "orPrefix": "или ",
     "signUpFree": "зарегистрируйся бесплатно",
-    "getDayPass": "купи Day Pass за $4"
+    "getDayPass": "купи Day Pass за $6"
   },
   "footer": {
     "readyPrefix": "Готов попробовать? ",

--- a/web/src/lib/i18n/locales/ru/search.json
+++ b/web/src/lib/i18n/locales/ru/search.json
@@ -10,7 +10,7 @@
     "title": "Ты использовал все {{limit}} карт в этом месяце",
     "body": "{{used}} / {{limit}} карт · обновятся {{resetsOn}}, когда вернутся твои бесплатные карты",
     "startingCheckout": "Открываем оплату",
-    "getDayPass": "Купить Day Pass — $4",
+    "getDayPass": "Купить Day Pass — $6",
     "seePlans": "Посмотреть планы"
   },
   "connect": {

--- a/web/src/pages/DocsPage/content/de/reference/plans.md
+++ b/web/src/pages/DocsPage/content/de/reference/plans.md
@@ -7,23 +7,23 @@ Die meisten nutzen Free oder ein monatliches Subscription. Aber zwei kurze Optio
 
 Für die vollständige Planliste und Preise siehe die [Preisseite](/pricing).
 
-## Day Pass — $4
+## Day Pass — $6
 
 24 Stunden Unlimited-Zugang, einmalig bezahlt.
 
 - **Dauer:** 24 Stunden ab Kauf.
-- **Kosten:** $4, einmalig.
+- **Kosten:** $6, einmalig.
 - **Was du bekommst:** Unbegrenzte Konvertierungen, jedes Upload-Format (`.zip`, `.html`, `.md`, `.csv`, `.apkg`), Image Occlusion, eigene Kartenvorlagen.
 - **Wo:** **Day Pass** auf der [Preisseite](/pricing).
 
 Nutze das, wenn du ein Wochenende voller Karten zu bauen hast und keine wiederkehrende Belastung willst.
 
-## Week Pass — $9
+## Week Pass — $12
 
 7 Tage Unlimited-Zugang, einmalig bezahlt.
 
 - **Dauer:** 7 Tage ab Kauf.
-- **Kosten:** $9, einmalig.
+- **Kosten:** $12, einmalig.
 - **Was du bekommst:** derselbe Funktionsumfang wie der Day Pass.
 - **Wo:** **Week Pass** auf der [Preisseite](/pricing).
 
@@ -33,7 +33,7 @@ Nutze das, wenn du eine Woche hast, um dich auf eine Prüfung vorzubereiten, ode
 
 |                                                       | Free      | Day Pass   | Week Pass  | Unlimited (Abo) |
 | ----------------------------------------------------- | --------- | ---------- | ---------- | --------------- |
-| Kosten                                                | $0        | $4         | $9         | $6 / Mon.       |
+| Kosten                                                | $0        | $6         | $12        | $6 / Mon.       |
 | Dauer                                                 | für immer | 24 h       | 7 Tage     | bis gekündigt   |
 | Karten pro Monat                                      | 100       | unbegrenzt | unbegrenzt | unbegrenzt      |
 | PDF-Unterstützung                                     | —         | ✓          | ✓          | ✓               |

--- a/web/src/pages/DocsPage/content/reference/plans.md
+++ b/web/src/pages/DocsPage/content/reference/plans.md
@@ -7,23 +7,23 @@ Most people use Free or a monthly Subscription. But two short options exist for 
 
 For the full plan list and prices, see the [pricing page](/pricing).
 
-## Day Pass — $4
+## Day Pass — $6
 
 24 hours of Unlimited access, paid once.
 
 - **Length:** 24 hours from purchase.
-- **Cost:** $4, one-time.
+- **Cost:** $6, one-time.
 - **What you get:** Unlimited conversions, every upload format (`.zip`, `.html`, `.md`, `.csv`, `.apkg`), image occlusion, custom card templates.
 - **Where:** **Day Pass** on the [pricing page](/pricing).
 
 Use this when you have a weekend of cards to build and don't want a recurring charge.
 
-## Week Pass — $9
+## Week Pass — $12
 
 7 days of Unlimited access, paid once.
 
 - **Length:** 7 days from purchase.
-- **Cost:** $9, one-time.
+- **Cost:** $12, one-time.
 - **What you get:** same feature set as the Day Pass.
 - **Where:** **Week Pass** on the [pricing page](/pricing).
 
@@ -33,7 +33,7 @@ Use this when you have a week to prep for an exam or a sprint to digitize a stac
 
 |                                                     | Free    | Day Pass  | Week Pass | Unlimited (sub)        |
 | --------------------------------------------------- | ------- | --------- | --------- | ---------------------- |
-| Cost                                                | $0      | $4        | $9        | $7.99 / mo or $64 / yr |
+| Cost                                                | $0      | $6        | $12       | $7.99 / mo or $64 / yr |
 | Length                                              | forever | 24 h      | 7 days    | until cancelled        |
 | Cards per month                                     | 100     | unlimited | unlimited | unlimited              |
 | PDF support                                         | —       | ✓         | ✓         | ✓                      |

--- a/web/src/pages/DownloadsPage/DownloadsPage.test.tsx
+++ b/web/src/pages/DownloadsPage/DownloadsPage.test.tsx
@@ -737,10 +737,10 @@ describe('DownloadsPage monthly limit panel', () => {
   it('leads the panel with the Day Pass primary CTA', () => {
     renderAt('/downloads');
     expect(
-      screen.getByRole('button', { name: 'Get Day Pass — $4' })
+      screen.getByRole('button', { name: 'Get Day Pass — $6' })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: 'Get Week Pass — $9' })
+      screen.getByRole('button', { name: 'Get Week Pass — $12' })
     ).toBeInTheDocument();
     expect(
       screen.getByRole('link', { name: 'Upgrade to Unlimited' })

--- a/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.test.tsx
+++ b/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.test.tsx
@@ -120,10 +120,10 @@ describe('ConversionResult — paywalled variant', () => {
   it('leads with the Day Pass as the primary CTA, then Week Pass, then Unlimited', () => {
     renderPaywall();
     expect(
-      screen.getByRole('button', { name: 'Get Day Pass — $4' })
+      screen.getByRole('button', { name: 'Get Day Pass — $6' })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: 'Get Week Pass — $9' })
+      screen.getByRole('button', { name: 'Get Week Pass — $12' })
     ).toBeInTheDocument();
     expect(
       screen.getByRole('link', { name: 'Upgrade to Unlimited' })
@@ -133,7 +133,7 @@ describe('ConversionResult — paywalled variant', () => {
   it('fires paywall_pass_clicked with plan=day and starts the 24h checkout', async () => {
     mockStartPassCheckout.mockResolvedValue({ status: 'error' });
     renderPaywall();
-    fireEvent.click(screen.getByRole('button', { name: 'Get Day Pass — $4' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Get Day Pass — $6' }));
     await waitFor(() => {
       expect(mockTrack).toHaveBeenCalledWith('paywall_pass_clicked', {
         surface: 'downloads-limit',
@@ -150,7 +150,9 @@ describe('ConversionResult — paywalled variant', () => {
   it('fires paywall_pass_clicked with plan=week and starts the 7d checkout', async () => {
     mockStartPassCheckout.mockResolvedValue({ status: 'error' });
     renderPaywall();
-    fireEvent.click(screen.getByRole('button', { name: 'Get Week Pass — $9' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Get Week Pass — $12' })
+    );
     await waitFor(() => {
       expect(mockTrack).toHaveBeenCalledWith('paywall_pass_clicked', {
         surface: 'downloads-limit',

--- a/web/src/pages/LandingPage/LandingPage.tsx
+++ b/web/src/pages/LandingPage/LandingPage.tsx
@@ -85,7 +85,7 @@ function renderHeroAction({
         {' — '}
         <a href="/pricing">
           {t('hero.getDayPass', {
-            defaultValue: 'get a Day Pass for $4',
+            defaultValue: 'get a Day Pass for $6',
           })}
         </a>
       </p>

--- a/web/src/pages/LimitPage/LimitPage.test.tsx
+++ b/web/src/pages/LimitPage/LimitPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { HelmetProvider } from 'react-helmet-async';
@@ -96,8 +96,12 @@ describe('LimitPage', () => {
 
   it('does not show a hardcoded Unlimited monthly price', () => {
     renderPage();
-    expect(screen.queryByText('$6')).toBeNull();
-    expect(screen.getByText('Upgrade to Unlimited')).toBeTruthy();
+    const unlimitedCard = screen
+      .getByText('Upgrade to Unlimited')
+      .closest('div');
+    if (unlimitedCard == null) throw new Error('Unlimited card not found');
+    expect(within(unlimitedCard).queryByText(/\$\d/)).toBeNull();
+    expect(screen.getByText('Upgrade to Unlimited')).toBeInTheDocument();
   });
 
   it('shows a back link to /upload', () => {

--- a/web/src/pages/NotionLandingPage/NotionLandingPage.test.tsx
+++ b/web/src/pages/NotionLandingPage/NotionLandingPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { HelmetProvider } from 'react-helmet-async';
 import { MemoryRouter } from 'react-router-dom';
@@ -42,14 +42,18 @@ describe('NotionLandingPage', () => {
     renderPage();
     expect(screen.getByText('Unlimited')).toBeInTheDocument();
     expect(screen.getByText('See pricing')).toBeInTheDocument();
-    expect(screen.queryByText('$6')).not.toBeInTheDocument();
+    const unlimitedCard = screen
+      .getByRole('heading', { name: 'Unlimited' })
+      .closest('div')?.parentElement;
+    if (unlimitedCard == null) throw new Error('Unlimited card not found');
+    expect(within(unlimitedCard).queryByText(/\$\d/)).toBeNull();
     expect(screen.getByText('Recommended')).toBeInTheDocument();
   });
 
   it('renders the Day Pass plan card as the secondary option', () => {
     renderPage();
     expect(screen.getByText('Day Pass')).toBeInTheDocument();
-    expect(screen.getByText('$4')).toBeInTheDocument();
+    expect(screen.getByText('$6')).toBeInTheDocument();
   });
 
   it('does not advertise the Auto Sync plan', () => {

--- a/web/src/pages/NotionLandingPage/NotionLandingPage.tsx
+++ b/web/src/pages/NotionLandingPage/NotionLandingPage.tsx
@@ -81,7 +81,7 @@ export function NotionLandingPage() {
           />
           <PricingCard
             title="Day Pass"
-            price="$4"
+            price="$6"
             priceSuffix={t('notionLanding.dayPassSuffix')}
             benefits={dayPassBenefits}
             link={DAY_PASS_HREF}

--- a/web/src/pages/PricingPage/PricingPage.module.css
+++ b/web/src/pages/PricingPage/PricingPage.module.css
@@ -713,6 +713,10 @@
   line-height: 1.3;
 }
 
+.priceCaption {
+  composes: yearlyHint;
+}
+
 .cardTerms {
   font-family: var(--font-sans);
   font-size: var(--text-xs);

--- a/web/src/pages/PricingPage/PricingPage.test.tsx
+++ b/web/src/pages/PricingPage/PricingPage.test.tsx
@@ -117,11 +117,12 @@ describe('PricingPage Unlimited benefits', () => {
     ).toBeGreaterThan(0);
   });
 
-  it('features the Day Pass with the Most popular badge', () => {
+  it('features the Week Pass and marks the Semester Pass best value', () => {
     renderAt('/pricing');
     expect(screen.getByText('Most popular')).toBeInTheDocument();
+    expect(screen.getByText('Best value')).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: 'Get Day Pass' })
+      screen.getByRole('button', { name: 'Get Week Pass' })
     ).toBeInTheDocument();
   });
 });
@@ -182,15 +183,15 @@ describe('PricingPage layout', () => {
     expect(screen.getByText('Pay once — no subscription')).toBeInTheDocument();
   });
 
-  it('shows the Monthly plans section label', () => {
+  it('shows the subscription section label', () => {
     renderAt('/pricing');
-    expect(screen.getByText('Monthly plans')).toBeInTheDocument();
+    expect(screen.getByText('Prefer a subscription?')).toBeInTheDocument();
   });
 
   it('leads with the pay-once passes above the monthly plans', () => {
     renderAt('/pricing');
     const passLabel = screen.getByText('Pay once — no subscription');
-    const monthlyLabel = screen.getByText('Monthly plans');
+    const monthlyLabel = screen.getByText('Prefer a subscription?');
     expect(
       passLabel.compareDocumentPosition(monthlyLabel) &
         Node.DOCUMENT_POSITION_FOLLOWING
@@ -200,7 +201,7 @@ describe('PricingPage layout', () => {
   it('leads with the monthly plans when the variant is unlimited-first', () => {
     mockPricingVariant.current = 'unlimited-first';
     renderAt('/pricing');
-    const monthlyLabel = screen.getByText('Monthly plans');
+    const monthlyLabel = screen.getByText('Prefer a subscription?');
     const passLabel = screen.getByText('Pay once — no subscription');
     expect(
       monthlyLabel.compareDocumentPosition(passLabel) &

--- a/web/src/pages/PricingPage/components/ComparisonTable.tsx
+++ b/web/src/pages/PricingPage/components/ComparisonTable.tsx
@@ -153,7 +153,7 @@ export function ComparisonTable({
     return value;
   };
 
-  const planPrices = ['$0', '$4 / $9', `${unlimitedMonthlyPrice} / mo`];
+  const planPrices = ['$0', '$6 / $12', `${unlimitedMonthlyPrice} / mo`];
 
   return (
     <section className={styles.section} aria-labelledby="comparison-heading">

--- a/web/src/pages/PricingPage/components/PassCards.test.tsx
+++ b/web/src/pages/PricingPage/components/PassCards.test.tsx
@@ -1,8 +1,15 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { PassCards } from './PassCards';
 
 type Overrides = Partial<Parameters<typeof PassCards>[0]>;
+
+function cardByTitle(title: string): HTMLElement {
+  const heading = screen.getByRole('heading', { name: title });
+  const card = heading.closest('div')?.parentElement;
+  if (card == null) throw new Error(`card for ${title} not found`);
+  return card;
+}
 
 function renderPassCards(overrides: Overrides = {}) {
   const props = {
@@ -89,14 +96,55 @@ describe('PassCards', () => {
 
   it('renders correct pricing for each pass', () => {
     renderPassCards();
-    expect(screen.getByText('$4')).toBeInTheDocument();
-    expect(screen.getByText('$9')).toBeInTheDocument();
+    expect(screen.getByText('$6')).toBeInTheDocument();
+    expect(screen.getByText('$12')).toBeInTheDocument();
     expect(screen.getByText('$29')).toBeInTheDocument();
   });
 
-  it('features the Day Pass as Most popular without overclaiming', () => {
-    renderPassCards({ featureDayPass: true });
-    expect(screen.getByText('Most popular')).toBeInTheDocument();
+  it('features the Day Pass as Most popular on the limit wall', () => {
+    renderPassCards({ featureDayPass: true, onSemesterPass: undefined });
+    expect(
+      within(cardByTitle('Day Pass')).getByText('Most popular')
+    ).toBeInTheDocument();
     expect(screen.queryByText('Best value')).not.toBeInTheDocument();
+  });
+
+  it('gives the Week Pass the primary treatment on the pricing page', () => {
+    renderPassCards({ featureDayPass: false });
+    expect(
+      within(cardByTitle('Week Pass')).getByText('Most popular')
+    ).toBeInTheDocument();
+    expect(
+      within(cardByTitle('Day Pass')).queryByText('Most popular')
+    ).toBeNull();
+  });
+
+  it('marks the Semester Pass as Best value and leaves the Day Pass unbadged', () => {
+    renderPassCards({ featureDayPass: false });
+    expect(
+      within(cardByTitle('Semester Pass')).getByText('Best value')
+    ).toBeInTheDocument();
+    expect(
+      within(cardByTitle('Day Pass')).queryByText('Best value')
+    ).toBeNull();
+    expect(
+      within(cardByTitle('Day Pass')).queryByText('Most popular')
+    ).toBeNull();
+  });
+
+  it('captions each pass with its study horizon on the pricing page', () => {
+    renderPassCards({ featureDayPass: false });
+    expect(screen.getByText('One study day')).toBeInTheDocument();
+    expect(screen.getByText('One exam week')).toBeInTheDocument();
+    expect(screen.getByText('A full term')).toBeInTheDocument();
+  });
+
+  it('shows the per-week value line under the Semester Pass', () => {
+    renderPassCards({ featureDayPass: false });
+    expect(
+      within(cardByTitle('Semester Pass')).getByText(
+        '≈$2/week — 85% less than the Week Pass'
+      )
+    ).toBeInTheDocument();
   });
 });

--- a/web/src/pages/PricingPage/components/PassCards.tsx
+++ b/web/src/pages/PricingPage/components/PassCards.tsx
@@ -37,13 +37,11 @@ export function PassCards({
     <div className={styles.passGrid}>
       <PricingCard
         title="Day Pass"
-        badge={
-          featureDayPass
-            ? t('pricing.pass.mostPopular')
-            : t('pricing.pass.payOnce')
+        badge={featureDayPass ? t('pricing.pass.mostPopular') : undefined}
+        horizonCaption={
+          featureDayPass ? undefined : t('pricing.pass.horizonDay')
         }
-        badgeMuted={!featureDayPass}
-        price="$4"
+        price={PASS_PRICES['24h']}
         priceSuffix={t('pricing.pass.day24')}
         benefits={benefits}
         onAction={onDayPass}
@@ -57,7 +55,11 @@ export function PassCards({
       />
       <PricingCard
         title="Week Pass"
-        price="$9"
+        badge={featureDayPass ? undefined : t('pricing.pass.mostPopular')}
+        horizonCaption={
+          featureDayPass ? undefined : t('pricing.pass.horizonWeek')
+        }
+        price={PASS_PRICES['7d']}
         priceSuffix={t('pricing.pass.week1')}
         benefits={benefits}
         onAction={onWeekPass}
@@ -67,10 +69,15 @@ export function PassCards({
             : t('pricing.pass.getWeekPass')
         }
         actionDisabled={weekPassPending}
+        className={featureDayPass ? undefined : styles.cardPro}
       />
       {onSemesterPass != null && (
         <PricingCard
           title="Semester Pass"
+          badge={t('pricing.pass.bestValue')}
+          badgeMuted
+          horizonCaption={t('pricing.pass.horizonSemester')}
+          valueCaption={t('pricing.pass.semesterPerWeek')}
           price={PASS_PRICES['120d']}
           priceSuffix={t('pricing.pass.semester4mo')}
           benefits={benefits}

--- a/web/src/pages/PricingPage/components/PricingCard.tsx
+++ b/web/src/pages/PricingPage/components/PricingCard.tsx
@@ -12,6 +12,8 @@ interface PricingCardProp {
   title: string;
   badge?: string;
   badgeMuted?: boolean;
+  horizonCaption?: string;
+  valueCaption?: string;
   benefits: string[];
   link?: string;
   linkText?: string;
@@ -54,6 +56,8 @@ export function PricingCard({
   title,
   badge,
   badgeMuted,
+  horizonCaption,
+  valueCaption,
   benefits,
   linkText,
   link,
@@ -103,6 +107,12 @@ export function PricingCard({
       <div className={styles.cardHeader}>
         <h3 className={styles.cardTitle}>{title}</h3>
         {priceNode}
+        {horizonCaption != null && (
+          <p className={styles.priceCaption}>{horizonCaption}</p>
+        )}
+        {valueCaption != null && (
+          <p className={styles.priceCaption}>{valueCaption}</p>
+        )}
       </div>
       <div className={styles.cardBody}>
         {benefits.map((benefit) => (

--- a/web/src/pages/PricingPage/components/UnlimitedCard.tsx
+++ b/web/src/pages/PricingPage/components/UnlimitedCard.tsx
@@ -82,9 +82,6 @@ export function UnlimitedCard({
 
   return (
     <div className={`${styles.card} ${styles.cardPro}`}>
-      <span className={styles.cardBadge}>
-        {t('pricing.unlimited.mostPopular')}
-      </span>
       <div className={styles.cardHeader}>
         <h3 className={styles.cardTitle}>Unlimited</h3>
         <span className={styles.cardPriceLine}>
@@ -161,6 +158,9 @@ export function UnlimitedCard({
         ) : (
           <p className={styles.cardTerms}>{terms}</p>
         )}
+        <p className={styles.cardCaption}>
+          {t('pricing.unlimited.pauseReassurance')}
+        </p>
       </div>
     </div>
   );

--- a/web/src/pages/PricingPage/payment.links.ts
+++ b/web/src/pages/PricingPage/payment.links.ts
@@ -1,5 +1,10 @@
+// These displayed prices MUST match the live Stripe prices behind the
+// PASS_24H_PRICE_ID / PASS_7D_PRICE_ID / PASS_120D_PRICE_ID env vars — a
+// mismatch shows one price on the page and charges another at checkout.
+// The pricing.pass.semesterPerWeek i18n string also hardcodes math derived
+// from the 120d ($29) and 7d ($12) values; re-derive it when either changes.
 export const PASS_PRICES = {
-  '24h': '$4',
-  '7d': '$9',
+  '24h': '$6',
+  '7d': '$12',
   '120d': '$29',
 } as const;

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -1412,7 +1412,7 @@ function UploadForm({
                 onClick={handleDayPass}
                 disabled={dayPassPending}
               >
-                {dayPassPending ? 'Starting checkout' : 'Get Day Pass — $4'}
+                {dayPassPending ? 'Starting checkout' : 'Get Day Pass — $6'}
               </button>
               <Link
                 to="/limit?ref=upload-limit-wall"
@@ -1723,7 +1723,7 @@ function UploadForm({
             onClick={handleDayPass}
             disabled={dayPassPending}
           >
-            {dayPassPending ? 'Starting checkout' : 'Get Day Pass — $4'}
+            {dayPassPending ? 'Starting checkout' : 'Get Day Pass — $6'}
           </button>
           <Link
             to="/limit?ref=upload-limit-wall"

--- a/web/src/pages/WhatsNewPage/changelog/2026-09-02-pass-pricing.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-09-02-pass-pricing.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-09-02-pass-pricing",
+  "date": "2026-09-02",
+  "type": "feature",
+  "title": "Passes now cost $6 for a day, $12 for a week, and $29 for a semester, shown on a clearer pricing page"
+}


### PR DESCRIPTION
## What
Two things in one PR on the pricing surfaces: (A) new pass display prices — Day $6, Week $12, Semester stays $29 — everywhere a pass price is shown, and (B) a re-weighting of `/pricing` that moves the primary treatment onto the Week Pass, marks the Semester Pass as best value, and adds study-horizon captions, plus a pause reassurance line under the Unlimited CTA.

## Why
The passes were repriced Stripe-side; this brings the displayed numbers in line so the page and the charge cannot diverge. The re-weighting steers buyers from the impulse Day Pass toward the higher-value Week and Semester passes — the passes with more per-user value.

## How
- `PASS_PRICES` (`payment.links.ts`) is the display source of truth; a comment there flags the Stripe-price coupling and the `semesterPerWeek` derived-math coupling. `PassCards` now reads `PASS_PRICES` for all three cards.
- Every other surface that shows a Day/Week pass price updated: `ComparisonTable`, `NotionLandingPage`, `UploadForm`, `LandingPage` default, the `landing`/`search` i18n strings (10 locales), and the `plans.md` docs (en + de).
- `PassCards`: order stays Day → Week → Semester. On the pricing page (`featureDayPass={false}`) the Week card gets `cardPro` + the indigo `Most popular` badge, the Semester card gets the muted `Best value` badge, the Day card is unbadged; each card shows a muted horizon caption under its price and the Semester card adds the per-week value line — all Semester-only lines live inside the Semester conditional. The limit-wall usage (`featureDayPass`) is unchanged.
- `UnlimitedCard`: removed the hardcoded `Most popular` badge; added a muted pause-reassurance caption under the terms line. Billing toggle untouched (monthly pre-selected).
- Section heading "Monthly plans" → "Prefer a subscription?" in all 10 locales.
- New i18n keys added to all 10 locales (`pricing.pass.bestValue/horizonDay/horizonWeek/horizonSemester/semesterPerWeek`, `pricing.unlimited.pauseReassurance`); now-unused `pricing.pass.payOnce` and `pricing.unlimited.mostPopular` removed from all 10.

Two deviations from the handoff, flagged: (1) the muted-badge styling already existed as `.cardBadgeMuted` (wired through `PricingCard`'s `badgeMuted` prop) — reused it instead of adding a duplicate `.badgeMuted`; (2) the `$6` sentinel in two "no hardcoded Unlimited monthly price" guard tests (LimitPage, NotionLandingPage) now collides with the Day Pass price, so those guards were re-scoped to the Unlimited card rather than a page-wide `$6` absence.

## Measuring success
Pricing funnel at `/api/ops/metrics`: `page → checkout` and `checkout → paid` for the pass products, plus the split of pass sales across Day/Week/Semester (target: share shifts toward Week + Semester). Read at the next weekly retro against the ~23 pass sales/wk baseline.

## Testing
- Full web vitest: 386 files, 3533 tests, all passing.
- Web `tsc --noEmit`: clean.
- `pnpm format:check` (tree-wide `src web/src`): clean.
- `pnpm --filter 2anki-web test:golden-path`: 4 passed.
- Unit tests added/updated: `PassCards.test.tsx` (prices $6/$12/$29, Week-primary/Semester-best-value/Day-unbadged, horizon captions, per-week value line), `PricingPage.test.tsx` (heading, re-weighted badges), plus price-literal + guard updates in `NotionLandingPage`, `LimitPage`, `DownloadsPage`, `ConversionResult`, `UpsellCard` tests.
- No server `src/` changes; server Jest not required.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px

Evidence: `pnpm --filter 2anki-web test:golden-path` drives the golden path at a 375px viewport with the backend mocked at the network edge and fails on any console error — ran green (4 passed).

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-09-02-pass-pricing.json` — "Passes now cost $6 for a day, $12 for a week, and $29 for a semester, shown on a clearer pricing page". (The Semester Pass launch itself was already announced by 2026-09-02-semester-pass.json from #4322, so this entry states the new prices plainly rather than re-announcing the pass.)

## Locked decisions
| Item | Value |
| --- | --- |
| Day Pass | $6 |
| Week Pass | $12 |
| Semester Pass | $29 |
| Subscription (Unlimited) pricing | untouched — monthly pre-selected, annual not default |

## Deploy coordination
Alexander must update prod env before or with this deploy: PASS_24H_PRICE_ID=price_1UBCziB4lekI0uHm1uA0UyLn, PASS_7D_PRICE_ID=price_1UBCzoB4lekI0uHm0mLkYz8K, PASS_120D_PRICE_ID=price_1UBCztB4lekI0uHmBzXigKpv. Old Stripe prices stay active until the flip, so the page and the charge cannot diverge mid-deploy.

## Risks
Display/Stripe divergence if the env price IDs are not flipped in step with this deploy — mitigated by the coordination note above and the coupling comment in `payment.links.ts`. Rollback is a straight revert; no schema or server changes.

## Goal alignment
Revenue lever: raises per-user value on the pay-once passes and nudges buyers toward the higher-value Week/Semester tiers. Metric to move: pass-product `checkout → paid` mix and per-pass revenue share, read at `/api/ops/metrics` / the weekly retro.

Pricing rail — do not merge from an agent. Awaiting Alexander's review in the GitHub UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TqUDQZHTnn6LkPHasw4C9f
