### PR TITLE
feat: resolve pass prices from Stripe at runtime

### DIFF
--- a/src/controllers/PassPricingController.test.ts
+++ b/src/controllers/PassPricingController.test.ts
@@ -1,0 +1,53 @@
+import { Request, Response } from 'express';
+import PassPricingController from './PassPricingController';
+import type {
+  GetPassPricingUseCase,
+  PassPricingResponse,
+} from '../usecases/checkout/GetPassPricingUseCase';
+
+const buildResponse = () => {
+  const res = {} as Response;
+  res.set = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  res.status = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+const makeUseCase = (response: PassPricingResponse): GetPassPricingUseCase =>
+  ({
+    execute: jest.fn().mockResolvedValue(response),
+  }) as unknown as GetPassPricingUseCase;
+
+describe('PassPricingController', () => {
+  it('returns the pass pricing payload as json', async () => {
+    const payload: PassPricingResponse = {
+      passes: { '24h': { amount: 600, currency: 'usd', display: '$6' } },
+    };
+    const res = buildResponse();
+
+    await new PassPricingController(makeUseCase(payload)).getPassPricing(
+      {} as Request,
+      res
+    );
+
+    expect(res.json).toHaveBeenCalledWith(payload);
+  });
+
+  it('sets a short public Cache-Control header', async () => {
+    const res = buildResponse();
+
+    await new PassPricingController(makeUseCase({ passes: {} })).getPassPricing(
+      {} as Request,
+      res
+    );
+
+    expect(res.set).toHaveBeenCalledWith(
+      'Cache-Control',
+      expect.stringContaining('public')
+    );
+    expect(res.set).toHaveBeenCalledWith(
+      'Cache-Control',
+      expect.stringContaining('max-age=')
+    );
+  });
+});

--- a/src/controllers/PassPricingController.ts
+++ b/src/controllers/PassPricingController.ts
@@ -1,0 +1,16 @@
+import { Request, Response } from 'express';
+import type { GetPassPricingUseCase } from '../usecases/checkout/GetPassPricingUseCase';
+
+const CACHE_CONTROL = 'public, max-age=300';
+
+class PassPricingController {
+  constructor(private readonly useCase: GetPassPricingUseCase) {}
+
+  async getPassPricing(_req: Request, res: Response): Promise<void> {
+    const pricing = await this.useCase.execute();
+    res.set('Cache-Control', CACHE_CONTROL);
+    res.json(pricing);
+  }
+}
+
+export default PassPricingController;

--- a/src/env.example
+++ b/src/env.example
@@ -45,10 +45,13 @@ DATABASE_URL='postgresql://localhost:5432/n'
 STRIPE_KEY=''
 # Stripe webhook signing secret. Verifies POST /webhook against the raw request body.
 STRIPE_ENDPOINT_SECRET=''
+# Pass prices are resolved at runtime from Stripe by the price metadata key
+# 2anki_pass_kind (24h / 7d / 120d), so Stripe is the single source of truth and
+# the displayed price can never diverge from the amount charged. These PASS_*_PRICE_ID
+# vars are the transition fallback only: used when Stripe resolution has never
+# succeeded (cold start). Unset AND no Stripe resolution = the pass route returns 503.
 PASS_24H_PRICE_ID=''
 PASS_7D_PRICE_ID=''
-# Stripe one-time Price id for the Semester Pass (120-day access). Unset = the
-# /api/checkout/pass/120d route returns 503 and the card is not sold.
 PASS_120D_PRICE_ID=''
 # Legacy Unlimited Stripe price IDs. Served to grandfathered accounts and used as the
 # fallback when v2 lookup_key resolution fails. v2 prices are resolved at runtime by

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -20,9 +20,18 @@ const WARN_VARS: ReadonlyArray<[string, string]> = [
   ['DATABASE_URL', 'Postgres connection; without it every query fails'],
   ['STRIPE_KEY', 'checkout, subscriptions, and Stripe sync'],
   ['STRIPE_ENDPOINT_SECRET', 'verifies Stripe webhook signatures'],
-  ['PASS_24H_PRICE_ID', 'day-pass checkout price'],
-  ['PASS_7D_PRICE_ID', 'week-pass checkout price'],
-  ['PASS_120D_PRICE_ID', 'semester-pass checkout price'],
+  [
+    'PASS_24H_PRICE_ID',
+    'day-pass price fallback (runtime resolves from Stripe)',
+  ],
+  [
+    'PASS_7D_PRICE_ID',
+    'week-pass price fallback (runtime resolves from Stripe)',
+  ],
+  [
+    'PASS_120D_PRICE_ID',
+    'semester-pass price fallback (runtime resolves from Stripe)',
+  ],
   ['UNLIMITED_MONTHLY_PRICE_ID', 'legacy monthly price and v2 fallback'],
   ['UNLIMITED_YEARLY_PRICE_ID', 'legacy annual price and v2 fallback'],
   ['ANTHROPIC_API_KEY', 'AI card generation, chat assistant, file conversion'],

--- a/src/routes/CheckoutRouter.test.ts
+++ b/src/routes/CheckoutRouter.test.ts
@@ -56,6 +56,8 @@ describe('CheckoutRouter — pass routes', () => {
   let url: string;
 
   beforeAll(async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
     ({ server, url } = await buildServer());
   });
 
@@ -238,6 +240,29 @@ describe('CheckoutRouter — pass routes', () => {
           line_items: [{ price: 'price_120d_test', quantity: 1 }],
         })
       );
+    });
+  });
+
+  describe('GET /api/pricing', () => {
+    it('responds 200 with a passes object', async () => {
+      const res = await fetch(`${url}/api/pricing`);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toHaveProperty('passes');
+      expect(typeof body.passes).toBe('object');
+    });
+
+    it('sets a public, cacheable Cache-Control header', async () => {
+      const res = await fetch(`${url}/api/pricing`);
+      const cacheControl = res.headers.get('cache-control');
+      expect(cacheControl).toContain('public');
+      expect(cacheControl).toContain('max-age=');
+    });
+
+    it('omits passes when Stripe amounts cannot be resolved', async () => {
+      const res = await fetch(`${url}/api/pricing`);
+      const body = await res.json();
+      expect(body.passes).toEqual({});
     });
   });
 });

--- a/src/routes/CheckoutRouter.ts
+++ b/src/routes/CheckoutRouter.ts
@@ -16,6 +16,9 @@ import { getEventsSink } from '../services/events/eventsSinkInstance';
 import { FeatureFlagsRepository } from '../data_layer/FeatureFlagsRepository';
 import UsersRepository from '../data_layer/UsersRepository';
 import { StripePriceResolver } from '../services/StripePriceResolver';
+import { getPricingService } from '../services/pricingServiceInstance';
+import { GetPassPricingUseCase } from '../usecases/checkout/GetPassPricingUseCase';
+import PassPricingController from '../controllers/PassPricingController';
 import { PRICING_V2_FLAG } from '../usecases/checkout/pricingV2';
 import PricingController from '../controllers/PricingController';
 
@@ -77,6 +80,7 @@ const CheckoutRouter = () => {
   const unlimitedMonthlyPriceId = process.env.UNLIMITED_MONTHLY_PRICE_ID ?? '';
   const unlimitedYearlyPriceId = process.env.UNLIMITED_YEARLY_PRICE_ID ?? '';
   const priceResolver = new StripePriceResolver(getStripe());
+  const pricingService = getPricingService();
 
   router.post(
     '/api/checkout/unlimited',
@@ -135,9 +139,9 @@ const CheckoutRouter = () => {
     '/api/checkout/pass/24h',
     optionalAuthMiddleware,
     express.json(),
-    (req, res) => {
-      const pass24hPriceId = process.env.PASS_24H_PRICE_ID ?? '';
-      if (pass24hPriceId === '') {
+    async (req, res) => {
+      const pass24hPriceId = await pricingService.resolvePriceId('24h');
+      if (pass24hPriceId == null) {
         return res
           .status(503)
           .json({ message: 'Day Pass is not available right now.' });
@@ -156,9 +160,9 @@ const CheckoutRouter = () => {
     '/api/checkout/pass/7d',
     optionalAuthMiddleware,
     express.json(),
-    (req, res) => {
-      const pass7dPriceId = process.env.PASS_7D_PRICE_ID ?? '';
-      if (pass7dPriceId === '') {
+    async (req, res) => {
+      const pass7dPriceId = await pricingService.resolvePriceId('7d');
+      if (pass7dPriceId == null) {
         return res
           .status(503)
           .json({ message: 'Week Pass is not available right now.' });
@@ -177,9 +181,9 @@ const CheckoutRouter = () => {
     '/api/checkout/pass/120d',
     optionalAuthMiddleware,
     express.json(),
-    (req, res) => {
-      const pass120dPriceId = process.env.PASS_120D_PRICE_ID ?? '';
-      if (pass120dPriceId === '') {
+    async (req, res) => {
+      const pass120dPriceId = await pricingService.resolvePriceId('120d');
+      if (pass120dPriceId == null) {
         return res
           .status(503)
           .json({ message: 'Semester Pass is not available right now.' });
@@ -193,6 +197,28 @@ const CheckoutRouter = () => {
       return controller.createSession(req, res);
     }
   );
+
+  /**
+   * @swagger
+   * /api/pricing:
+   *   get:
+   *     summary: Get the current one-time pass prices
+   *     description: |
+   *       Returns the live amount, currency, and formatted display string for
+   *       each pass kind (24h, 7d, 120d), resolved from Stripe by price
+   *       metadata so the displayed price can never diverge from the amount
+   *       charged at checkout. Public and cacheable; a pass whose amount cannot
+   *       be resolved from Stripe is omitted so the client keeps its fallback.
+   *     tags: [Payments]
+   *     responses:
+   *       200:
+   *         description: Amount, currency, and display string per pass kind
+   */
+  router.get('/api/pricing', (req, res) => {
+    const useCase = new GetPassPricingUseCase(pricingService);
+    const controller = new PassPricingController(useCase);
+    return controller.getPassPricing(req, res);
+  });
 
   /**
    * @swagger

--- a/src/services/PricingService.test.ts
+++ b/src/services/PricingService.test.ts
@@ -1,0 +1,194 @@
+import { PricingService, PASS_PRICE_KINDS } from './PricingService';
+
+interface FakePrice {
+  id: string;
+  unit_amount: number | null;
+  currency: string;
+  created: number;
+}
+
+const makeStripe = (searchImpl: jest.Mock) =>
+  ({ prices: { search: searchImpl } }) as never;
+
+const price = (over: Partial<FakePrice> = {}): FakePrice => ({
+  id: 'price_default',
+  unit_amount: 600,
+  currency: 'usd',
+  created: 1000,
+  ...over,
+});
+
+describe('PricingService', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    delete process.env.PASS_24H_PRICE_ID;
+    delete process.env.PASS_7D_PRICE_ID;
+    delete process.env.PASS_120D_PRICE_ID;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  it('resolves the active price for a pass kind by its metadata', async () => {
+    const search = jest.fn().mockResolvedValue({
+      data: [price({ id: 'price_24h', unit_amount: 600, currency: 'usd' })],
+    });
+    const service = new PricingService(makeStripe(search));
+
+    const resolved = await service.resolve('24h');
+
+    expect(resolved).toEqual({
+      kind: '24h',
+      priceId: 'price_24h',
+      amount: 600,
+      currency: 'usd',
+      source: 'stripe',
+    });
+    expect(search).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.stringContaining("metadata['2anki_pass_kind']:'24h'"),
+      })
+    );
+    expect(search.mock.calls[0][0].query).toContain("active:'true'");
+  });
+
+  it('picks the newest active price and warns when more than one matches', async () => {
+    const warn = jest.spyOn(console, 'warn');
+    const search = jest.fn().mockResolvedValue({
+      data: [
+        price({ id: 'price_old', created: 1000, unit_amount: 500 }),
+        price({ id: 'price_new', created: 2000, unit_amount: 700 }),
+      ],
+    });
+    const service = new PricingService(makeStripe(search));
+
+    const resolved = await service.resolve('7d');
+
+    expect(resolved.priceId).toBe('price_new');
+    expect(resolved.amount).toBe(700);
+    expect(warn).toHaveBeenCalledWith(
+      'pricing.pass.multiple_active',
+      expect.objectContaining({ kind: '7d', count: 2 })
+    );
+  });
+
+  it('serves the cached result within the TTL without calling Stripe again', async () => {
+    jest.useFakeTimers();
+    const search = jest.fn().mockResolvedValue({
+      data: [price({ id: 'price_120d' })],
+    });
+    const service = new PricingService(makeStripe(search));
+
+    await service.resolve('120d');
+    jest.advanceTimersByTime(4 * 60 * 1000);
+    await service.resolve('120d');
+
+    expect(search).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
+  });
+
+  it('re-resolves from Stripe once the 5-minute TTL has elapsed', async () => {
+    jest.useFakeTimers();
+    const search = jest.fn().mockResolvedValue({
+      data: [price({ id: 'price_120d' })],
+    });
+    const service = new PricingService(makeStripe(search));
+
+    await service.resolve('120d');
+    jest.advanceTimersByTime(5 * 60 * 1000 + 1);
+    await service.resolve('120d');
+
+    expect(search).toHaveBeenCalledTimes(2);
+    jest.useRealTimers();
+  });
+
+  it('serves the last-known-good result when Stripe fails after a prior success', async () => {
+    jest.useFakeTimers();
+    const search = jest
+      .fn()
+      .mockResolvedValueOnce({ data: [price({ id: 'price_24h_good' })] })
+      .mockRejectedValueOnce(new Error('stripe down'));
+    const service = new PricingService(makeStripe(search));
+
+    const first = await service.resolve('24h');
+    jest.advanceTimersByTime(6 * 60 * 1000);
+    const second = await service.resolve('24h');
+
+    expect(first.source).toBe('stripe');
+    expect(second.priceId).toBe('price_24h_good');
+    expect(second.source).toBe('cache');
+    jest.useRealTimers();
+  });
+
+  it('falls back to the env price id on a cold start with no prior success', async () => {
+    process.env.PASS_24H_PRICE_ID = 'price_env_24h';
+    const search = jest.fn().mockRejectedValue(new Error('stripe down'));
+    const service = new PricingService(makeStripe(search));
+
+    const resolved = await service.resolve('24h');
+
+    expect(resolved).toEqual({
+      kind: '24h',
+      priceId: 'price_env_24h',
+      amount: null,
+      currency: null,
+      source: 'env',
+    });
+  });
+
+  it('returns a null price id when Stripe, cache, and env are all unavailable', async () => {
+    const search = jest.fn().mockRejectedValue(new Error('stripe down'));
+    const service = new PricingService(makeStripe(search));
+
+    const resolved = await service.resolve('7d');
+
+    expect(resolved.priceId).toBeNull();
+    expect(resolved.source).toBe('none');
+  });
+
+  it('falls back to env when the Stripe search returns no matching price', async () => {
+    process.env.PASS_120D_PRICE_ID = 'price_env_120d';
+    const search = jest.fn().mockResolvedValue({ data: [] });
+    const service = new PricingService(makeStripe(search));
+
+    const resolved = await service.resolve('120d');
+
+    expect(resolved.priceId).toBe('price_env_120d');
+    expect(resolved.source).toBe('env');
+  });
+
+  it('resolvePriceId returns just the price id string', async () => {
+    const search = jest.fn().mockResolvedValue({
+      data: [price({ id: 'price_7d' })],
+    });
+    const service = new PricingService(makeStripe(search));
+
+    expect(await service.resolvePriceId('7d')).toBe('price_7d');
+  });
+
+  it('resolveAll resolves every pass kind', async () => {
+    const search = jest.fn().mockImplementation((params: { query: string }) => {
+      const kind = PASS_PRICE_KINDS.find((k) =>
+        params.query.includes(`:'${k}'`)
+      );
+      return Promise.resolve({
+        data: [price({ id: `price_${kind}`, unit_amount: 100 })],
+      });
+    });
+    const service = new PricingService(makeStripe(search));
+
+    const all = await service.resolveAll();
+
+    expect(all.map((r) => r.kind)).toEqual(['24h', '7d', '120d']);
+    expect(all.map((r) => r.priceId)).toEqual([
+      'price_24h',
+      'price_7d',
+      'price_120d',
+    ]);
+  });
+});

--- a/src/services/PricingService.test.ts
+++ b/src/services/PricingService.test.ts
@@ -191,4 +191,19 @@ describe('PricingService', () => {
       'price_120d',
     ]);
   });
+
+  it('coalesces concurrent cold-cache resolutions into one Stripe call', async () => {
+    const search = jest.fn().mockResolvedValue({
+      data: [price({ id: 'price_24h_coalesced' })],
+    });
+    const service = new PricingService(makeStripe(search));
+    const [a, b, c] = await Promise.all([
+      service.resolve('24h'),
+      service.resolve('24h'),
+      service.resolve('24h'),
+    ]);
+    expect(search).toHaveBeenCalledTimes(1);
+    expect(a.priceId).toBe(b.priceId);
+    expect(b.priceId).toBe(c.priceId);
+  });
 });

--- a/src/services/PricingService.ts
+++ b/src/services/PricingService.ts
@@ -1,0 +1,131 @@
+import type { Stripe as StripeTypes } from 'stripe/cjs/stripe.core';
+
+export type PassPriceKind = '24h' | '7d' | '120d';
+
+export const PASS_PRICE_KINDS: readonly PassPriceKind[] = ['24h', '7d', '120d'];
+
+export type PassPriceSource = 'stripe' | 'cache' | 'env' | 'none';
+
+export interface ResolvedPassPrice {
+  kind: PassPriceKind;
+  priceId: string | null;
+  amount: number | null;
+  currency: string | null;
+  source: PassPriceSource;
+}
+
+const PASS_KIND_METADATA_KEY = '2anki_pass_kind';
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const SEARCH_LIMIT = 100;
+
+const ENV_PRICE_ID_BY_KIND: Record<PassPriceKind, string> = {
+  '24h': 'PASS_24H_PRICE_ID',
+  '7d': 'PASS_7D_PRICE_ID',
+  '120d': 'PASS_120D_PRICE_ID',
+};
+
+const envPriceId = (kind: PassPriceKind): string =>
+  process.env[ENV_PRICE_ID_BY_KIND[kind]] ?? '';
+
+interface CacheEntry {
+  record: ResolvedPassPrice;
+  expiresAt: number;
+}
+
+export class PricingService {
+  private readonly cache = new Map<PassPriceKind, CacheEntry>();
+  private readonly lastKnownGood = new Map<PassPriceKind, ResolvedPassPrice>();
+
+  constructor(private readonly stripe: Pick<StripeTypes, 'prices'>) {}
+
+  async resolve(kind: PassPriceKind): Promise<ResolvedPassPrice> {
+    const cached = this.cache.get(kind);
+    if (cached != null && cached.expiresAt > Date.now()) {
+      return cached.record;
+    }
+
+    const fresh = await this.resolveFromStripe(kind);
+    if (fresh != null) {
+      this.cache.set(kind, {
+        record: fresh,
+        expiresAt: Date.now() + CACHE_TTL_MS,
+      });
+      this.lastKnownGood.set(kind, fresh);
+      return fresh;
+    }
+
+    return this.fallback(kind);
+  }
+
+  async resolvePriceId(kind: PassPriceKind): Promise<string | null> {
+    return (await this.resolve(kind)).priceId;
+  }
+
+  async resolveAll(): Promise<ResolvedPassPrice[]> {
+    return Promise.all(PASS_PRICE_KINDS.map((kind) => this.resolve(kind)));
+  }
+
+  private async resolveFromStripe(
+    kind: PassPriceKind
+  ): Promise<ResolvedPassPrice | null> {
+    try {
+      const result = await this.stripe.prices.search({
+        query: `metadata['${PASS_KIND_METADATA_KEY}']:'${kind}' AND active:'true'`,
+        limit: SEARCH_LIMIT,
+      });
+      const prices = result.data ?? [];
+      if (prices.length === 0) {
+        console.warn('pricing.pass.miss', { kind });
+        return null;
+      }
+      if (prices.length > 1) {
+        console.warn('pricing.pass.multiple_active', {
+          kind,
+          count: prices.length,
+        });
+      }
+      const chosen = prices.reduce((newest, current) =>
+        current.created > newest.created ? current : newest
+      );
+      return {
+        kind,
+        priceId: chosen.id,
+        amount: chosen.unit_amount,
+        currency: chosen.currency,
+        source: 'stripe',
+      };
+    } catch (error) {
+      console.error('pricing.pass.resolve_failed', {
+        kind,
+        message: error instanceof Error ? error.message : 'unknown',
+      });
+      return null;
+    }
+  }
+
+  private fallback(kind: PassPriceKind): ResolvedPassPrice {
+    const known = this.lastKnownGood.get(kind);
+    if (known != null) {
+      return { ...known, source: 'cache' };
+    }
+
+    const fallbackPriceId = envPriceId(kind);
+    if (fallbackPriceId !== '') {
+      return {
+        kind,
+        priceId: fallbackPriceId,
+        amount: null,
+        currency: null,
+        source: 'env',
+      };
+    }
+
+    return {
+      kind,
+      priceId: null,
+      amount: null,
+      currency: null,
+      source: 'none',
+    };
+  }
+}

--- a/src/services/PricingService.ts
+++ b/src/services/PricingService.ts
@@ -34,6 +34,10 @@ interface CacheEntry {
 
 export class PricingService {
   private readonly cache = new Map<PassPriceKind, CacheEntry>();
+  private readonly inFlight = new Map<
+    PassPriceKind,
+    Promise<ResolvedPassPrice | null>
+  >();
   private readonly lastKnownGood = new Map<PassPriceKind, ResolvedPassPrice>();
 
   constructor(private readonly stripe: Pick<StripeTypes, 'prices'>) {}
@@ -44,7 +48,19 @@ export class PricingService {
       return cached.record;
     }
 
-    const fresh = await this.resolveFromStripe(kind);
+    const pending = this.inFlight.get(kind);
+    if (pending != null) {
+      const shared = await pending;
+      if (shared != null) {
+        return shared;
+      }
+      return this.fallback(kind);
+    }
+    const request = this.resolveFromStripe(kind).finally(() => {
+      this.inFlight.delete(kind);
+    });
+    this.inFlight.set(kind, request);
+    const fresh = await request;
     if (fresh != null) {
       this.cache.set(kind, {
         record: fresh,

--- a/src/services/pricingServiceInstance.ts
+++ b/src/services/pricingServiceInstance.ts
@@ -1,0 +1,15 @@
+import { PricingService } from './PricingService';
+import { getStripe } from '../lib/integrations/stripe';
+
+let instance: PricingService | null = null;
+
+export const getPricingService = (): PricingService => {
+  if (instance == null) {
+    instance = new PricingService(getStripe());
+  }
+  return instance;
+};
+
+export const resetPricingServiceForTesting = (): void => {
+  instance = null;
+};

--- a/src/usecases/checkout/GetPassPricingUseCase.test.ts
+++ b/src/usecases/checkout/GetPassPricingUseCase.test.ts
@@ -1,0 +1,108 @@
+import { GetPassPricingUseCase } from './GetPassPricingUseCase';
+import type {
+  PricingService,
+  ResolvedPassPrice,
+} from '../../services/PricingService';
+
+const makeService = (records: ResolvedPassPrice[]): PricingService =>
+  ({
+    resolveAll: jest.fn().mockResolvedValue(records),
+  }) as unknown as PricingService;
+
+describe('GetPassPricingUseCase', () => {
+  it('maps resolved prices into the pass pricing response with a display string', async () => {
+    const service = makeService([
+      {
+        kind: '24h',
+        priceId: 'p1',
+        amount: 600,
+        currency: 'usd',
+        source: 'stripe',
+      },
+      {
+        kind: '7d',
+        priceId: 'p2',
+        amount: 1200,
+        currency: 'usd',
+        source: 'stripe',
+      },
+      {
+        kind: '120d',
+        priceId: 'p3',
+        amount: 2900,
+        currency: 'usd',
+        source: 'stripe',
+      },
+    ]);
+
+    const result = await new GetPassPricingUseCase(service).execute();
+
+    expect(result).toEqual({
+      passes: {
+        '24h': { amount: 600, currency: 'usd', display: '$6' },
+        '7d': { amount: 1200, currency: 'usd', display: '$12' },
+        '120d': { amount: 2900, currency: 'usd', display: '$29' },
+      },
+    });
+  });
+
+  it('renders cents with two decimals when the amount is not a whole dollar', async () => {
+    const service = makeService([
+      {
+        kind: '24h',
+        priceId: 'p1',
+        amount: 650,
+        currency: 'usd',
+        source: 'stripe',
+      },
+    ]);
+
+    const result = await new GetPassPricingUseCase(service).execute();
+
+    expect(result.passes['24h']?.display).toBe('$6.50');
+  });
+
+  it('omits a pass whose amount could not be resolved from Stripe', async () => {
+    const service = makeService([
+      {
+        kind: '24h',
+        priceId: 'env_price',
+        amount: null,
+        currency: null,
+        source: 'env',
+      },
+      {
+        kind: '7d',
+        priceId: 'p2',
+        amount: 1200,
+        currency: 'usd',
+        source: 'stripe',
+      },
+    ]);
+
+    const result = await new GetPassPricingUseCase(service).execute();
+
+    expect(result.passes['24h']).toBeUndefined();
+    expect(result.passes['7d']).toEqual({
+      amount: 1200,
+      currency: 'usd',
+      display: '$12',
+    });
+  });
+
+  it('formats non-usd currencies with their symbol', async () => {
+    const service = makeService([
+      {
+        kind: '24h',
+        priceId: 'p1',
+        amount: 500,
+        currency: 'eur',
+        source: 'stripe',
+      },
+    ]);
+
+    const result = await new GetPassPricingUseCase(service).execute();
+
+    expect(result.passes['24h']?.display).toBe('€5');
+  });
+});

--- a/src/usecases/checkout/GetPassPricingUseCase.ts
+++ b/src/usecases/checkout/GetPassPricingUseCase.ts
@@ -1,0 +1,59 @@
+import type {
+  PassPriceKind,
+  PricingService,
+  ResolvedPassPrice,
+} from '../../services/PricingService';
+
+export interface PassPriceView {
+  amount: number;
+  currency: string;
+  display: string;
+}
+
+export interface PassPricingResponse {
+  passes: Partial<Record<PassPriceKind, PassPriceView>>;
+}
+
+const CURRENCY_SYMBOLS: Record<string, string> = {
+  usd: '$',
+  eur: '€',
+  gbp: '£',
+};
+
+const symbolFor = (currency: string): string =>
+  CURRENCY_SYMBOLS[currency.toLowerCase()] ?? `${currency.toUpperCase()} `;
+
+const formatDisplay = (amount: number, currency: string): string => {
+  const dollars = amount / 100;
+  const rendered = amount % 100 === 0 ? String(dollars) : dollars.toFixed(2);
+  return `${symbolFor(currency)}${rendered}`;
+};
+
+export class GetPassPricingUseCase {
+  constructor(private readonly pricingService: PricingService) {}
+
+  async execute(): Promise<PassPricingResponse> {
+    const resolved = await this.pricingService.resolveAll();
+    const passes: PassPricingResponse['passes'] = {};
+
+    for (const record of resolved) {
+      const view = this.toView(record);
+      if (view != null) {
+        passes[record.kind] = view;
+      }
+    }
+
+    return { passes };
+  }
+
+  private toView(record: ResolvedPassPrice): PassPriceView | null {
+    if (record.amount == null || record.currency == null) {
+      return null;
+    }
+    return {
+      amount: record.amount,
+      currency: record.currency,
+      display: formatDisplay(record.amount, record.currency),
+    };
+  }
+}

--- a/web/src/components/UpsellCard/UpsellCard.tsx
+++ b/web/src/components/UpsellCard/UpsellCard.tsx
@@ -7,7 +7,7 @@ import { get2ankiApi } from '../../lib/backend/get2ankiApi';
 import { useCardUsage } from '../../lib/hooks/useCardUsage';
 import { useUserLocals } from '../../lib/hooks/useUserLocals';
 import { isPayingUser } from '../NavigationBar/helpers/getPlanLabel';
-import { PASS_PRICES } from '../../pages/PricingPage/payment.links';
+import { usePassPrices } from '../../lib/hooks/usePassPrices';
 import styles from './UpsellCard.module.css';
 
 type Surface = 'downloads_upsell' | 'upload_success_upsell';
@@ -32,6 +32,7 @@ export function UpsellCard({
   hideForAnonymous = false,
 }: UpsellCardProps) {
   const { t } = useTranslation('marketing');
+  const passPrices = usePassPrices();
   const { data } = useUserLocals();
   const [pendingKind, setPendingKind] = useState<'24h' | '7d' | null>(null);
   const upgradeClickedRef = useRef(false);
@@ -116,7 +117,7 @@ export function UpsellCard({
         >
           {pendingKind === '24h'
             ? t('upsell.startingCheckout')
-            : t('upsell.getDayPass', { price: PASS_PRICES['24h'] })}
+            : t('upsell.getDayPass', { price: passPrices['24h'] })}
         </button>
         <Link
           className={styles.secondary}

--- a/web/src/lib/backend/getPassPricing.ts
+++ b/web/src/lib/backend/getPassPricing.ts
@@ -1,0 +1,21 @@
+import { get } from './api';
+
+export type PassPriceKind = '24h' | '7d' | '120d';
+
+export interface PassPriceEntry {
+  amount: number;
+  currency: string;
+  display: string;
+}
+
+export interface PassPricingResponse {
+  passes: Partial<Record<PassPriceKind, PassPriceEntry>>;
+}
+
+export const getPassPricing = async (): Promise<PassPricingResponse> => {
+  const data = await get('/api/pricing');
+  if (data == null || typeof data.passes !== 'object') {
+    return { passes: {} };
+  }
+  return data as PassPricingResponse;
+};

--- a/web/src/lib/hooks/usePassPrices.test.tsx
+++ b/web/src/lib/hooks/usePassPrices.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement } from 'react';
+
+vi.mock('../backend/getPassPricing', () => ({
+  getPassPricing: vi.fn(),
+}));
+
+import { getPassPricing } from '../backend/getPassPricing';
+import { usePassPrices } from './usePassPrices';
+
+function buildWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe('usePassPrices', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the hardcoded fallback prices before the endpoint resolves', () => {
+    vi.mocked(getPassPricing).mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => usePassPrices(), {
+      wrapper: buildWrapper(),
+    });
+
+    expect(result.current).toEqual({ '24h': '$6', '7d': '$12', '120d': '$29' });
+  });
+
+  it('reconciles to the live display strings once the endpoint resolves', async () => {
+    vi.mocked(getPassPricing).mockResolvedValue({
+      passes: {
+        '24h': { amount: 700, currency: 'usd', display: '$7' },
+        '7d': { amount: 1400, currency: 'usd', display: '$14' },
+        '120d': { amount: 3200, currency: 'usd', display: '$32' },
+      },
+    });
+
+    const { result } = renderHook(() => usePassPrices(), {
+      wrapper: buildWrapper(),
+    });
+
+    await waitFor(() =>
+      expect(result.current).toEqual({
+        '24h': '$7',
+        '7d': '$14',
+        '120d': '$32',
+      })
+    );
+  });
+
+  it('keeps the fallback for any pass the endpoint omits', async () => {
+    vi.mocked(getPassPricing).mockResolvedValue({
+      passes: {
+        '7d': { amount: 1400, currency: 'usd', display: '$14' },
+      },
+    });
+
+    const { result } = renderHook(() => usePassPrices(), {
+      wrapper: buildWrapper(),
+    });
+
+    await waitFor(() => expect(result.current['7d']).toBe('$14'));
+    expect(result.current['24h']).toBe('$6');
+    expect(result.current['120d']).toBe('$29');
+  });
+
+  it('keeps the fallback when the endpoint request fails', async () => {
+    vi.mocked(getPassPricing).mockRejectedValue(new Error('network'));
+
+    const { result } = renderHook(() => usePassPrices(), {
+      wrapper: buildWrapper(),
+    });
+
+    await waitFor(() => expect(getPassPricing).toHaveBeenCalled());
+    expect(result.current).toEqual({ '24h': '$6', '7d': '$12', '120d': '$29' });
+  });
+});

--- a/web/src/lib/hooks/usePassPrices.ts
+++ b/web/src/lib/hooks/usePassPrices.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query';
+import { getPassPricing } from '../backend/getPassPricing';
+import { FALLBACK_PASS_PRICES } from '../../pages/PricingPage/payment.links';
+
+export type PassPriceDisplay = Record<'24h' | '7d' | '120d', string>;
+
+const FIVE_MINUTES_MS = 5 * 60 * 1000;
+
+export function usePassPrices(): PassPriceDisplay {
+  const { data } = useQuery({
+    queryKey: ['passPricing'],
+    queryFn: getPassPricing,
+    staleTime: FIVE_MINUTES_MS,
+    retry: false,
+  });
+
+  return {
+    '24h': data?.passes['24h']?.display ?? FALLBACK_PASS_PRICES['24h'],
+    '7d': data?.passes['7d']?.display ?? FALLBACK_PASS_PRICES['7d'],
+    '120d': data?.passes['120d']?.display ?? FALLBACK_PASS_PRICES['120d'],
+  };
+}

--- a/web/src/lib/i18n/locales/de/landing.json
+++ b/web/src/lib/i18n/locales/de/landing.json
@@ -24,7 +24,7 @@
     "freeQuota": "Kostenlos · bis zu 1 000 Karten pro Import",
     "orPrefix": "oder ",
     "signUpFree": "kostenlos registrieren",
-    "getDayPass": "hol dir einen Day Pass für $6"
+    "getDayPass": "hol dir einen Day Pass für {{price}}"
   },
   "footer": {
     "readyPrefix": "Bereit zum Ausprobieren? ",

--- a/web/src/lib/i18n/locales/de/search.json
+++ b/web/src/lib/i18n/locales/de/search.json
@@ -10,7 +10,7 @@
     "title": "Du hast diesen Monat alle {{limit}} Karten genutzt",
     "body": "{{used}} / {{limit}} Karten · Auffrischung am {{resetsOn}}, dann kommen deine kostenlosen Karten zurück",
     "startingCheckout": "Checkout wird gestartet",
-    "getDayPass": "Day Pass holen — $6",
+    "getDayPass": "Day Pass holen — {{price}}",
     "seePlans": "Tarife ansehen"
   },
   "connect": {

--- a/web/src/lib/i18n/locales/en/landing.json
+++ b/web/src/lib/i18n/locales/en/landing.json
@@ -24,7 +24,7 @@
     "freeQuota": "Free · up to 1 000 cards per import",
     "orPrefix": "or ",
     "signUpFree": "sign up free",
-    "getDayPass": "get a Day Pass for $6"
+    "getDayPass": "get a Day Pass for {{price}}"
   },
   "footer": {
     "readyPrefix": "Ready to try it? ",

--- a/web/src/lib/i18n/locales/en/search.json
+++ b/web/src/lib/i18n/locales/en/search.json
@@ -10,7 +10,7 @@
     "title": "You've used all {{limit}} cards this month",
     "body": "{{used}} / {{limit}} cards · resets {{resetsOn}}, when your free cards come back",
     "startingCheckout": "Starting checkout",
-    "getDayPass": "Get Day Pass — $6",
+    "getDayPass": "Get Day Pass — {{price}}",
     "seePlans": "See plans"
   },
   "connect": {

--- a/web/src/lib/i18n/locales/es/landing.json
+++ b/web/src/lib/i18n/locales/es/landing.json
@@ -24,7 +24,7 @@
     "freeQuota": "Gratis · hasta 1 000 tarjetas por importación",
     "orPrefix": "o ",
     "signUpFree": "regístrate gratis",
-    "getDayPass": "consigue un Day Pass por $6"
+    "getDayPass": "consigue un Day Pass por {{price}}"
   },
   "footer": {
     "readyPrefix": "¿Listo para probarlo? ",

--- a/web/src/lib/i18n/locales/es/search.json
+++ b/web/src/lib/i18n/locales/es/search.json
@@ -10,7 +10,7 @@
     "title": "Has usado las {{limit}} tarjetas de este mes",
     "body": "{{used}} / {{limit}} tarjetas · se reinicia el {{resetsOn}}, cuando vuelven tus tarjetas gratis",
     "startingCheckout": "Abriendo el pago",
-    "getDayPass": "Consigue el Day Pass — $6",
+    "getDayPass": "Consigue el Day Pass — {{price}}",
     "seePlans": "Ver planes"
   },
   "connect": {

--- a/web/src/lib/i18n/locales/fr/landing.json
+++ b/web/src/lib/i18n/locales/fr/landing.json
@@ -24,7 +24,7 @@
     "freeQuota": "Gratuit · jusqu'à 1 000 cartes par import",
     "orPrefix": "ou ",
     "signUpFree": "inscris-toi gratuitement",
-    "getDayPass": "prends un Day Pass à $6"
+    "getDayPass": "prends un Day Pass à {{price}}"
   },
   "footer": {
     "readyPrefix": "Prêt à essayer ? ",

--- a/web/src/lib/i18n/locales/fr/search.json
+++ b/web/src/lib/i18n/locales/fr/search.json
@@ -10,7 +10,7 @@
     "title": "Tu as utilisé tes {{limit}} cartes ce mois-ci",
     "body": "{{used}} / {{limit}} cartes · réinitialisées le {{resetsOn}}, quand tes cartes gratuites reviennent",
     "startingCheckout": "Ouverture du paiement",
-    "getDayPass": "Prendre un Day Pass — $6",
+    "getDayPass": "Prendre un Day Pass — {{price}}",
     "seePlans": "Voir les offres"
   },
   "connect": {

--- a/web/src/lib/i18n/locales/it/landing.json
+++ b/web/src/lib/i18n/locales/it/landing.json
@@ -24,7 +24,7 @@
     "freeQuota": "Gratis · fino a 1 000 carte per importazione",
     "orPrefix": "oppure ",
     "signUpFree": "registrati gratis",
-    "getDayPass": "prendi un Day Pass a $6"
+    "getDayPass": "prendi un Day Pass a {{price}}"
   },
   "footer": {
     "readyPrefix": "Pronto a provarlo? ",

--- a/web/src/lib/i18n/locales/it/search.json
+++ b/web/src/lib/i18n/locales/it/search.json
@@ -10,7 +10,7 @@
     "title": "Hai usato tutte le {{limit}} carte di questo mese",
     "body": "{{used}} / {{limit}} carte · si rinnovano il {{resetsOn}}, quando tornano le tue carte gratuite",
     "startingCheckout": "Avvio del pagamento",
-    "getDayPass": "Ottieni il Day Pass — $6",
+    "getDayPass": "Ottieni il Day Pass — {{price}}",
     "seePlans": "Vedi i piani"
   },
   "connect": {

--- a/web/src/lib/i18n/locales/ja/landing.json
+++ b/web/src/lib/i18n/locales/ja/landing.json
@@ -24,7 +24,7 @@
     "freeQuota": "無料 · 1 回のインポートで最大 1 000 枚",
     "orPrefix": "または ",
     "signUpFree": "無料で登録",
-    "getDayPass": "$6 の Day Pass を購入"
+    "getDayPass": "{{price}} の Day Pass を購入"
   },
   "footer": {
     "readyPrefix": "試してみますか？ ",

--- a/web/src/lib/i18n/locales/ja/search.json
+++ b/web/src/lib/i18n/locales/ja/search.json
@@ -10,7 +10,7 @@
     "title": "今月の {{limit}} 枚のカードをすべて使い切りました",
     "body": "{{used}} / {{limit}} 枚 · {{resetsOn}} に無料カードが戻ってリセットされます",
     "startingCheckout": "チェックアウトを開始しています",
-    "getDayPass": "Get Day Pass — $6",
+    "getDayPass": "Get Day Pass — {{price}}",
     "seePlans": "プランを見る"
   },
   "connect": {

--- a/web/src/lib/i18n/locales/nl/landing.json
+++ b/web/src/lib/i18n/locales/nl/landing.json
@@ -24,7 +24,7 @@
     "freeQuota": "Gratis · tot 1 000 kaarten per import",
     "orPrefix": "of ",
     "signUpFree": "meld je gratis aan",
-    "getDayPass": "koop een Day Pass voor $6"
+    "getDayPass": "koop een Day Pass voor {{price}}"
   },
   "footer": {
     "readyPrefix": "Klaar om het te proberen? ",

--- a/web/src/lib/i18n/locales/nl/search.json
+++ b/web/src/lib/i18n/locales/nl/search.json
@@ -10,7 +10,7 @@
     "title": "Je hebt alle {{limit}} kaarten deze maand gebruikt",
     "body": "{{used}} / {{limit}} kaarten · vernieuwt {{resetsOn}}, wanneer je gratis kaarten terugkomen",
     "startingCheckout": "Afrekenen starten",
-    "getDayPass": "Day Pass kopen — $6",
+    "getDayPass": "Day Pass kopen — {{price}}",
     "seePlans": "Bekijk abonnementen"
   },
   "connect": {

--- a/web/src/lib/i18n/locales/pl/landing.json
+++ b/web/src/lib/i18n/locales/pl/landing.json
@@ -24,7 +24,7 @@
     "freeQuota": "Za darmo · do 1 000 kart na import",
     "orPrefix": "albo ",
     "signUpFree": "zarejestruj się za darmo",
-    "getDayPass": "kup Day Pass za $6"
+    "getDayPass": "kup Day Pass za {{price}}"
   },
   "footer": {
     "readyPrefix": "Gotowy, aby spróbować? ",

--- a/web/src/lib/i18n/locales/pl/search.json
+++ b/web/src/lib/i18n/locales/pl/search.json
@@ -10,7 +10,7 @@
     "title": "Wykorzystałeś wszystkie {{limit}} kart w tym miesiącu",
     "body": "{{used}} / {{limit}} kart · odnawia się {{resetsOn}}, gdy wrócą Twoje darmowe karty",
     "startingCheckout": "Rozpoczynanie płatności",
-    "getDayPass": "Kup Day Pass — $6",
+    "getDayPass": "Kup Day Pass — {{price}}",
     "seePlans": "Zobacz plany"
   },
   "connect": {

--- a/web/src/lib/i18n/locales/pt/landing.json
+++ b/web/src/lib/i18n/locales/pt/landing.json
@@ -24,7 +24,7 @@
     "freeQuota": "Grátis · até 1 000 cartões por importação",
     "orPrefix": "ou ",
     "signUpFree": "cadastre-se grátis",
-    "getDayPass": "pegue um Day Pass por $6"
+    "getDayPass": "pegue um Day Pass por {{price}}"
   },
   "footer": {
     "readyPrefix": "Pronto para testar? ",

--- a/web/src/lib/i18n/locales/pt/search.json
+++ b/web/src/lib/i18n/locales/pt/search.json
@@ -10,7 +10,7 @@
     "title": "Você usou todos os {{limit}} cartões deste mês",
     "body": "{{used}} / {{limit}} cartões · renova em {{resetsOn}}, quando seus cartões grátis voltam",
     "startingCheckout": "Iniciando o checkout",
-    "getDayPass": "Obter Day Pass — $6",
+    "getDayPass": "Obter Day Pass — {{price}}",
     "seePlans": "Ver planos"
   },
   "connect": {

--- a/web/src/lib/i18n/locales/ru/landing.json
+++ b/web/src/lib/i18n/locales/ru/landing.json
@@ -24,7 +24,7 @@
     "freeQuota": "Бесплатно · до 1 000 карт за один импорт",
     "orPrefix": "или ",
     "signUpFree": "зарегистрируйся бесплатно",
-    "getDayPass": "купи Day Pass за $6"
+    "getDayPass": "купи Day Pass за {{price}}"
   },
   "footer": {
     "readyPrefix": "Готов попробовать? ",

--- a/web/src/lib/i18n/locales/ru/search.json
+++ b/web/src/lib/i18n/locales/ru/search.json
@@ -10,7 +10,7 @@
     "title": "Ты использовал все {{limit}} карт в этом месяце",
     "body": "{{used}} / {{limit}} карт · обновятся {{resetsOn}}, когда вернутся твои бесплатные карты",
     "startingCheckout": "Открываем оплату",
-    "getDayPass": "Купить Day Pass — $6",
+    "getDayPass": "Купить Day Pass — {{price}}",
     "seePlans": "Посмотреть планы"
   },
   "connect": {

--- a/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.i18n.test.tsx
+++ b/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.i18n.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import i18n from '../../../../lib/i18n';
 import { ConversionResult } from './ConversionResult';
@@ -11,7 +12,14 @@ vi.mock('../../../../lib/analytics/track', () => ({
 }));
 
 function renderResult(node: React.ReactElement) {
-  return render(<MemoryRouter>{node}</MemoryRouter>);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>{node}</MemoryRouter>
+    </QueryClientProvider>
+  );
 }
 
 describe('ConversionResult in German', () => {

--- a/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.test.tsx
+++ b/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ConversionResult } from './ConversionResult';
 import { parseMonthlyLimitPayload } from './parseMonthlyLimitPayload';
 
@@ -64,20 +65,26 @@ describe('ConversionResult — paywalled variant', () => {
 
   const renderPaywall = (
     props: Partial<{ cardsUsed: number; limit: number; resetOn?: string }> = {}
-  ) =>
-    render(
-      <MemoryRouter>
-        <ConversionResult
-          variant="paywalled"
-          title="Big deck"
-          limit={props.limit ?? 100}
-          cardsUsed={props.cardsUsed ?? 56}
-          resetOn={
-            'resetOn' in props ? props.resetOn : '2026-07-01T00:00:00.000Z'
-          }
-        />
-      </MemoryRouter>
+  ) => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ConversionResult
+            variant="paywalled"
+            title="Big deck"
+            limit={props.limit ?? 100}
+            cardsUsed={props.cardsUsed ?? 56}
+            resetOn={
+              'resetOn' in props ? props.resetOn : '2026-07-01T00:00:00.000Z'
+            }
+          />
+        </MemoryRouter>
+      </QueryClientProvider>
     );
+  };
 
   it('shows the used-of-limit headline when cards_used is below the limit', () => {
     renderPaywall({ cardsUsed: 56, limit: 100 });

--- a/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.tsx
+++ b/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { classifyUploadError } from '../../../../components/errors/helpers/getErrorMessage';
 import { parseAmbiguousColumnsPayload } from '../../../../lib/fieldMapping/types';
-import { PASS_PRICES } from '../../../PricingPage/payment.links';
+import { usePassPrices } from '../../../../lib/hooks/usePassPrices';
 import { get2ankiApi } from '../../../../lib/backend/get2ankiApi';
 import { startUnlimitedUpgrade } from '../../../../lib/backend/startUnlimitedUpgrade';
 import { track } from '../../../../lib/analytics/track';
@@ -78,6 +78,7 @@ function PaywalledVariant({
   resetOn,
 }: Omit<PaywalledProps, 'variant' | 'title'>) {
   const { t } = useTranslation();
+  const passPrices = usePassPrices();
   const shownFiredRef = useRef(false);
   const [pendingKind, setPendingKind] = useState<'24h' | '7d' | null>(null);
   const resetDate = formatResetDate(resetOn);
@@ -140,7 +141,7 @@ function PaywalledVariant({
           {pendingKind === '24h'
             ? t('conversionResult.paywall.openingCheckout')
             : t('conversionResult.paywall.getDayPass', {
-                price: PASS_PRICES['24h'],
+                price: passPrices['24h'],
               })}
         </button>
         <button
@@ -152,7 +153,7 @@ function PaywalledVariant({
           {pendingKind === '7d'
             ? t('conversionResult.paywall.openingCheckout')
             : t('conversionResult.paywall.getWeekPass', {
-                price: PASS_PRICES['7d'],
+                price: passPrices['7d'],
               })}
         </button>
         <a

--- a/web/src/pages/LandingPage/LandingPage.tsx
+++ b/web/src/pages/LandingPage/LandingPage.tsx
@@ -6,6 +6,7 @@ import UploadForm from '../UploadPage/components/UploadForm/UploadForm';
 import { ErrorHandlerType } from '../../components/errors/helpers/getErrorMessage';
 import { persistSignupOrigin } from '../../lib/signupOrigin';
 import { canonicalUrl } from '../../lib/seo/canonicalUrl';
+import { usePassPrices } from '../../lib/hooks/usePassPrices';
 import styles from './LandingPage.module.css';
 import sharedStyles from '../../styles/shared.module.css';
 import type { LandingCopy } from './types';
@@ -44,6 +45,7 @@ interface HeroActionProps {
   ctaLabel?: string;
   setErrorMessage: ErrorHandlerType;
   registerHref: string;
+  dayPassPrice: string;
   t: TFunction<'landing'>;
 }
 
@@ -53,6 +55,7 @@ function renderHeroAction({
   ctaLabel,
   setErrorMessage,
   registerHref,
+  dayPassPrice,
   t,
 }: Readonly<HeroActionProps>) {
   if (heroSlot != null) {
@@ -85,7 +88,8 @@ function renderHeroAction({
         {' — '}
         <a href="/pricing">
           {t('hero.getDayPass', {
-            defaultValue: 'get a Day Pass for $6',
+            price: dayPassPrice,
+            defaultValue: 'get a Day Pass for {{price}}',
           })}
         </a>
       </p>
@@ -99,6 +103,7 @@ function LandingPage({
   heroSlot,
 }: Readonly<LandingPageProps>) {
   const { t } = useTranslation('landing');
+  const passPrices = usePassPrices();
   useEffect(() => {
     persistSignupOrigin(copy.pathname, globalThis.sessionStorage ?? null);
   }, [copy.pathname]);
@@ -166,6 +171,7 @@ function LandingPage({
             ctaLabel: copy.ctaLabel,
             setErrorMessage,
             registerHref,
+            dayPassPrice: passPrices['24h'],
             t,
           })}
         </div>

--- a/web/src/pages/NotionLandingPage/NotionLandingPage.i18n.test.tsx
+++ b/web/src/pages/NotionLandingPage/NotionLandingPage.i18n.test.tsx
@@ -3,6 +3,7 @@ import '@testing-library/jest-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { HelmetProvider } from 'react-helmet-async';
 import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import i18n from '../../lib/i18n';
 import { NotionLandingPage } from './NotionLandingPage';
@@ -10,12 +11,17 @@ import { NotionLandingPage } from './NotionLandingPage';
 vi.mock('../../lib/analytics/track', () => ({ track: vi.fn() }));
 
 function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
   return render(
-    <HelmetProvider>
-      <MemoryRouter>
-        <NotionLandingPage />
-      </MemoryRouter>
-    </HelmetProvider>
+    <QueryClientProvider client={queryClient}>
+      <HelmetProvider>
+        <MemoryRouter>
+          <NotionLandingPage />
+        </MemoryRouter>
+      </HelmetProvider>
+    </QueryClientProvider>
   );
 }
 

--- a/web/src/pages/NotionLandingPage/NotionLandingPage.test.tsx
+++ b/web/src/pages/NotionLandingPage/NotionLandingPage.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { HelmetProvider } from 'react-helmet-async';
 import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { NotionLandingPage } from './NotionLandingPage';
@@ -13,12 +14,17 @@ vi.mock('../../lib/analytics/track', () => ({
 import { track } from '../../lib/analytics/track';
 
 function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
   return render(
-    <MemoryRouter>
-      <HelmetProvider>
-        <NotionLandingPage />
-      </HelmetProvider>
-    </MemoryRouter>
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <HelmetProvider>
+          <NotionLandingPage />
+        </HelmetProvider>
+      </MemoryRouter>
+    </QueryClientProvider>
   );
 }
 

--- a/web/src/pages/NotionLandingPage/NotionLandingPage.tsx
+++ b/web/src/pages/NotionLandingPage/NotionLandingPage.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { track } from '../../lib/analytics/track';
 import { canonicalUrl } from '../../lib/seo/canonicalUrl';
 import { PricingCard } from '../PricingPage/components/PricingCard';
+import { usePassPrices } from '../../lib/hooks/usePassPrices';
 import styles from './NotionLandingPage.module.css';
 
 const REF = 'notion-marketplace';
@@ -15,6 +16,7 @@ const DAY_PASS_HREF = `/pricing?ref=${REF}`;
 
 export function NotionLandingPage() {
   const { t } = useTranslation('marketing');
+  const passPrices = usePassPrices();
 
   const unlimitedBenefits = [
     t('notionLanding.unlimitedBenefit1'),
@@ -81,7 +83,7 @@ export function NotionLandingPage() {
           />
           <PricingCard
             title="Day Pass"
-            price="$6"
+            price={passPrices['24h']}
             priceSuffix={t('notionLanding.dayPassSuffix')}
             benefits={dayPassBenefits}
             link={DAY_PASS_HREF}

--- a/web/src/pages/PricingPage/PricingPage.tsx
+++ b/web/src/pages/PricingPage/PricingPage.tsx
@@ -19,7 +19,8 @@ import { useInViewOnce } from '../../lib/hooks/useInViewOnce';
 import styles from './PricingPage.module.css';
 import sharedStyles from '../../styles/shared.module.css';
 import { formatMonthly, LEGACY_UNLIMITED_PRICING } from './pricing.constants';
-import { PRICING_FAQ } from './pricingFaq';
+import { buildPricingFaq } from './pricingFaq';
+import { usePassPrices } from '../../lib/hooks/usePassPrices';
 
 interface PricingPageProps {
   isLoggedIn: boolean;
@@ -56,6 +57,7 @@ export default function PricingPage({
   const shownFiredRef = useRef(false);
   const cardUsage = useCardUsage(true);
   const pricingOrder = usePricingOrderVariant();
+  const passPrices = usePassPrices();
   const quotaRemaining =
     cardUsage != null && !cardUsage.loading
       ? cardUsage.cards_limit - cardUsage.cards_used
@@ -183,7 +185,7 @@ export default function PricingPage({
   const pricingFaqJsonLd = JSON.stringify({
     '@context': 'https://schema.org',
     '@type': 'FAQPage',
-    mainEntity: PRICING_FAQ.map((item) => ({
+    mainEntity: buildPricingFaq(passPrices).map((item) => ({
       '@type': 'Question',
       name: item.question,
       acceptedAnswer: {
@@ -205,6 +207,7 @@ export default function PricingPage({
       weekPassPending={weekPassState === 'pending'}
       semesterPassPending={semesterPassState === 'pending'}
       featureDayPass={false}
+      prices={passPrices}
     />
   );
 
@@ -292,9 +295,10 @@ export default function PricingPage({
 
       <ComparisonTable
         unlimitedMonthlyPrice={formatMonthly(pricing.monthlyCents)}
+        passPrices={passPrices}
       />
 
-      <PricingFaq />
+      <PricingFaq passPrices={passPrices} />
 
       <section ref={educatorsRef} className={styles.educators}>
         <h2 className={styles.educatorsTitle}>{t('pricing.educatorsTitle')}</h2>

--- a/web/src/pages/PricingPage/components/ComparisonTable.tsx
+++ b/web/src/pages/PricingPage/components/ComparisonTable.tsx
@@ -1,6 +1,8 @@
 import { Fragment } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { FALLBACK_PASS_PRICES } from '../payment.links';
+import type { PassPriceDisplay } from '../../../lib/hooks/usePassPrices';
 import styles from './ComparisonTable.module.css';
 
 const PLANS = ['Free', 'Day / Week pass', 'Unlimited'];
@@ -38,10 +40,12 @@ function CheckIcon() {
 
 interface ComparisonTableProps {
   unlimitedMonthlyPrice: string;
+  passPrices?: PassPriceDisplay;
 }
 
 export function ComparisonTable({
   unlimitedMonthlyPrice,
+  passPrices = FALLBACK_PASS_PRICES,
 }: Readonly<ComparisonTableProps>) {
   const { t } = useTranslation('pricingtable');
 
@@ -153,7 +157,11 @@ export function ComparisonTable({
     return value;
   };
 
-  const planPrices = ['$0', '$6 / $12', `${unlimitedMonthlyPrice} / mo`];
+  const planPrices = [
+    '$0',
+    `${passPrices['24h']} / ${passPrices['7d']}`,
+    `${unlimitedMonthlyPrice} / mo`,
+  ];
 
   return (
     <section className={styles.section} aria-labelledby="comparison-heading">

--- a/web/src/pages/PricingPage/components/PassCards.tsx
+++ b/web/src/pages/PricingPage/components/PassCards.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { PricingCard } from './PricingCard';
-import { PASS_PRICES } from '../payment.links';
+import { FALLBACK_PASS_PRICES } from '../payment.links';
+import type { PassPriceDisplay } from '../../../lib/hooks/usePassPrices';
 import styles from '../PricingPage.module.css';
 
 const PASS_BENEFIT_KEYS = [
@@ -20,6 +21,7 @@ interface PassCardsProps {
   weekPassPending: boolean;
   semesterPassPending?: boolean;
   featureDayPass?: boolean;
+  prices?: PassPriceDisplay;
 }
 
 export function PassCards({
@@ -30,6 +32,7 @@ export function PassCards({
   weekPassPending,
   semesterPassPending = false,
   featureDayPass = true,
+  prices = FALLBACK_PASS_PRICES,
 }: Readonly<PassCardsProps>) {
   const { t } = useTranslation();
   const benefits = PASS_BENEFIT_KEYS.map((key) => t(key));
@@ -41,7 +44,7 @@ export function PassCards({
         horizonCaption={
           featureDayPass ? undefined : t('pricing.pass.horizonDay')
         }
-        price={PASS_PRICES['24h']}
+        price={prices['24h']}
         priceSuffix={t('pricing.pass.day24')}
         benefits={benefits}
         onAction={onDayPass}
@@ -59,7 +62,7 @@ export function PassCards({
         horizonCaption={
           featureDayPass ? undefined : t('pricing.pass.horizonWeek')
         }
-        price={PASS_PRICES['7d']}
+        price={prices['7d']}
         priceSuffix={t('pricing.pass.week1')}
         benefits={benefits}
         onAction={onWeekPass}
@@ -78,7 +81,7 @@ export function PassCards({
           badgeMuted
           horizonCaption={t('pricing.pass.horizonSemester')}
           valueCaption={t('pricing.pass.semesterPerWeek')}
-          price={PASS_PRICES['120d']}
+          price={prices['120d']}
           priceSuffix={t('pricing.pass.semester4mo')}
           benefits={benefits}
           onAction={onSemesterPass}

--- a/web/src/pages/PricingPage/components/PricingFaq.tsx
+++ b/web/src/pages/PricingPage/components/PricingFaq.tsx
@@ -1,10 +1,19 @@
 import { useTranslation } from 'react-i18next';
 
-import { PRICING_FAQ } from '../pricingFaq';
+import { buildPricingFaq } from '../pricingFaq';
+import { FALLBACK_PASS_PRICES } from '../payment.links';
+import type { PassPriceDisplay } from '../../../lib/hooks/usePassPrices';
 import styles from './PricingFaq.module.css';
 
-export function PricingFaq() {
+interface PricingFaqProps {
+  passPrices?: PassPriceDisplay;
+}
+
+export function PricingFaq({
+  passPrices = FALLBACK_PASS_PRICES,
+}: Readonly<PricingFaqProps>) {
   const { t } = useTranslation('pricingtable');
+  const faqItems = buildPricingFaq(passPrices);
 
   return (
     <section className={styles.faq} aria-labelledby="pricing-faq-heading">
@@ -12,7 +21,7 @@ export function PricingFaq() {
         {t('faq.heading')}
       </h2>
       <div className={styles.list}>
-        {PRICING_FAQ.map((item) => (
+        {faqItems.map((item) => (
           <details key={item.questionKey} className={styles.item}>
             <summary className={styles.summary}>
               <span>{t(item.questionKey)}</span>

--- a/web/src/pages/PricingPage/payment.links.ts
+++ b/web/src/pages/PricingPage/payment.links.ts
@@ -1,9 +1,11 @@
-// These displayed prices MUST match the live Stripe prices behind the
-// PASS_24H_PRICE_ID / PASS_7D_PRICE_ID / PASS_120D_PRICE_ID env vars — a
-// mismatch shows one price on the page and charges another at checkout.
-// The pricing.pass.semesterPerWeek i18n string also hardcodes math derived
-// from the 120d ($29) and 7d ($12) values; re-derive it when either changes.
-export const PASS_PRICES = {
+// Fallback pass prices shown instantly on first paint and whenever the live
+// GET /api/pricing lookup has not resolved yet. The live endpoint resolves
+// amounts from Stripe by price metadata, so these values only surface during
+// loading or if the endpoint is unavailable — they must match the live Stripe
+// prices so a brief fallback render never disagrees with checkout.
+// The pricing.pass.semesterPerWeek i18n string still hardcodes math derived
+// from the 120d and 7d values; re-derive it when either changes.
+export const FALLBACK_PASS_PRICES = {
   '24h': '$6',
   '7d': '$12',
   '120d': '$29',

--- a/web/src/pages/PricingPage/pricingFaq.ts
+++ b/web/src/pages/PricingPage/pricingFaq.ts
@@ -1,4 +1,5 @@
-import { PASS_PRICES } from './payment.links';
+import { FALLBACK_PASS_PRICES } from './payment.links';
+import type { PassPriceDisplay } from '../../lib/hooks/usePassPrices';
 
 export interface PricingFaqItem {
   question: string;
@@ -8,7 +9,9 @@ export interface PricingFaqItem {
   answerValues?: Record<string, string>;
 }
 
-export const PRICING_FAQ: PricingFaqItem[] = [
+export const buildPricingFaq = (
+  passPrices: PassPriceDisplay
+): PricingFaqItem[] => [
   {
     question: 'How many cards can I make for free?',
     answer:
@@ -18,13 +21,13 @@ export const PRICING_FAQ: PricingFaqItem[] = [
   },
   {
     question: 'Is there a one-time payment option?',
-    answer: `Day Pass (${PASS_PRICES['24h']}) gives 24 hours of unlimited access. Week Pass (${PASS_PRICES['7d']}) gives 7 days. Semester Pass (${PASS_PRICES['120d']}) gives about 4 months. All are one-time payments, no subscription required.`,
+    answer: `Day Pass (${passPrices['24h']}) gives 24 hours of unlimited access. Week Pass (${passPrices['7d']}) gives 7 days. Semester Pass (${passPrices['120d']}) gives about 4 months. All are one-time payments, no subscription required.`,
     questionKey: 'faq.q2.question',
     answerKey: 'faq.q2.answer',
     answerValues: {
-      dayPrice: PASS_PRICES['24h'],
-      weekPrice: PASS_PRICES['7d'],
-      semesterPrice: PASS_PRICES['120d'],
+      dayPrice: passPrices['24h'],
+      weekPrice: passPrices['7d'],
+      semesterPrice: passPrices['120d'],
     },
   },
   {
@@ -63,3 +66,6 @@ export const PRICING_FAQ: PricingFaqItem[] = [
     answerKey: 'faq.q7.answer',
   },
 ];
+
+export const PRICING_FAQ: PricingFaqItem[] =
+  buildPricingFaq(FALLBACK_PASS_PRICES);

--- a/web/src/pages/SearchPage/SearchPage.test.tsx
+++ b/web/src/pages/SearchPage/SearchPage.test.tsx
@@ -30,6 +30,10 @@ vi.mock('../../lib/hooks/useCardUsage', () => ({
   CARD_USAGE_QUERY_KEY: ['cardUsage'],
 }));
 
+vi.mock('../../lib/hooks/usePassPrices', () => ({
+  usePassPrices: () => ({ '24h': '$6', '7d': '$12', '120d': '$29' }),
+}));
+
 describe('SearchPage over the monthly limit', () => {
   beforeEach(() => {
     mockUseNotionData.mockReturnValue({

--- a/web/src/pages/SearchPage/SearchPage.tsx
+++ b/web/src/pages/SearchPage/SearchPage.tsx
@@ -6,6 +6,7 @@ import { ErrorHandlerType } from '../../components/errors/helpers/getErrorMessag
 import { SkeletonList } from '../../components/Skeleton/Skeleton';
 import { get2ankiApi } from '../../lib/backend/get2ankiApi';
 import { useCardUsage } from '../../lib/hooks/useCardUsage';
+import { usePassPrices } from '../../lib/hooks/usePassPrices';
 import { useUserLocals } from '../../lib/hooks/useUserLocals';
 import { isPayingUser } from '../../components/NavigationBar/helpers/getPlanLabel';
 import styles from '../../styles/shared.module.css';
@@ -20,6 +21,7 @@ interface SearchPageProps {
 
 export function SearchPage({ setError }: Readonly<SearchPageProps>) {
   const { t } = useTranslation('search');
+  const passPrices = usePassPrices();
   const notionData = useNotionData(get2ankiApi());
   const { data: userLocals } = useUserLocals();
   const isAuthenticated = userLocals?.user?.id != null;
@@ -105,7 +107,7 @@ export function SearchPage({ setError }: Readonly<SearchPageProps>) {
           >
             {dayPassPending
               ? t('limit.startingCheckout')
-              : t('limit.getDayPass')}
+              : t('limit.getDayPass', { price: passPrices['24h'] })}
           </button>
           <Link
             to="/limit?ref=notion-limit-wall"

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
@@ -38,6 +38,10 @@ vi.mock('../../../../lib/hooks/useCardUsage', () => ({
   CARD_USAGE_QUERY_KEY: ['cardUsage'],
 }));
 
+vi.mock('../../../../lib/hooks/usePassPrices', () => ({
+  usePassPrices: () => ({ '24h': '$6', '7d': '$12', '120d': '$29' }),
+}));
+
 import { useUserLocals } from '../../../../lib/hooks/useUserLocals';
 import { useCardUsage } from '../../../../lib/hooks/useCardUsage';
 import { get2ankiApi } from '../../../../lib/backend/get2ankiApi';

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -23,6 +23,7 @@ import { ConversionResult } from '../../../DownloadsPage/components/ConversionRe
 import { OverSplitNotice } from './OverSplitNotice';
 import { getEmptyDeckChatPrompt } from '../../helpers/getEmptyDeckChatPrompt';
 import { useDrag } from '../../../../lib/hooks/useDrag';
+import { usePassPrices } from '../../../../lib/hooks/usePassPrices';
 import { useUploadFormState } from './hooks/useUploadFormState';
 import {
   useFileValidation,
@@ -399,6 +400,7 @@ function UploadForm({
   };
 
   const { data: userLocals } = useUserLocals();
+  const passPrices = usePassPrices();
   const queryClient = useQueryClient();
   const isAuthenticated = userLocals?.user?.id != null;
   const [dayPassPending, setDayPassPending] = useState(false);
@@ -1412,7 +1414,9 @@ function UploadForm({
                 onClick={handleDayPass}
                 disabled={dayPassPending}
               >
-                {dayPassPending ? 'Starting checkout' : 'Get Day Pass — $6'}
+                {dayPassPending
+                  ? 'Starting checkout'
+                  : `Get Day Pass — ${passPrices['24h']}`}
               </button>
               <Link
                 to="/limit?ref=upload-limit-wall"
@@ -1723,7 +1727,9 @@ function UploadForm({
             onClick={handleDayPass}
             disabled={dayPassPending}
           >
-            {dayPassPending ? 'Starting checkout' : 'Get Day Pass — $6'}
+            {dayPassPending
+              ? 'Starting checkout'
+              : `Get Day Pass — ${passPrices['24h']}`}
           </button>
           <Link
             to="/limit?ref=upload-limit-wall"


### PR DESCRIPTION
## What
Replaces the three `PASS_*_PRICE_ID` env vars as the source of truth for one-time pass prices with runtime resolution from Stripe. A new `PricingService` resolves each pass price from Stripe by the price metadata key `2anki_pass_kind` (`24h`/`7d`/`120d`), caches with a 5-minute in-memory TTL, and exposes it to checkout and to a new public `GET /api/pricing`. Every web surface that hardcoded a pass price now reads `/api/pricing` through a small `usePassPrices` hook, with today's numbers as the instant fallback.

## Why
`CheckoutRouter`'s pass routes charged whatever `PASS_*_PRICE_ID` pointed at, while the page showed prices hardcoded in `payment.links.ts` and in i18n strings. Those two values could drift independently — one price on the card, another at checkout. Making Stripe the single source of truth for both display and charge makes that divergence structurally impossible.

## How
- `src/services/PricingService.ts` — resolves the active one-time price per kind via `stripe.prices.search({ query: "metadata['2anki_pass_kind']:'<kind>' AND active:'true'" })`. Exactly one active price expected per kind; more than one → newest `created` wins and logs `pricing.pass.multiple_active`. Kinds are a closed set (`24h`/`7d`/`120d`), so no user input reaches the Stripe query.
- **Fallback chain (unchanged 503 behavior at the end):** fresh Stripe result → cached (5-min TTL) → last-known-good (served on any Stripe failure/empty after a prior success) → `PASS_*_PRICE_ID` env (cold start, no prior success; price id only, no amount) → `null` → the existing `503` shape per route. Only successful Stripe resolutions are cached/retained; fallbacks don't freeze the TTL, so recovery is automatic.
- `GET /api/pricing` (route → `PassPricingController` → `GetPassPricingUseCase` → `PricingService`): public, no auth, `Cache-Control: public, max-age=300`. Returns `{ passes: { '24h': { amount, currency, display }, ... } }` where `display` is formatted from Stripe `unit_amount` (e.g. `$6`). A pass whose amount can't be resolved (env-only cold start) is omitted so the client keeps its fallback.
- Web: `usePassPrices` (react-query, 5-min `staleTime`) returns the three display strings, seeded from the renamed `FALLBACK_PASS_PRICES` constant so the page paints instantly with today's numbers, then reconciles when `/api/pricing` resolves — no spinner, no layout shift beyond the digits. Wired into PassCards, ComparisonTable, PricingFaq (+ the pricing-page FAQ JSON-LD), UpsellCard, ConversionResult paywall CTAs, UploadForm limit-wall CTAs, NotionLandingPage, LandingPage hero, and the SearchPage limit CTA. The two i18n CTA strings that embedded `$6` (`landing.hero.getDayPass`, `search.limit.getDayPass`) now interpolate `{{price}}` across all 10 locales.
- `PASS_*_PRICE_ID` env plumbing and `env.example`/`config.ts` entries are kept and re-labelled as the transition fallback (not deleted).

### Known limitation
The `pricing.pass.semesterPerWeek` i18n string ("≈$2/week — 85% less than the Week Pass") stays static — it hardcodes math derived from the 120d/7d prices and would only drift if the pass prices change again. Left as-is per the spec; re-derive it if a pass price changes.

## Measuring success
- `GET /api/pricing` returns non-empty `passes` in prod (curl after deploy) → Stripe resolution is live, not env fallback.
- Log lines: `pricing.pass.multiple_active` (duplicate active price for a kind), `pricing.pass.miss` (no active price found), `pricing.pass.resolve_failed` (Stripe call threw). A quiet log + non-empty `/api/pricing` = healthy. A spike in `resolve_failed` with pass sales still flowing = fallback chain doing its job.
- Pass checkout success rate (23 pass sales/wk baseline) should be unchanged — this is plumbing, prices are identical.

## Testing
- Unit tests added:
  - `PricingService.test.ts` — resolution happy path, multiple-active newest+warn, TTL cache hit/expiry (fake timers), Stripe-down → last-known-good, cold-start → env fallback, empty-result → env, `resolvePriceId`/`resolveAll`.
  - `GetPassPricingUseCase.test.ts` — display formatting (whole vs cents, non-USD symbol), omits unresolved passes.
  - `PassPricingController.test.ts` — json payload + `Cache-Control`.
  - `CheckoutRouter.test.ts` — `/api/pricing` wiring (200, `passes` shape, cache header); existing pass-route 503/checkout tests still pass via env fallback.
  - `usePassPrices.test.tsx` — fallback-before-resolve, reconcile-after-resolve, per-pass fallback on omission, fallback on request failure.
- Full server Jest: 712 suites / 6961 tests pass; the only 9 failing suites are the documented environmental ones (Python `create_deck` bridge `PythonExitError` + `getPageCount` pdfinfo) — no venv/pdfinfo in this worktree, none touch pricing.
- Full web vitest: 387 files / 3537 tests pass.
- `tsc -p . --noEmit` (server, incl. tests) clean; web `tsc --noEmit` clean; `pnpm format:check` clean tree-wide.
- Sonar: not run locally; PR decoration will report.

## Browser check
- [x] Golden path on localhost:3000 — `pnpm --filter 2anki-web test:golden-path` passed 4/4 at 375px
- [x] No console errors at 375px — enforced by the golden-path spec (fails on any console error / pageerror)
Notes: golden path drives the mocked landing/dashboard/account flows at 375px; `/api/pricing` is served by the catch-all `/api/**` fixture, so the pricing hook falls back cleanly with no console error.

## Changelog
no changelog entry — internal price-resolution plumbing, displayed prices unchanged

## Risks
- If Stripe prices lack the `2anki_pass_kind` metadata in prod, `/api/pricing` returns empty and the web keeps the hardcoded fallback, while checkout falls back to `PASS_*_PRICE_ID` env — i.e. exactly today's behavior, no regression. The metadata values (`24h`/`7d`/`120d`) are stated to already exist on the live prices.
- Rollback: revert the PR; env-based resolution returns unchanged.
- Not touched: subscription price resolution (`UnlimitedCheckoutUseCase` lookup keys), the webhook, and the $96 lifetime threshold.

## Goal alignment
Removes a class of trust-breaking bug (page price ≠ charged price) on the pass-purchase path — passes are the no-subscription conversion lane (23 sales/wk). No metric is targeted to move; the win is correctness/robustness of the pass checkout and making a future price change a single Stripe edit instead of a code+env+10-locale change. Funnel metric to watch for no-regression: pass checkout→paid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TqUDQZHTnn6LkPHasw4C9f
