### PR TITLE
fix: fire account_created for every signup path, not just password

### DIFF
--- a/src/controllers/UsersControllers.test.ts
+++ b/src/controllers/UsersControllers.test.ts
@@ -643,7 +643,8 @@ describe('UsersController.requestMagicLink', () => {
       'al@example.com',
       'login',
       null,
-      undefined
+      undefined,
+      expect.objectContaining({ anonymousId: null })
     );
   });
 
@@ -662,7 +663,8 @@ describe('UsersController.requestMagicLink', () => {
       'al@example.com',
       'login',
       null,
-      '/upload'
+      '/upload',
+      expect.objectContaining({ anonymousId: null })
     );
   });
 
@@ -685,7 +687,8 @@ describe('UsersController.requestMagicLink', () => {
       'al@example.com',
       'login',
       null,
-      undefined
+      undefined,
+      expect.objectContaining({ anonymousId: null })
     );
   });
 

--- a/src/controllers/UsersControllers.test.ts
+++ b/src/controllers/UsersControllers.test.ts
@@ -171,11 +171,16 @@ describe('UsersController.register', () => {
 
     await controller.register(req, res, next);
 
-    expect(trackMock).toHaveBeenCalledWith('account_created', {
-      userId: 1,
-      anonymousId: 'anon-abc-123',
-      props: { signup_origin: '/notion-to-anki' },
-    });
+    expect(register).toHaveBeenCalledWith(
+      '',
+      'hashed',
+      'jane.doe@example.com',
+      '/notion-to-anki',
+      expect.objectContaining({
+        method: 'password',
+        anonymousId: 'anon-abc-123',
+      })
+    );
   });
 
   it('emits signup_origin and signup_referrer from the first_touch cookie', async () => {
@@ -197,19 +202,16 @@ describe('UsersController.register', () => {
 
     await controller.register(req, res, next);
 
-    expect(trackMock).toHaveBeenCalledWith('account_created', {
-      userId: 1,
-      anonymousId: 'anon-abc-123',
-      props: {
-        signup_origin: '/pdf-to-anki',
-        signup_referrer: 'chatgpt.com',
-      },
-    });
     expect(register).toHaveBeenCalledWith(
       '',
       'hashed',
       'jane.doe@example.com',
-      '/pdf-to-anki'
+      '/pdf-to-anki',
+      expect.objectContaining({
+        method: 'password',
+        anonymousId: 'anon-abc-123',
+        referrer: 'chatgpt.com',
+      })
     );
   });
 
@@ -232,11 +234,13 @@ describe('UsersController.register', () => {
 
     await controller.register(req, res, next);
 
-    expect(trackMock).toHaveBeenCalledWith('account_created', {
-      userId: 1,
-      anonymousId: null,
-      props: { signup_origin: '/markdown-to-anki' },
-    });
+    expect(register).toHaveBeenCalledWith(
+      '',
+      'hashed',
+      'jane.doe@example.com',
+      '/markdown-to-anki',
+      expect.objectContaining({ method: 'password', anonymousId: null })
+    );
   });
 
   it('emits account_created with a null anonymous id when no anon_id cookie is present', async () => {
@@ -252,9 +256,12 @@ describe('UsersController.register', () => {
 
     await controller.register(req, res, next);
 
-    expect(trackMock).toHaveBeenCalledWith(
-      'account_created',
-      expect.objectContaining({ userId: 1, anonymousId: null })
+    expect(register).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.any(String),
+      null,
+      expect.objectContaining({ method: 'password', anonymousId: null })
     );
   });
 
@@ -274,6 +281,7 @@ describe('UsersController.register', () => {
     await controller.register(req, res, next);
 
     expect(trackMock).not.toHaveBeenCalled();
+    expect(register).not.toHaveBeenCalled();
   });
 
   it('rejects requests missing both email and password with 400', async () => {
@@ -361,7 +369,8 @@ describe('UsersController.register', () => {
       'Alex',
       'hashed',
       'alex@example.com',
-      null
+      null,
+      expect.objectContaining({ method: 'password' })
     );
     expect(res.status).toHaveBeenCalledWith(200);
   });
@@ -386,7 +395,8 @@ describe('UsersController.register', () => {
       expect.any(String),
       'hashed',
       'al@example.com',
-      '/notion-to-anki'
+      '/notion-to-anki',
+      expect.objectContaining({ method: 'password' })
     );
   });
 
@@ -410,7 +420,8 @@ describe('UsersController.register', () => {
       expect.any(String),
       'hashed',
       'al@example.com',
-      null
+      null,
+      expect.objectContaining({ method: 'password' })
     );
   });
 
@@ -1083,7 +1094,8 @@ describe('UsersController.loginWithGoogle', () => {
       expect.any(String),
       expect.any(String),
       'g@example.com',
-      'google'
+      'google',
+      expect.objectContaining({ method: 'google' })
     );
   });
 
@@ -1236,7 +1248,8 @@ describe('UsersController.loginWithMicrosoft', () => {
       expect.any(String),
       expect.any(String),
       'm@example.com',
-      'microsoft'
+      'microsoft',
+      expect.objectContaining({ method: 'microsoft' })
     );
     expect(MockedOauthIdentitiesRepo.prototype.link).toHaveBeenCalledWith(
       'microsoft',
@@ -1469,7 +1482,8 @@ describe('UsersController.loginWithApple', () => {
       expect.any(String),
       expect.any(String),
       'apple@example.com',
-      'apple'
+      'apple',
+      expect.objectContaining({ method: 'apple' })
     );
     expect(MockedOauthIdentitiesRepo.prototype.link).toHaveBeenCalledWith(
       'apple',
@@ -2178,7 +2192,8 @@ describe('UsersController.loginWithNotion', () => {
       expect.any(String),
       expect.any(String),
       'n@example.com',
-      'notion_oauth'
+      'notion_oauth',
+      expect.objectContaining({ method: 'notion_oauth' })
     );
   });
 
@@ -3023,7 +3038,8 @@ describe('UsersController.loginWithAppleNative', () => {
       expect.any(String),
       expect.any(String),
       'native-apple@example.com',
-      'apple'
+      'apple',
+      expect.objectContaining({ method: 'apple' })
     );
     expect(MockedOauthIdentitiesRepo.prototype.link).toHaveBeenCalledWith(
       'apple',
@@ -3085,7 +3101,8 @@ describe('UsersController.loginWithAppleNative', () => {
       'Jane Doe',
       expect.any(String),
       'native-apple@example.com',
-      'apple'
+      'apple',
+      expect.objectContaining({ method: 'apple' })
     );
   });
 
@@ -3100,7 +3117,8 @@ describe('UsersController.loginWithAppleNative', () => {
       'native-apple@example.com',
       expect.any(String),
       'native-apple@example.com',
-      'apple'
+      'apple',
+      expect.objectContaining({ method: 'apple' })
     );
   });
 });

--- a/src/controllers/UsersControllers.ts
+++ b/src/controllers/UsersControllers.ts
@@ -53,6 +53,12 @@ function readFirstTouchCookie(req: express.Request): FirstTouchAttribution {
   return parseFirstTouch(cookies?.first_touch);
 }
 
+function readAnonIdCookie(req: express.Request): string | null {
+  const cookies = req.cookies as Record<string, unknown> | undefined;
+  const anonId = cookies?.anon_id;
+  return typeof anonId === 'string' && anonId.length > 0 ? anonId : null;
+}
+
 class UsersController {
   constructor(
     private readonly userService: UsersService,
@@ -242,8 +248,6 @@ class UsersController {
     const signupOrigin =
       firstTouch.signupOrigin ?? parseSignupOrigin(req.body.source);
     try {
-      const cookies = req.cookies as Record<string, unknown> | undefined;
-      const anonId = cookies?.anon_id;
       await this.userService.register(
         name ?? '',
         password,
@@ -251,8 +255,7 @@ class UsersController {
         signupOrigin,
         {
           method: 'password',
-          anonymousId:
-            typeof anonId === 'string' && anonId.length > 0 ? anonId : null,
+          anonymousId: readAnonIdCookie(req),
           referrer: firstTouch.signupReferrer,
         }
       );
@@ -720,7 +723,11 @@ class UsersController {
         hashedPassword,
         email,
         readFirstTouchCookie(req).signupOrigin ?? 'google',
-        { method: 'google', referrer: readFirstTouchCookie(req).signupReferrer }
+        {
+          method: 'google',
+          anonymousId: readAnonIdCookie(req),
+          referrer: readFirstTouchCookie(req).signupReferrer,
+        }
       );
       user = await this.userService.getUserFrom(email);
     }
@@ -836,6 +843,7 @@ class UsersController {
           readFirstTouchCookie(req).signupOrigin ?? 'microsoft',
           {
             method: 'microsoft',
+            anonymousId: readAnonIdCookie(req),
             referrer: readFirstTouchCookie(req).signupReferrer,
           }
         );
@@ -1079,6 +1087,7 @@ class UsersController {
           readFirstTouchCookie(req).signupOrigin ?? 'apple',
           {
             method: 'apple',
+            anonymousId: readAnonIdCookie(req),
             referrer: readFirstTouchCookie(req).signupReferrer,
           }
         );
@@ -1202,6 +1211,7 @@ class UsersController {
         readFirstTouchCookie(req).signupOrigin ?? 'notion_oauth',
         {
           method: 'notion_oauth',
+          anonymousId: readAnonIdCookie(req),
           referrer: readFirstTouchCookie(req).signupReferrer,
         }
       );
@@ -1272,7 +1282,11 @@ class UsersController {
         email.trim(),
         purpose,
         readFirstTouchCookie(req).signupOrigin,
-        redirect
+        redirect,
+        {
+          anonymousId: readAnonIdCookie(req),
+          referrer: readFirstTouchCookie(req).signupReferrer,
+        }
       );
     } catch (error) {
       if (error instanceof MagicLinkRateLimitError) {

--- a/src/controllers/UsersControllers.ts
+++ b/src/controllers/UsersControllers.ts
@@ -41,7 +41,6 @@ import NotionRepository from '../data_layer/NotionRespository';
 import hashToken from '../lib/misc/hashToken';
 import { extractCountryFromRequest } from '../lib/http/extractCountryFromRequest';
 import { RecordUserVisibleErrorUseCase } from '../usecases/observability/RecordUserVisibleErrorUseCase';
-import { track } from '../services/events/track';
 import { mapEntitlement } from './helpers/mapEntitlement';
 import { hasAnkifyAccess } from '../lib/ankify/access';
 import EmailChangeTokenRepository from '../data_layer/EmailChangeTokenRepository';
@@ -52,20 +51,6 @@ import type { IEmailService } from '../services/EmailService/EmailService';
 function readFirstTouchCookie(req: express.Request): FirstTouchAttribution {
   const cookies = req.cookies as Record<string, unknown> | undefined;
   return parseFirstTouch(cookies?.first_touch);
-}
-
-function buildSignupProps(
-  signupOrigin: string | null,
-  signupReferrer: string | null
-): Record<string, string> {
-  const props: Record<string, string> = {};
-  if (signupOrigin != null) {
-    props.signup_origin = signupOrigin;
-  }
-  if (signupReferrer != null) {
-    props.signup_referrer = signupReferrer;
-  }
-  return props;
 }
 
 class UsersController {
@@ -257,22 +242,22 @@ class UsersController {
     const signupOrigin =
       firstTouch.signupOrigin ?? parseSignupOrigin(req.body.source);
     try {
+      const cookies = req.cookies as Record<string, unknown> | undefined;
+      const anonId = cookies?.anon_id;
       await this.userService.register(
         name ?? '',
         password,
         email,
-        signupOrigin
+        signupOrigin,
+        {
+          method: 'password',
+          anonymousId:
+            typeof anonId === 'string' && anonId.length > 0 ? anonId : null,
+          referrer: firstTouch.signupReferrer,
+        }
       );
       const newUser = await this.userService.getUserFrom(email);
       if (newUser) {
-        const cookies = req.cookies as Record<string, unknown> | undefined;
-        const anonId = cookies?.anon_id;
-        track('account_created', {
-          userId: Number(newUser.id),
-          anonymousId:
-            typeof anonId === 'string' && anonId.length > 0 ? anonId : null,
-          props: buildSignupProps(signupOrigin, firstTouch.signupReferrer),
-        });
         try {
           const country = extractCountryFromRequest(req);
           if (country != null) {
@@ -734,7 +719,8 @@ class UsersController {
         name ?? email,
         hashedPassword,
         email,
-        readFirstTouchCookie(req).signupOrigin ?? 'google'
+        readFirstTouchCookie(req).signupOrigin ?? 'google',
+        { method: 'google', referrer: readFirstTouchCookie(req).signupReferrer }
       );
       user = await this.userService.getUserFrom(email);
     }
@@ -847,7 +833,11 @@ class UsersController {
           name ?? email,
           hashedPassword,
           email,
-          readFirstTouchCookie(req).signupOrigin ?? 'microsoft'
+          readFirstTouchCookie(req).signupOrigin ?? 'microsoft',
+          {
+            method: 'microsoft',
+            referrer: readFirstTouchCookie(req).signupReferrer,
+          }
         );
         user = await this.userService.getUserFrom(email);
         isNewUser = true;
@@ -1086,7 +1076,11 @@ class UsersController {
           rawName ?? email,
           hashedPassword,
           email,
-          readFirstTouchCookie(req).signupOrigin ?? 'apple'
+          readFirstTouchCookie(req).signupOrigin ?? 'apple',
+          {
+            method: 'apple',
+            referrer: readFirstTouchCookie(req).signupReferrer,
+          }
         );
         user = await this.userService.getUserFrom(email);
         isNewUser = true;
@@ -1205,7 +1199,11 @@ class UsersController {
         name,
         hashedPassword,
         email,
-        readFirstTouchCookie(req).signupOrigin ?? 'notion_oauth'
+        readFirstTouchCookie(req).signupOrigin ?? 'notion_oauth',
+        {
+          method: 'notion_oauth',
+          referrer: readFirstTouchCookie(req).signupReferrer,
+        }
       );
       user = await this.userService.getUserFrom(email);
     }

--- a/src/services/UsersService.test.ts
+++ b/src/services/UsersService.test.ts
@@ -124,12 +124,13 @@ describe('UsersService.register', () => {
 
     await service.register('Alex', 'hashed', 'al@example.com', 'google', {
       method: 'google',
+      anonymousId: 'anon-xyz-9',
       referrer: 'https://google.com',
     });
 
     expect(trackMock).toHaveBeenCalledWith('account_created', {
       userId: 1,
-      anonymousId: null,
+      anonymousId: 'anon-xyz-9',
       props: {
         signup_origin: 'google',
         signup_referrer: 'https://google.com',

--- a/src/services/UsersService.test.ts
+++ b/src/services/UsersService.test.ts
@@ -8,6 +8,12 @@ import type AuthenticationService from './AuthenticationService';
 import { InMemoryMagicTokenRepository } from '../data_layer/MagicTokenRepository';
 
 jest.mock('../lib/misc/hashToken', () => (s: string) => `hashed:${s}`);
+jest.mock('./events/track', () => ({
+  track: jest.fn(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const trackMock = require('./events/track').track as jest.Mock;
 
 function buildEmailService(
   overrides: Partial<IEmailService> = {}
@@ -109,6 +115,41 @@ describe('UsersService.register', () => {
       'al@example.com',
       '/notion-to-anki'
     );
+  });
+
+  it('fires account_created with method and origin for every creation path', async () => {
+    trackMock.mockReset();
+    const repository = buildRegisterRepository();
+    const service = new UsersService(repository, buildEmailService());
+
+    await service.register('Alex', 'hashed', 'al@example.com', 'google', {
+      method: 'google',
+      referrer: 'https://google.com',
+    });
+
+    expect(trackMock).toHaveBeenCalledWith('account_created', {
+      userId: 1,
+      anonymousId: null,
+      props: {
+        signup_origin: 'google',
+        signup_referrer: 'https://google.com',
+        method: 'google',
+      },
+    });
+  });
+
+  it('fires account_created with method unknown when no telemetry is given', async () => {
+    trackMock.mockReset();
+    const repository = buildRegisterRepository();
+    const service = new UsersService(repository, buildEmailService());
+
+    await service.register('Alex', 'hashed', 'al@example.com');
+
+    expect(trackMock).toHaveBeenCalledWith('account_created', {
+      userId: 1,
+      anonymousId: null,
+      props: { method: 'unknown' },
+    });
   });
 });
 

--- a/src/services/UsersService.ts
+++ b/src/services/UsersService.ts
@@ -10,6 +10,21 @@ import { IEmailService } from './EmailService/EmailService';
 import type { IMagicTokenRepository } from '../data_layer/MagicTokenRepository';
 import hashToken from '../lib/misc/hashToken';
 import { isResetTokenLive } from '../lib/User/isResetTokenLive';
+import { track } from './events/track';
+
+// Who signed up how, threaded into the account_created event at the single
+// creation choke point in register().
+export interface RegisterTelemetry {
+  method:
+    | 'password'
+    | 'google'
+    | 'microsoft'
+    | 'apple'
+    | 'notion_oauth'
+    | 'magic_link';
+  anonymousId?: string | null;
+  referrer?: string | null;
+}
 
 const MAGIC_LINK_RATE_LIMIT = 5;
 const MAGIC_LINK_RATE_WINDOW_MS = 60 * 60 * 1000;
@@ -110,18 +125,40 @@ class UsersService {
     name: string,
     password: string,
     email: string,
-    signupOrigin?: string | null
+    signupOrigin?: string | null,
+    telemetry?: RegisterTelemetry
   ) {
     const normalizedEmail = email.toLowerCase();
     const trimmedName = name?.trim() ?? '';
     const resolvedName =
       trimmedName.length > 0 ? trimmedName : normalizedEmail.split('@')[0];
-    return this.repository.createUserAndSeedFromTombstone(
+    const inserted = await this.repository.createUserAndSeedFromTombstone(
       resolvedName,
       password,
       normalizedEmail,
       signupOrigin ?? null
     );
+    // account_created must fire for EVERY creation path (password, all four
+    // OAuth providers, magic-link) or the signup funnel undercounts — it sat
+    // on the password path alone for months and missed ~84% of signups. The
+    // event lives here, at the single choke point, so a new path can't forget.
+    const userId = Number(inserted[0]?.id);
+    if (Number.isFinite(userId)) {
+      const props: Record<string, string> = {};
+      if (signupOrigin != null) {
+        props.signup_origin = signupOrigin;
+      }
+      if (telemetry?.referrer != null) {
+        props.signup_referrer = telemetry.referrer;
+      }
+      props.method = telemetry?.method ?? 'unknown';
+      track('account_created', {
+        userId,
+        anonymousId: telemetry?.anonymousId ?? null,
+        props,
+      });
+    }
+    return inserted;
   }
 
   deleteUser(owner: any) {
@@ -207,7 +244,8 @@ class UsersService {
         '',
         placeholderPassword,
         email,
-        signupOrigin ?? 'magic_link'
+        signupOrigin ?? 'magic_link',
+        { method: 'magic_link' }
       );
       user = await this.repository.getByEmail(email.toLowerCase());
       if (user?.id == null) {

--- a/src/services/UsersService.ts
+++ b/src/services/UsersService.ts
@@ -220,7 +220,8 @@ class UsersService {
     email: string,
     purpose: 'login' | 'password_reset',
     signupOrigin?: string | null,
-    redirect?: string
+    redirect?: string,
+    telemetry?: Omit<RegisterTelemetry, 'method'>
   ): Promise<void> {
     if (this.magicTokenRepository == null) {
       return;
@@ -245,7 +246,7 @@ class UsersService {
         placeholderPassword,
         email,
         signupOrigin ?? 'magic_link',
-        { method: 'magic_link' }
+        { method: 'magic_link', ...telemetry }
       );
       user = await this.repository.getByEmail(email.toLowerCase());
       if (user?.id == null) {


### PR DESCRIPTION
## Summary

Fixes https://github.com/2anki/server/issues/4362 — the ops signup funnel undercounted real signups by ~84% because `account_created` only fired on the password registration path. Google, Microsoft, Apple (web + native share `#upsertAppleUser`), Notion OAuth, and magic-link signups never emitted it (58 tracked vs 353 actual users last week).

- The event now fires inside `UsersService.register` — the single creation choke point — so no current or future signup path can forget it.
- A `RegisterTelemetry` argument threads `method` (`password | google | microsoft | apple | notion_oauth | magic_link`), the anon-id cookie, and the first-touch referrer into the event; the controller's duplicate emission is removed.
- `UploadFunnelService` needs no change — its `account_created` key now sees every signup, and the event gains a `method` prop for free.

Closes #4362

## Expected metric impact

Ops upload-funnel Signup tile becomes accurate from this deploy (expect ~6x jump in the tile — that's the undercount closing, not a growth spike). `download_to_signup_rate_pct` becomes trustworthy. New: signup method split available via the `method` prop.

## Testing

- Full server suite: 724 suites / 7074 tests passed (documented `getPageCount` pdfinfo env failure only).
- `UsersService.register` tests extended: telemetry-threaded event shape + method-unknown fallback.
- All five controller register paths now assert their `method` value reaches `register`.
- `tsc -p . --noEmit` clean; `pnpm format:check` clean.

No changelog entry — internal analytics correctness, no user-visible behavior change.

Sonar: not run locally; PR decoration will report.

Browser check: not applicable — server-only diff, no web/src changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TqUDQZHTnn6LkPHasw4C9f
