### PR TITLE
feat: ship German PDF and PowerPoint to Anki landing pages

### DIFF
--- a/src/routes/knownRoutes.test.ts
+++ b/src/routes/knownRoutes.test.ts
@@ -10,6 +10,8 @@ describe('isKnownAppRoute', () => {
     '/notion-marketplace',
     '/notion-to-anki',
     '/notion-zu-anki',
+    '/pdf-zu-anki',
+    '/powerpoint-zu-anki',
     '/quizlet-to-anki',
     '/convert/csv-to-anki',
     '/answers/fsrs-explained',

--- a/src/routes/knownRoutes.ts
+++ b/src/routes/knownRoutes.ts
@@ -68,6 +68,8 @@ const LANDING_SLUGS = new Set<string>([
   'quizlet-to-anki',
   'markdown-to-anki',
   'pdf-to-anki',
+  'pdf-zu-anki',
+  'powerpoint-zu-anki',
   'anki-to-notion',
   'usmle-anki',
   'step1-anki',

--- a/web/public/sitemap.xml
+++ b/web/public/sitemap.xml
@@ -45,6 +45,10 @@
     <lastmod>2026-05-25</lastmod>
   </url>
   <url>
+    <loc>https://2anki.net/pdf-zu-anki/</loc>
+    <lastmod>2026-09-07</lastmod>
+  </url>
+  <url>
     <loc>https://2anki.net/anki-to-notion/</loc>
     <lastmod>2026-05-18</lastmod>
   </url>
@@ -79,6 +83,10 @@
   <url>
     <loc>https://2anki.net/powerpoint-to-anki/</loc>
     <lastmod>2026-05-25</lastmod>
+  </url>
+  <url>
+    <loc>https://2anki.net/powerpoint-zu-anki/</loc>
+    <lastmod>2026-09-07</lastmod>
   </url>
   <url>
     <loc>https://2anki.net/goodnotes-to-anki/</loc>

--- a/web/scripts/prerenderLandingPages.test.ts
+++ b/web/scripts/prerenderLandingPages.test.ts
@@ -10,6 +10,8 @@ import {
 } from './prerenderLandingPages';
 import notionCopy from '../src/pages/LandingPage/copy/notion';
 import notionZuAnkiCopy from '../src/pages/LandingPage/copy/notion-zu-anki';
+import pdfZuAnkiCopy from '../src/pages/LandingPage/copy/pdf-zu-anki';
+import powerpointZuAnkiCopy from '../src/pages/LandingPage/copy/powerpoint-zu-anki';
 import { ANSWERS_PAGES } from '../src/pages/AnswersPage/answersConfig';
 
 let buildDir: string;
@@ -52,13 +54,17 @@ beforeEach(() => {
 describe('emitLandingPages', () => {
   it('writes one HTML file per landing path', () => {
     const files = emitLandingPages(buildDir);
-    expect(files).toHaveLength(42);
+    expect(files).toHaveLength(44);
     expect(files.some((p) => p.endsWith('notion-to-anki/index.html'))).toBe(
       true
     );
     expect(files.some((p) => p.endsWith('notion-zu-anki/index.html'))).toBe(
       true
     );
+    expect(files.some((p) => p.endsWith('pdf-zu-anki/index.html'))).toBe(true);
+    expect(
+      files.some((p) => p.endsWith('powerpoint-zu-anki/index.html'))
+    ).toBe(true);
     expect(files.some((p) => p.endsWith('anki-for-japanese/index.html'))).toBe(
       true
     );
@@ -330,6 +336,89 @@ describe('emitLandingPages German hreflang twin', () => {
     expect(body).toContain('Physikum');
   });
 });
+
+describe.each([
+  {
+    name: 'pdf',
+    copy: pdfZuAnkiCopy,
+    germanSlug: 'pdf-zu-anki',
+    englishSlug: 'pdf-to-anki',
+  },
+  {
+    name: 'powerpoint',
+    copy: powerpointZuAnkiCopy,
+    germanSlug: 'powerpoint-zu-anki',
+    englishSlug: 'powerpoint-to-anki',
+  },
+])(
+  'emitLandingPages German hreflang twin ($name)',
+  ({ copy, germanSlug, englishSlug }) => {
+    const hreflangEn = `<link rel="alternate" hreflang="en" href="https://2anki.net/${englishSlug}/">`;
+    const hreflangDe = `<link rel="alternate" hreflang="de" href="https://2anki.net/${germanSlug}/">`;
+    const hreflangXDefault = `<link rel="alternate" hreflang="x-default" href="https://2anki.net/${englishSlug}/">`;
+
+    const readGerman = (): string => {
+      emitLandingPages(buildDir);
+      return readFileSync(join(buildDir, germanSlug, 'index.html'), 'utf8');
+    };
+
+    const readEnglish = (): string => {
+      emitLandingPages(buildDir);
+      return readFileSync(join(buildDir, englishSlug, 'index.html'), 'utf8');
+    };
+
+    it('prerenders the authored German title', () => {
+      expect(readGerman()).toContain(`<title>${copy.title}</title>`);
+    });
+
+    it('sets the html lang attribute to de on the German page', () => {
+      expect(readGerman()).toContain('<html lang="de">');
+      expect(readGerman()).not.toContain('<html lang="en">');
+    });
+
+    it('self-canonicals the German page to itself, not the English page', () => {
+      expect(readGerman()).toContain(
+        `<link rel="canonical" href="https://2anki.net/${germanSlug}/">`
+      );
+    });
+
+    it('emits a single de_DE og:locale, replacing the base en_US one', () => {
+      const html = readGerman();
+      expect(html).toContain('<meta property="og:locale" content="de_DE">');
+      expect(html).not.toContain('<meta property="og:locale" content="en_US">');
+      expect(countMatches(html, /<meta\s+property="og:locale"/g)).toBe(1);
+    });
+
+    it('carries the full hreflang triplet on the German page', () => {
+      const html = readGerman();
+      expect(html).toContain(hreflangEn);
+      expect(html).toContain(hreflangDe);
+      expect(html).toContain(hreflangXDefault);
+    });
+
+    it('carries the identical hreflang triplet on the English page', () => {
+      const html = readEnglish();
+      expect(html).toContain(hreflangEn);
+      expect(html).toContain(hreflangDe);
+      expect(html).toContain(hreflangXDefault);
+    });
+
+    it('leaves the English page lang unchanged and out of German locale', () => {
+      const html = readEnglish();
+      expect(html).toContain('<html lang="en">');
+      expect(html).not.toContain('<html lang="de">');
+      expect(html).toContain('<meta property="og:locale" content="en_US">');
+      expect(html).not.toContain('<meta property="og:locale" content="de_DE">');
+    });
+
+    it('renders the German med-exam framing in the crawlable body', () => {
+      const html = readGerman();
+      const body = html.slice(html.indexOf('<div id="root">'));
+      expect(body).toContain('Für Medizin, Pflege und Examen gebaut');
+      expect(body).toContain('Physikum');
+    });
+  }
+);
 
 describe('emitMetaOnlyPages', () => {
   it('writes one HTML file per meta-only route', () => {

--- a/web/scripts/prerenderLandingPages.ts
+++ b/web/scripts/prerenderLandingPages.ts
@@ -2,6 +2,8 @@ import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import notionCopy from '../src/pages/LandingPage/copy/notion';
 import notionZuAnkiCopy from '../src/pages/LandingPage/copy/notion-zu-anki';
+import pdfZuAnkiCopy from '../src/pages/LandingPage/copy/pdf-zu-anki';
+import powerpointZuAnkiCopy from '../src/pages/LandingPage/copy/powerpoint-zu-anki';
 import quizletCopy from '../src/pages/LandingPage/copy/quizlet';
 import markdownCopy from '../src/pages/LandingPage/copy/markdown';
 import pdfCopy from '../src/pages/LandingPage/copy/pdf';
@@ -33,6 +35,8 @@ import {
 const LANDING_COPIES: LandingCopy[] = [
   notionCopy,
   notionZuAnkiCopy,
+  pdfZuAnkiCopy,
+  powerpointZuAnkiCopy,
   quizletCopy,
   markdownCopy,
   pdfCopy,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -182,6 +182,14 @@ const NotionZuAnki = lazyWithRetry(
   () => import('./pages/LandingPage/NotionZuAnki'),
   './pages/LandingPage/NotionZuAnki'
 );
+const PdfZuAnki = lazyWithRetry(
+  () => import('./pages/LandingPage/PdfZuAnki'),
+  './pages/LandingPage/PdfZuAnki'
+);
+const PowerpointZuAnki = lazyWithRetry(
+  () => import('./pages/LandingPage/PowerpointZuAnki'),
+  './pages/LandingPage/PowerpointZuAnki'
+);
 const AnkiToNotion = lazyWithRetry(
   () => import('./pages/LandingPage/AnkiToNotion'),
   './pages/LandingPage/AnkiToNotion'
@@ -627,6 +635,14 @@ function AppContent({
             <Route
               path="/notion-zu-anki"
               element={<NotionZuAnki setErrorMessage={setErrorMessage} />}
+            />
+            <Route
+              path="/pdf-zu-anki"
+              element={<PdfZuAnki setErrorMessage={setErrorMessage} />}
+            />
+            <Route
+              path="/powerpoint-zu-anki"
+              element={<PowerpointZuAnki setErrorMessage={setErrorMessage} />}
             />
             <Route
               path="/anki-to-notion"

--- a/web/src/pages/LandingPage/PdfZuAnki.test.tsx
+++ b/web/src/pages/LandingPage/PdfZuAnki.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+import { HelmetProvider } from 'react-helmet-async';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+import PdfZuAnki from './PdfZuAnki';
+import pdfZuAnkiCopy from './copy/pdf-zu-anki';
+
+function renderPdfZuAnki() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <HelmetProvider>
+          <PdfZuAnki setErrorMessage={vi.fn()} />
+        </HelmetProvider>
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+describe('PdfZuAnki', () => {
+  it('renders the authored German H1 from the copy file', () => {
+    renderPdfZuAnki();
+    expect(
+      screen.getByRole('heading', { level: 1, name: pdfZuAnkiCopy.h1 })
+    ).toBeInTheDocument();
+  });
+
+  it('renders every authored German FAQ question', () => {
+    renderPdfZuAnki();
+    for (const faq of pdfZuAnkiCopy.faqs) {
+      expect(screen.getByText(faq.q)).toBeInTheDocument();
+    }
+  });
+
+  it('renders the med-exam framing card', () => {
+    renderPdfZuAnki();
+    expect(
+      screen.getByText('Für Medizin, Pflege und Examen gebaut')
+    ).toBeInTheDocument();
+  });
+
+  it('links the German related nav to the PowerPoint German twin', () => {
+    renderPdfZuAnki();
+    expect(
+      screen.getByRole('link', { name: 'Aus PowerPoint-Folien Karten machen' })
+    ).toHaveAttribute('href', '/powerpoint-zu-anki');
+  });
+});

--- a/web/src/pages/LandingPage/PdfZuAnki.tsx
+++ b/web/src/pages/LandingPage/PdfZuAnki.tsx
@@ -1,0 +1,11 @@
+import LandingPage from './LandingPage';
+import pdfZuAnkiCopy from './copy/pdf-zu-anki';
+import { ErrorHandlerType } from '../../components/errors/helpers/getErrorMessage';
+
+interface Props {
+  setErrorMessage: ErrorHandlerType;
+}
+
+export default function PdfZuAnki({ setErrorMessage }: Readonly<Props>) {
+  return <LandingPage copy={pdfZuAnkiCopy} setErrorMessage={setErrorMessage} />;
+}

--- a/web/src/pages/LandingPage/PowerpointZuAnki.test.tsx
+++ b/web/src/pages/LandingPage/PowerpointZuAnki.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+import { HelmetProvider } from 'react-helmet-async';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+import PowerpointZuAnki from './PowerpointZuAnki';
+import powerpointZuAnkiCopy from './copy/powerpoint-zu-anki';
+
+function renderPowerpointZuAnki() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <HelmetProvider>
+          <PowerpointZuAnki setErrorMessage={vi.fn()} />
+        </HelmetProvider>
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+describe('PowerpointZuAnki', () => {
+  it('renders the authored German H1 from the copy file', () => {
+    renderPowerpointZuAnki();
+    expect(
+      screen.getByRole('heading', { level: 1, name: powerpointZuAnkiCopy.h1 })
+    ).toBeInTheDocument();
+  });
+
+  it('renders every authored German FAQ question', () => {
+    renderPowerpointZuAnki();
+    for (const faq of powerpointZuAnkiCopy.faqs) {
+      expect(screen.getByText(faq.q)).toBeInTheDocument();
+    }
+  });
+
+  it('renders the med-exam framing card', () => {
+    renderPowerpointZuAnki();
+    expect(
+      screen.getByText('Für Medizin, Pflege und Examen gebaut')
+    ).toBeInTheDocument();
+  });
+
+  it('links the German related nav to the PDF German twin', () => {
+    renderPowerpointZuAnki();
+    expect(
+      screen.getByRole('link', { name: 'Aus einem PDF Karten machen' })
+    ).toHaveAttribute('href', '/pdf-zu-anki');
+  });
+});

--- a/web/src/pages/LandingPage/PowerpointZuAnki.tsx
+++ b/web/src/pages/LandingPage/PowerpointZuAnki.tsx
@@ -1,0 +1,16 @@
+import LandingPage from './LandingPage';
+import powerpointZuAnkiCopy from './copy/powerpoint-zu-anki';
+import { ErrorHandlerType } from '../../components/errors/helpers/getErrorMessage';
+
+interface Props {
+  setErrorMessage: ErrorHandlerType;
+}
+
+export default function PowerpointZuAnki({ setErrorMessage }: Readonly<Props>) {
+  return (
+    <LandingPage
+      copy={powerpointZuAnkiCopy}
+      setErrorMessage={setErrorMessage}
+    />
+  );
+}

--- a/web/src/pages/LandingPage/copy/notion-zu-anki.ts
+++ b/web/src/pages/LandingPage/copy/notion-zu-anki.ts
@@ -83,7 +83,7 @@ const notionZuAnkiCopy: LandingCopy = {
     },
   ],
   relatedLinks: [
-    { label: 'Karten aus einem PDF', href: '/pdf-to-anki' },
+    { label: 'Karten aus einem PDF', href: '/pdf-zu-anki' },
     { label: 'Automatische Synchronisierung', href: '/pricing' },
     { label: 'Alle Konverter ansehen', href: '/convert' },
   ],

--- a/web/src/pages/LandingPage/copy/pdf-zu-anki.ts
+++ b/web/src/pages/LandingPage/copy/pdf-zu-anki.ts
@@ -66,7 +66,7 @@ const pdfZuAnkiCopy: LandingCopy = {
     },
     {
       q: 'Wie entscheidet 2anki, was zur Karte wird?',
-      a: 'Überschriften werden zu Deck- und Tag-Namen. Aufzählungspunkte und kurze Absätze werden zur Kartenvorderseite; die nächste Zeile oder Einrückung zur Rückseite. Du kannst die Karten danach in Anki bearbeiten — wir sperren nichts.',
+      a: 'Überschriften werden zu Deck- und Tag-Namen. Aufzählungspunkte und kurze Absätze werden zur Kartenvorderseite; die nächste Zeile oder Einrückung zur Rückseite. Du kannst die Karten danach in Anki frei bearbeiten.',
     },
     {
       q: 'Kann ich ein ganzes Lehrbuch hochladen?',

--- a/web/src/pages/LandingPage/copy/pdf-zu-anki.ts
+++ b/web/src/pages/LandingPage/copy/pdf-zu-anki.ts
@@ -1,0 +1,90 @@
+import type { LandingCopy } from '../types';
+
+const pdfZuAnkiCopy: LandingCopy = {
+  pathname: '/pdf-zu-anki',
+  htmlLang: 'de',
+  alternates: [
+    { hreflang: 'en', href: 'https://2anki.net/pdf-to-anki/' },
+    { hreflang: 'de', href: 'https://2anki.net/pdf-zu-anki/' },
+    { hreflang: 'x-default', href: 'https://2anki.net/pdf-to-anki/' },
+  ],
+  title: 'PDF zu Anki — Karteikarten aus jedem PDF | 2anki',
+  description:
+    'Lade ein PDF hoch und mach daraus einen Anki-Stapel: Überschriften werden zu Decks, Bilder eingebettet, sauberer Import. Datei rein, .apkg raus.',
+  h1: 'Aus einem PDF Anki-Karteikarten machen',
+  subhead:
+    'Lade ein PDF hoch — Vorlesungsskript, Lehrbuchkapitel oder Zusammenfassung — und 2anki holt den Text heraus, aus dem du Karten baust.',
+  steps: [
+    {
+      title: 'PDF hochladen',
+      body: 'Zieh dein Vorlesungsskript, ein Lehrbuchkapitel oder eine Zusammenfassung als PDF hierher.',
+    },
+    {
+      title: '2anki baut deinen Stapel',
+      body: 'Meist ein paar Sekunden. Größere Dateien dauern eine Minute.',
+    },
+    {
+      title: 'In Anki öffnen',
+      body: 'Lade die .apkg-Datei herunter und öffne sie per Doppelklick. Deine Karten sind sofort lernbereit.',
+    },
+  ],
+  formats: [
+    'PDF',
+    'Notion',
+    'Word',
+    'Markdown',
+    'PowerPoint',
+    'Quizlet',
+    'CSV',
+  ],
+  whatComesAcross: [
+    {
+      title: 'Cloze bleibt anklickbar',
+      body: '{{c1::...}} wird zu einer echten Anki-Cloze-Karte, nicht zu einfachem Text.',
+    },
+    {
+      title: 'Bilder erscheinen in der Karte',
+      body: 'Eingebettete Abbildungen und Diagramme werden übernommen und auf Vorder- oder Rückseite angezeigt.',
+    },
+    {
+      title: 'Überschriften werden zu Decks',
+      body: 'Kapitelüberschriften aus dem PDF werden zu Deck- und Tag-Namen, damit dein Stapel geordnet bleibt.',
+    },
+    {
+      title: 'Richtige Notiztypen',
+      body: 'Basic, Cloze und Vorder-/Rückseite landen im passenden Anki-Notiztyp, damit der Import sauber ist.',
+    },
+    {
+      title: 'Für Medizin, Pflege und Examen gebaut',
+      body: 'Ob Physikum, Hammerexamen oder Pflegeexamen — lade dein Vorlesungsskript oder ein Lehrbuchkapitel als PDF hoch und lerne aus deinem eigenen Material statt aus einem Stapel von der Stange.',
+    },
+  ],
+  faqs: [
+    {
+      q: 'Funktioniert das mit gescannten PDFs?',
+      a: 'Nur wenn der Scan eine Textebene hat (OCR). Die meisten aktuellen Lehrbücher und Folien-Exporte haben das. Ist deins ein Foto einer Seite ohne Textebene, schick es vorher durch ein OCR-Tool — die macOS-Vorschau und Adobe Acrobat können das beide.',
+    },
+    {
+      q: 'Wie entscheidet 2anki, was zur Karte wird?',
+      a: 'Überschriften werden zu Deck- und Tag-Namen. Aufzählungspunkte und kurze Absätze werden zur Kartenvorderseite; die nächste Zeile oder Einrückung zur Rückseite. Du kannst die Karten danach in Anki bearbeiten — wir sperren nichts.',
+    },
+    {
+      q: 'Kann ich ein ganzes Lehrbuch hochladen?',
+      a: 'Ja, aber große PDFs dauern länger und erzeugen riesige Stapel. Wir empfehlen, ein Kapitel nach dem anderen hochzuladen — leichter zu prüfen, leichter zu teilen, und Anki kommt mit einem Stapel aus ein paar Hundert Karten besser klar als mit einem aus Zehntausenden.',
+    },
+    {
+      q: 'Was passiert mit Diagrammen und Formeln?',
+      a: 'Diagramme werden als eingebettete Bilder übernommen. Als Bild gerenderte Formeln bleiben Bilder; als Text gespeicherte Formeln brauchen aktiviertes MathJax in deiner Anki-Kartenvorlage, um angezeigt zu werden.',
+    },
+  ],
+  relatedLinks: [
+    {
+      label: 'Aus PowerPoint-Folien Karten machen',
+      href: '/powerpoint-zu-anki',
+    },
+    { label: 'Notion-Seiten zu Anki', href: '/notion-zu-anki' },
+    { label: 'Alle Konverter ansehen', href: '/convert' },
+  ],
+};
+
+export default pdfZuAnkiCopy;

--- a/web/src/pages/LandingPage/copy/pdf.ts
+++ b/web/src/pages/LandingPage/copy/pdf.ts
@@ -2,6 +2,11 @@ import type { LandingCopy } from '../types';
 import { ankiFidelityProof } from './ankiFidelityProof';
 
 const pdfCopy: LandingCopy = {
+  alternates: [
+    { hreflang: 'en', href: 'https://2anki.net/pdf-to-anki/' },
+    { hreflang: 'de', href: 'https://2anki.net/pdf-zu-anki/' },
+    { hreflang: 'x-default', href: 'https://2anki.net/pdf-to-anki/' },
+  ],
   relatedLinks: [
     { label: 'Convert PowerPoint slides to Anki', href: '/powerpoint-to-anki' },
     {

--- a/web/src/pages/LandingPage/copy/powerpoint-zu-anki.ts
+++ b/web/src/pages/LandingPage/copy/powerpoint-zu-anki.ts
@@ -17,7 +17,7 @@ const powerpointZuAnkiCopy: LandingCopy = {
   steps: [
     {
       title: 'Folien hochladen',
-      body: 'Zieh deine .pptx hierher — native PowerPoint oder ein Google-Slides-Export.',
+      body: 'Zieh deine .pptx hierher — eine native PowerPoint-Datei oder ein Google-Slides-Export.',
     },
     {
       title: '2anki liest deine Folien',
@@ -66,7 +66,7 @@ const powerpointZuAnkiCopy: LandingCopy = {
     },
     {
       q: 'Werden meine Referentennotizen übernommen?',
-      a: '2anki liest den Text auf den Folien selbst, deshalb werden Notizen, die nur im Referentennotizen-Bereich stehen, nicht erfasst. Schreib alles, was auf eine Karte soll, vor dem Hochladen direkt auf die Folie.',
+      a: '2anki liest den Text auf den Folien selbst, deshalb werden Notizen, die nur im Notizenbereich stehen, nicht erfasst. Schreib alles, was auf eine Karte soll, vor dem Hochladen direkt auf die Folie.',
     },
     {
       q: 'Ich habe meine Folien in Google Slides erstellt — geht das?',
@@ -74,7 +74,7 @@ const powerpointZuAnkiCopy: LandingCopy = {
     },
     {
       q: 'Was passiert mit Folien, die nur aus einem Bild bestehen?',
-      a: 'Folien ohne Text — ein bildfüllendes Diagramm oder Foto — haben nichts, was wir lesen könnten, und erzeugen daher keine Karte. Füge dieser Folie einen Titel oder eine Zeile Text hinzu, wenn sie zur Karte werden soll. Wird ein Blocktyp nicht so übernommen, wie du es dir wünschst, schick uns die Datei an support@2anki.net.',
+      a: 'Folien ohne Text — ein bildfüllendes Diagramm oder Foto — haben nichts, was wir lesen könnten, und erzeugen daher keine Karte. Füge dieser Folie einen Titel oder eine Zeile Text hinzu, wenn sie zur Karte werden soll. Wird etwas nicht so übernommen, wie du es dir wünschst, schick uns die Datei an support@2anki.net.',
     },
   ],
   relatedLinks: [

--- a/web/src/pages/LandingPage/copy/powerpoint-zu-anki.ts
+++ b/web/src/pages/LandingPage/copy/powerpoint-zu-anki.ts
@@ -1,0 +1,87 @@
+import type { LandingCopy } from '../types';
+
+const powerpointZuAnkiCopy: LandingCopy = {
+  pathname: '/powerpoint-zu-anki',
+  htmlLang: 'de',
+  alternates: [
+    { hreflang: 'en', href: 'https://2anki.net/powerpoint-to-anki/' },
+    { hreflang: 'de', href: 'https://2anki.net/powerpoint-zu-anki/' },
+    { hreflang: 'x-default', href: 'https://2anki.net/powerpoint-to-anki/' },
+  ],
+  title: 'PowerPoint zu Anki — Vorlesungsfolien als Karteikarten | 2anki',
+  description:
+    'Lade eine .pptx hoch und 2anki macht aus dem Text deiner Folien einen Anki-Stapel. Funktioniert auch mit Google-Slides-Exporten.',
+  h1: 'Aus PowerPoint-Folien Anki-Karteikarten machen',
+  subhead:
+    'Lade eine .pptx hoch — deine Vorlesungsfolien — und 2anki liest den Text auf den Folien und baut einen Anki-Stapel, den du bearbeiten kannst.',
+  steps: [
+    {
+      title: 'Folien hochladen',
+      body: 'Zieh deine .pptx hierher — native PowerPoint oder ein Google-Slides-Export.',
+    },
+    {
+      title: '2anki liest deine Folien',
+      body: 'Titel, Aufzählungen und Fließtext werden zu Karten. Meist ein paar Sekunden.',
+    },
+    {
+      title: 'In Anki öffnen',
+      body: 'Lade die .apkg-Datei herunter und öffne sie per Doppelklick. Deine Karten sind sofort lernbereit.',
+    },
+  ],
+  formats: [
+    'PowerPoint',
+    'PDF',
+    'Notion',
+    'Word',
+    'Markdown',
+    'Quizlet',
+    'CSV',
+  ],
+  whatComesAcross: [
+    {
+      title: 'Folientext wird zu Karten',
+      body: 'Titel, Aufzählungspunkte und Fließtext jeder Folie werden zu Karten, die du in Anki bearbeiten und umsortieren kannst.',
+    },
+    {
+      title: 'Bilder bleiben erhalten',
+      body: 'Eingebettete Abbildungen und Diagramme von deinen Folien werden in die Karte übernommen.',
+    },
+    {
+      title: 'Richtige Notiztypen',
+      body: 'Basic und Vorder-/Rückseite landen im passenden Anki-Notiztyp, damit der Import sauber ist.',
+    },
+    {
+      title: 'Kein Ballast in den Karten',
+      body: 'Keine leeren Rückseiten und keine übrig gebliebenen Sonderzeichen aus deinen Folien.',
+    },
+    {
+      title: 'Für Medizin, Pflege und Examen gebaut',
+      body: 'Ob Physikum, Hammerexamen oder Pflegeexamen — lade deine Vorlesungsfolien hoch und lerne aus dem Material deiner eigenen Dozenten statt aus einem Stapel von der Stange.',
+    },
+  ],
+  faqs: [
+    {
+      q: 'Welcher Folieninhalt wird zur Karte?',
+      a: 'Der Text auf jeder Folie — Titel, Aufzählungen und Fließtext. 2anki liest ihn und baut Karten, die du danach in Anki bearbeiten und umsortieren kannst.',
+    },
+    {
+      q: 'Werden meine Referentennotizen übernommen?',
+      a: '2anki liest den Text auf den Folien selbst, deshalb werden Notizen, die nur im Referentennotizen-Bereich stehen, nicht erfasst. Schreib alles, was auf eine Karte soll, vor dem Hochladen direkt auf die Folie.',
+    },
+    {
+      q: 'Ich habe meine Folien in Google Slides erstellt — geht das?',
+      a: 'Ja. Wähle in Google Slides Datei, dann Herunterladen, dann Microsoft PowerPoint (.pptx). Lade diese Datei hier hoch, und sie wird genauso konvertiert wie eine native PowerPoint-Datei.',
+    },
+    {
+      q: 'Was passiert mit Folien, die nur aus einem Bild bestehen?',
+      a: 'Folien ohne Text — ein bildfüllendes Diagramm oder Foto — haben nichts, was wir lesen könnten, und erzeugen daher keine Karte. Füge dieser Folie einen Titel oder eine Zeile Text hinzu, wenn sie zur Karte werden soll. Wird ein Blocktyp nicht so übernommen, wie du es dir wünschst, schick uns die Datei an support@2anki.net.',
+    },
+  ],
+  relatedLinks: [
+    { label: 'Aus einem PDF Karten machen', href: '/pdf-zu-anki' },
+    { label: 'Notion-Seiten zu Anki', href: '/notion-zu-anki' },
+    { label: 'Alle Konverter ansehen', href: '/convert' },
+  ],
+};
+
+export default powerpointZuAnkiCopy;

--- a/web/src/pages/LandingPage/copy/powerpoint.ts
+++ b/web/src/pages/LandingPage/copy/powerpoint.ts
@@ -1,6 +1,11 @@
 import type { LandingCopy } from '../types';
 
 const powerpointCopy: LandingCopy = {
+  alternates: [
+    { hreflang: 'en', href: 'https://2anki.net/powerpoint-to-anki/' },
+    { hreflang: 'de', href: 'https://2anki.net/powerpoint-zu-anki/' },
+    { hreflang: 'x-default', href: 'https://2anki.net/powerpoint-to-anki/' },
+  ],
   relatedLinks: [
     { label: 'Convert a PDF to Anki', href: '/pdf-to-anki' },
     {

--- a/web/src/pages/WhatsNewPage/changelog/2026-09-07-german-pdf-powerpoint-landing.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-09-07-german-pdf-powerpoint-landing.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-09-07-german-pdf-powerpoint-landing",
+  "date": "2026-09-07",
+  "type": "feature",
+  "title": "The PDF to Anki and PowerPoint to Anki guides are now available in German"
+}


### PR DESCRIPTION
## What
Ships two prerendered German landing pages — `/pdf-zu-anki` and `/powerpoint-zu-anki` — as German twins of the shipped `/pdf-to-anki` and `/powerpoint-to-anki` pages. Each carries authored German-first copy (title, description, h1, subhead, steps, "what you get in Anki" fidelity proof, med/exam framing, FAQs, related links), stamps `<html lang="de">` + a single `og:locale de_DE`, self-canonicals, and links a reciprocal `hreflang` triplet (`en` / `de` / `x-default`) to its English twin. The two English pages gain the matching reciprocal hreflang set; everything else on them is byte-unchanged.

This mirrors the full #4333 pattern (`/notion-zu-anki`): copy files, thin page components, lazy routes in `web/src/App.tsx`, server allowlist slugs in `src/routes/knownRoutes.ts`, prerender registration + assertions in `web/scripts/prerenderLandingPages.*`, and `web/public/sitemap.xml`.

## Why
The German-speaking cohort is 2anki's largest paying segment and DACH acquisition is underexploited. The existing client-side `de`-locale swap renders after hydration, so crawlers only ever see the English shell — German searchers never find us for German-language converter queries. These give Google real German documents to index for the two highest-intent formats German med students convert.

**Pages chosen and why:**
- **`/pdf-zu-anki`** ("PDF zu Anki") — German med students convert lecture handouts (*Skripte*) and textbook chapters, which are PDFs. Maps directly to the battle-tested `/pdf-to-anki` converter (PDF text extraction, image embedding, headings→decks).
- **`/powerpoint-zu-anki`** ("PowerPoint zu Anki / Vorlesungsfolien als Karteikarten") — lecture slides (*Vorlesungsfolien*) are the other primary DACH-med study input. Maps to the shipped `/powerpoint-to-anki` converter (.pptx slide-text extraction, Google Slides exports).
- **Not chosen: "Notion Karteikarten erstellen".** Notion German intent already has a real page (`/notion-zu-anki`, #4333). A second Notion German page would cannibalize it for overlapping branded intent. Broadening format coverage (PDF, PowerPoint) beats doubling up on Notion.

## How
- New `copy/pdf-zu-anki.ts` and `copy/powerpoint-zu-anki.ts` (`LandingCopy` with `htmlLang: 'de'` + `alternates`); thin `PdfZuAnki.tsx` / `PowerpointZuAnki.tsx`; lazy routes in `App.tsx`; slugs in `knownRoutes.ts`; both copies registered in `prerenderLandingPages.ts`; sitemap entries.
- Reciprocal `alternates` added to the English `copy/pdf.ts` and `copy/powerpoint.ts` (same mechanism #4333 used on `copy/notion.ts`).
- No changes to `types.ts` or `prerenderLandingPages.ts`'s `rewriteHead`/`localizedHeadTags` logic were needed — the `htmlLang`/`alternates` machinery from #4333 already generalizes; these pages just supply the data.
- Prerendered section labels ("How it works", "Common questions", …) stay English, exactly as on `/notion-zu-anki` — the visible copy (h1, subhead, steps, fidelity proof, FAQs, related links) is authored German.

## Measuring success
Search Console: impressions/clicks for `/pdf-zu-anki/` and `/powerpoint-zu-anki/` and German converter queries. Per-page `de` → `checkout` rate off `/api/ops/metrics` (signup origin persists the pathname via `persistSignupOrigin`). Confirm indexing by fetching each deployed page and grepping the head for `lang="de"` + the hreflang triplet.

## Testing
- Unit tests added: `PdfZuAnki.test.tsx` and `PowerpointZuAnki.test.tsx` (German h1, all FAQs, med-exam framing card, related-nav cross-link to the sibling German page).
- Prerender: parameterized `describe.each` covering both new twins in `prerenderLandingPages.test.ts` — authored German title, `lang="de"`, self-canonical, single `de_DE` og:locale replacing base `en_US`, full hreflang triplet on both the German and English page, English page lang/locale unchanged, med-exam framing (`Physikum`) in the crawlable body. Landing-page count bumped 42 → 44.
- Server: `knownRoutes.test.ts` extended with both new slugs — **46 passed**.
- Full web suite: **389 files / 3564 tests passed**.
- Full server suite: **713 suites / 6983 tests passed**; the 9 failing suites (81 tests) are the documented worktree-environmental set only — `DeckParser*` / `golden` / `canary` (need the `create_deck` Python venv) and `getPageCount` (needs pdfinfo).
- `pnpm format:check` clean (exact CI command), web `typecheck` clean, server `tsc -p . --noEmit` clean, web lint clean (only pre-existing warnings, none in touched files).

Sonar: not run locally; PR decoration will report.

## Browser check
Browser check: not applicable — no browser available in this environment; the pages are an exact mirror of the shipped /notion-zu-anki pattern (#4333) and were verified via the production prerender output instead: `pnpm --filter 2anki-web build` emits both pages with `<html lang="de">`, authored German titles, self-canonicals, the full en/de/x-default hreflang triplet on both sides of each pair, and exactly one `og:locale de_DE` — all additionally pinned by the parameterized prerender test suite. English twins byte-unchanged except the reciprocal hreflang.
