### PR TITLE
fix: map dominant Q/A tables to one card per row

### DIFF
--- a/src/lib/parser/DeckParser.induction.test.ts
+++ b/src/lib/parser/DeckParser.induction.test.ts
@@ -388,4 +388,33 @@ describe('DeckParser dominant table documents', () => {
 
     expect(parser.inducedRule).toBeUndefined();
   });
+
+  it('fails honest on a dominant table with repeated fronts (floor guard)', () => {
+    const planner =
+      '<table><thead><tr><th>Day</th><th>Task</th></tr></thead><tbody>' +
+      '<tr><td>Monday</td><td>Study cardiology chapter one</td></tr>' +
+      '<tr><td>Monday</td><td>Review pharmacology flashcards</td></tr>' +
+      '<tr><td>Monday</td><td>Practice ECG interpretation</td></tr>' +
+      '<tr><td>Monday</td><td>Read renal physiology notes</td></tr>' +
+      '</tbody></table>';
+    const parser = parse(page(planner), new CardOption({}));
+
+    expect(parser.payload[0].cards).toHaveLength(0);
+    expect(parser.inducedRule).toMatchObject({ outcome: 'rescue_rejected' });
+  });
+
+  it('leaves a wide data matrix to the existing pipeline', () => {
+    const timetable =
+      '<table><thead><tr><th>Time</th><th>Mon</th><th>Tue</th><th>Wed</th><th>Thu</th></tr></thead><tbody>' +
+      '<tr><td>09:00</td><td>Maths</td><td>English</td><td>Biology</td><td>History</td></tr>' +
+      '<tr><td>10:00</td><td>Physics</td><td>Art</td><td>Maths</td><td>English</td></tr>' +
+      '</tbody></table>';
+    const parser = parse(page(timetable), new CardOption({}));
+
+    expect(parser.payload[0].cards).toHaveLength(0);
+    expect(
+      parser.inducedRule == null ||
+        parser.inducedRule.outcome === 'rescue_rejected'
+    ).toBe(true);
+  });
 });

--- a/src/lib/parser/DeckParser.induction.test.ts
+++ b/src/lib/parser/DeckParser.induction.test.ts
@@ -275,3 +275,117 @@ describe('DeckParser degenerate-yield rescue', () => {
     expect(fronts).toContain('Toggle question 1?');
   });
 });
+
+// The reported shape behind #4366: a document whose body is one two-column
+// Question/Answer table with a bullet list inside each answer cell. The row is
+// the card boundary the author already drew; the parser must never fan the
+// answer bullets out into per-bullet cards, whatever the row count.
+const qaTable = (rows: Array<[string, string[]]>): string => {
+  const body = rows
+    .map(
+      ([question, bullets]) =>
+        `<tr><td>${question}</td><td><ul>${bullets
+          .map((bullet) => `<li>${bullet}</li>`)
+          .join('')}</ul></td></tr>`
+    )
+    .join('');
+  return `<table><thead><tr><th>Question</th><th>Answer</th></tr></thead><tbody>${body}</tbody></table>`;
+};
+
+const TWO_ROWS: Array<[string, string[]]> = [
+  [
+    'What maintains a stable internal environment?',
+    ['Negative feedback loops', 'Receptors detect change', 'Effectors respond'],
+  ],
+  [
+    'What is a set point?',
+    ['The target value', 'Defended by feedback', 'Varies per variable'],
+  ],
+];
+
+const FOUR_ROWS: Array<[string, string[]]> = [
+  ...TWO_ROWS,
+  [
+    'What do receptors do?',
+    ['Detect stimuli', 'Signal the control center', 'Monitor conditions'],
+  ],
+  [
+    'What do effectors do?',
+    ['Carry out the response', 'Muscles and glands', 'Restore the set point'],
+  ],
+];
+
+describe('DeckParser dominant table documents', () => {
+  it('maps a two-row Q/A table to one card per row instead of per-bullet fan-out', () => {
+    const parser = parse(page(qaTable(TWO_ROWS)), new CardOption({}));
+
+    const cards = parser.payload[0].cards;
+    expect(cards).toHaveLength(2);
+    expect(cards[0].name).toContain('stable internal environment');
+    expect(cards[0].back).toContain('Negative feedback loops');
+    expect(cards[0].back).toContain('Effectors respond');
+    expect(cards[1].back).toContain('Defended by feedback');
+    expect(parser.inducedRule).toMatchObject({
+      rule: 'columns',
+      outcome: 'rescue_shipped',
+    });
+  });
+
+  it('maps a four-row Q/A table to one card per row', () => {
+    const parser = parse(page(qaTable(FOUR_ROWS)), new CardOption({}));
+
+    const cards = parser.payload[0].cards;
+    expect(cards).toHaveLength(4);
+    expect(cards[3].name).toContain('effectors');
+    expect(cards[3].back).toContain('Restore the set point');
+    expect(parser.inducedRule).toMatchObject({
+      rule: 'columns',
+      outcome: 'rescue_shipped',
+    });
+  });
+
+  it('still maps rows when the table sits inside a wrapper div', () => {
+    const parser = parse(
+      page(`<div>${qaTable(TWO_ROWS)}</div>`),
+      new CardOption({})
+    );
+
+    expect(parser.payload[0].cards).toHaveLength(2);
+    expect(parser.inducedRule).toMatchObject({ rule: 'columns' });
+  });
+
+  it('does not hijack a document where the table is incidental to prose', () => {
+    const smallTable =
+      '<table><tbody><tr><td>mol</td><td>unit of amount</td></tr><tr><td>K</td><td>unit of temperature</td></tr></tbody></table>';
+    const parser = parse(
+      page(`${smallTable}${bigHeadingSections(8)}`),
+      new CardOption({ cherry: 'false' })
+    );
+
+    expect(parser.inducedRule).toMatchObject({
+      rule: 'heading',
+      outcome: 'rescue_shipped',
+    });
+    const fronts = parser.payload[0].cards.map((card) => card.name).join(' ');
+    expect(fronts).toContain('Section question 1?');
+  });
+
+  it('ignores a single-column table (no answer side to map)', () => {
+    const singleColumn =
+      '<table><tbody><tr><td>Only one cell</td></tr><tr><td>Another lone cell</td></tr></tbody></table>';
+    const parser = parse(page(singleColumn), new CardOption({}));
+
+    expect(
+      parser.inducedRule == null || parser.inducedRule.rule !== 'columns'
+    ).toBe(true);
+  });
+
+  it('leaves cherry-picked conversions alone even for a dominant table', () => {
+    const parser = parse(
+      page(qaTable(FOUR_ROWS)),
+      new CardOption({ cherry: 'true' })
+    );
+
+    expect(parser.inducedRule).toBeUndefined();
+  });
+});

--- a/src/lib/parser/DeckParser.induction.test.ts
+++ b/src/lib/parser/DeckParser.induction.test.ts
@@ -403,6 +403,22 @@ describe('DeckParser dominant table documents', () => {
     expect(parser.inducedRule).toMatchObject({ outcome: 'rescue_rejected' });
   });
 
+  it('does not append fan-out lists when disable-indented-bullets is on', () => {
+    const strayList = '<ul class="bulleted-list"><li>stray note</li></ul>';
+    const parser = parse(
+      page(`${qaTable(FOUR_ROWS)}${strayList}`),
+      new CardOption({ 'disable-indented-bullets': 'true' })
+    );
+
+    const cards = parser.payload[0].cards;
+    expect(cards).toHaveLength(4);
+    expect(cards.map((card) => card.name).join(' ')).not.toContain('stray');
+    expect(parser.inducedRule).toMatchObject({
+      rule: 'columns',
+      outcome: 'rescue_shipped',
+    });
+  });
+
   it('leaves a wide data matrix to the existing pipeline', () => {
     const timetable =
       '<table><thead><tr><th>Time</th><th>Mon</th><th>Tue</th><th>Wed</th><th>Thu</th></tr></thead><tbody>' +

--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -483,21 +483,21 @@ export class DeckParser {
     const disableIndentedBullets = this.settings.disableIndentedBulletPoints;
     if (cards.length === 0) {
       const tableNotes = this.induceDominantTableCards(dom);
-      if (tableNotes != null) {
-        cards.push(...tableNotes);
-      }
-    }
-    if (cards.length === 0) {
-      const overlappingPageNotes = this.buildPageListOverlappingNotes(dom);
+      const overlappingPageNotes =
+        tableNotes != null ? [] : this.buildPageListOverlappingNotes(dom);
       const overlappingParagraphNotes =
-        overlappingPageNotes.length > 0
+        tableNotes != null || overlappingPageNotes.length > 0
           ? []
           : this.buildPageParagraphOverlappingNotes(dom);
       const overlappingLineNotes =
-        overlappingPageNotes.length > 0 || overlappingParagraphNotes.length > 0
+        tableNotes != null ||
+        overlappingPageNotes.length > 0 ||
+        overlappingParagraphNotes.length > 0
           ? []
           : this.buildPageLinesOverlappingNotes(dom);
-      if (overlappingPageNotes.length > 0) {
+      if (tableNotes != null) {
+        cards.push(...tableNotes);
+      } else if (overlappingPageNotes.length > 0) {
         cards.push(...overlappingPageNotes);
       } else if (overlappingParagraphNotes.length > 0) {
         cards.push(...overlappingParagraphNotes);

--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -83,6 +83,7 @@ import { runInduction } from './induction/rankCandidates';
 import { scoreCandidateDeck } from './scoreCandidateDeck';
 import {
   domPlainTextLength,
+  hasDominantTable,
   induceCardsFromDom,
   UPLOAD_CANDIDATE_RULES,
 } from './induction/induceCardsFromDom';
@@ -480,6 +481,12 @@ export class DeckParser {
 
     const disableIndentedBullets = this.settings.disableIndentedBulletPoints;
     if (cards.length === 0) {
+      const tableNotes = this.induceDominantTableCards(dom);
+      if (tableNotes != null) {
+        cards.push(...tableNotes);
+      }
+    }
+    if (cards.length === 0) {
       const overlappingPageNotes = this.buildPageListOverlappingNotes(dom);
       const overlappingParagraphNotes =
         overlappingPageNotes.length > 0
@@ -647,6 +654,32 @@ export class DeckParser {
       return rules.filter((rule) => rule !== 'heading');
     }
     return rules;
+  }
+
+  // Runs first when the normal HTML parse produced zero cards. A document whose
+  // body is one dominant table is a deliberate two-column layout — its rows are
+  // the card boundary the author drew — so it routes straight to the columns
+  // rule, ahead of the per-bullet fan-out and without the rescue's minimum-card
+  // floor: a two-row Q/A table must ship two row cards, not six bullet
+  // fragments (#4366). Anything short of the dominance predicate falls through
+  // to the existing pipeline unchanged.
+  private induceDominantTableCards(dom: cheerio.CheerioAPI): Note[] | null {
+    if (this.uploadCandidateRules().length === 0) {
+      return null;
+    }
+    if (!hasDominantTable(dom)) {
+      return null;
+    }
+    const notes = induceCardsFromDom(dom, 'columns');
+    if (notes.length < 2) {
+      return null;
+    }
+    this.recordInducedRule({
+      rule: 'columns',
+      outcome: 'rescue_shipped',
+      score: scoreCandidateDeck(notes, domPlainTextLength(dom)),
+    });
+    return notes;
   }
 
   // Runs only when the normal HTML parse produced zero cards. It re-derives the

--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -80,6 +80,7 @@ import {
   mergeInducedRescue,
 } from './induction/candidateRules';
 import { runInduction } from './induction/rankCandidates';
+import { clearsQualityFloorExceptCount } from './induction/qualityFloor';
 import { scoreCandidateDeck } from './scoreCandidateDeck';
 import {
   domPlainTextLength,
@@ -659,9 +660,10 @@ export class DeckParser {
   // Runs first when the normal HTML parse produced zero cards. A document whose
   // body is one dominant table is a deliberate two-column layout — its rows are
   // the card boundary the author drew — so it routes straight to the columns
-  // rule, ahead of the per-bullet fan-out and without the rescue's minimum-card
-  // floor: a two-row Q/A table must ship two row cards, not six bullet
-  // fragments (#4366). Anything short of the dominance predicate falls through
+  // rule, ahead of the per-bullet fan-out and exempt from FLOOR_MIN_CARDS only:
+  // a two-row Q/A table must ship two row cards, not six bullet fragments
+  // (#4366). The rest of the quality floor still applies — a dominant table of
+  // repeated fronts or blank backs fails honest exactly as before. Anything short of the dominance predicate falls through
   // to the existing pipeline unchanged.
   private induceDominantTableCards(dom: cheerio.CheerioAPI): Note[] | null {
     if (this.uploadCandidateRules().length === 0) {
@@ -674,10 +676,14 @@ export class DeckParser {
     if (notes.length < 2) {
       return null;
     }
+    const score = scoreCandidateDeck(notes, domPlainTextLength(dom));
+    if (!clearsQualityFloorExceptCount(notes, score)) {
+      return null;
+    }
     this.recordInducedRule({
       rule: 'columns',
       outcome: 'rescue_shipped',
-      score: scoreCandidateDeck(notes, domPlainTextLength(dom)),
+      score,
     });
     return notes;
   }

--- a/src/lib/parser/induction/induceCardsFromDom.test.ts
+++ b/src/lib/parser/induction/induceCardsFromDom.test.ts
@@ -292,6 +292,15 @@ describe('hasDominantTable', () => {
     expect(hasDominantTable(load(headerOnly))).toBe(false);
   });
 
+  it('rejects a wide data matrix (rows of three or more cells)', () => {
+    const timetable =
+      '<table><tbody>' +
+      '<tr><td>09:00</td><td>Maths</td><td>English</td><td>Biology</td></tr>' +
+      '<tr><td>10:00</td><td>Physics</td><td>Art</td><td>Maths</td></tr>' +
+      '</tbody></table>';
+    expect(hasDominantTable(load(timetable))).toBe(false);
+  });
+
   it('rejects single-cell rows (no answer column to map)', () => {
     const singleColumn =
       '<table><tbody><tr><td>Only cell</td></tr><tr><td>Another cell</td></tr></tbody></table>';

--- a/src/lib/parser/induction/induceCardsFromDom.test.ts
+++ b/src/lib/parser/induction/induceCardsFromDom.test.ts
@@ -1,5 +1,9 @@
 import * as cheerio from 'cheerio';
-import { induceCardsFromDom, domPlainTextLength } from './induceCardsFromDom';
+import {
+  induceCardsFromDom,
+  domPlainTextLength,
+  hasDominantTable,
+} from './induceCardsFromDom';
 
 function load(inner: string) {
   return cheerio.load(`<div class="page-body">${inner}</div>`);
@@ -243,5 +247,54 @@ describe('induceCardsFromDom', () => {
   it('measures the plain-text length of the page body', () => {
     const dom = load(`<p>abcdef</p>`);
     expect(domPlainTextLength(dom)).toBe(6);
+  });
+});
+
+describe('hasDominantTable', () => {
+  const qaTable =
+    '<table><thead><tr><th>Question</th><th>Answer</th></tr></thead><tbody>' +
+    '<tr><td>What maintains balance?</td><td><ul><li>Feedback loops</li><li>Receptors</li></ul></td></tr>' +
+    '<tr><td>What is a set point?</td><td><ul><li>The target value</li><li>Defended by loops</li></ul></td></tr>' +
+    '</tbody></table>';
+
+  it('accepts a body that is one two-column table with two data rows', () => {
+    expect(hasDominantTable(load(qaTable))).toBe(true);
+  });
+
+  it('rejects a table drowned out by surrounding prose', () => {
+    const prose = `<p>${'Long narrative prose about the topic. '.repeat(60)}</p>`;
+    expect(hasDominantTable(load(`${qaTable}${prose}`))).toBe(false);
+  });
+
+  it('rejects a body with two top-level tables', () => {
+    expect(hasDominantTable(load(`${qaTable}${qaTable}`))).toBe(false);
+  });
+
+  it('counts a nested table as part of its enclosing one', () => {
+    const nested =
+      '<table><tbody>' +
+      '<tr><td>Outer prompt</td><td><table><tbody><tr><td>inner</td><td>cell</td></tr></tbody></table></td></tr>' +
+      '<tr><td>Second prompt</td><td>Second answer</td></tr>' +
+      '</tbody></table>';
+    expect(hasDominantTable(load(nested))).toBe(true);
+  });
+
+  it('rejects a table with only one data row', () => {
+    const oneRow =
+      '<table><thead><tr><th>Question</th><th>Answer</th></tr></thead><tbody>' +
+      '<tr><td>Lone prompt</td><td>Lone answer</td></tr></tbody></table>';
+    expect(hasDominantTable(load(oneRow))).toBe(false);
+  });
+
+  it('rejects a header-only table', () => {
+    const headerOnly =
+      '<table><thead><tr><th>Question</th><th>Answer</th></tr></thead></table>';
+    expect(hasDominantTable(load(headerOnly))).toBe(false);
+  });
+
+  it('rejects single-cell rows (no answer column to map)', () => {
+    const singleColumn =
+      '<table><tbody><tr><td>Only cell</td></tr><tr><td>Another cell</td></tr></tbody></table>';
+    expect(hasDominantTable(load(singleColumn))).toBe(false);
   });
 });

--- a/src/lib/parser/induction/induceCardsFromDom.ts
+++ b/src/lib/parser/induction/induceCardsFromDom.ts
@@ -373,7 +373,9 @@ function runRule(dom: CheerioAPI, rule: InducedRule): Note[] {
 
 // True when the document body is, in substance, one table: a single
 // non-nested table holding at least 80% of the body's visible text, with two or
-// more data rows of two or more cells. That shape is a deliberate two-column
+// more data rows of exactly two cells. A wider matrix (a timetable, a
+// multi-column dataset) is not a Q/A pairing and is left to the rescue's full
+// quality floor. That shape is a deliberate two-column
 // layout — the rows are the card boundary the author already drew — so the
 // caller may route it straight to the columns rule instead of letting the
 // bullet fan-out or the rescue's minimum-card floor decide. A table that is
@@ -402,6 +404,7 @@ export function hasDominantTable(dom: CheerioAPI): boolean {
     return false;
   }
   let dataRows = 0;
+  let wideRows = 0;
   dom(table)
     .find('tr')
     .each((_index, row) => {
@@ -412,11 +415,16 @@ export function hasDominantTable(dom: CheerioAPI): boolean {
         .children('td,th')
         .toArray()
         .filter((cell): cell is Element => (cell as Element).type === 'tag');
-      if (cells.length >= 2 && !isHeaderRow(dom, row, cells)) {
+      if (cells.length < 2 || isHeaderRow(dom, row, cells)) {
+        return;
+      }
+      if (cells.length === 2) {
         dataRows += 1;
+      } else {
+        wideRows += 1;
       }
     });
-  return dataRows >= DOMINANT_TABLE_MIN_DATA_ROWS;
+  return wideRows === 0 && dataRows >= DOMINANT_TABLE_MIN_DATA_ROWS;
 }
 
 export function domPlainTextLength(dom: CheerioAPI): number {

--- a/src/lib/parser/induction/induceCardsFromDom.ts
+++ b/src/lib/parser/induction/induceCardsFromDom.ts
@@ -371,6 +371,54 @@ function runRule(dom: CheerioAPI, rule: InducedRule): Note[] {
   }
 }
 
+// True when the document body is, in substance, one table: a single
+// non-nested table holding at least 80% of the body's visible text, with two or
+// more data rows of two or more cells. That shape is a deliberate two-column
+// layout — the rows are the card boundary the author already drew — so the
+// caller may route it straight to the columns rule instead of letting the
+// bullet fan-out or the rescue's minimum-card floor decide. A table that is
+// incidental to surrounding prose fails the dominance share and is left alone.
+const DOMINANT_TABLE_MIN_TEXT_SHARE = 0.8;
+const DOMINANT_TABLE_MIN_DATA_ROWS = 2;
+
+export function hasDominantTable(dom: CheerioAPI): boolean {
+  const tables = dom('table')
+    .toArray()
+    .filter(
+      (table): table is Element =>
+        (table as Element).type === 'tag' &&
+        dom(table).parents('table').length === 0
+    );
+  if (tables.length !== 1) {
+    return false;
+  }
+  const table = tables[0];
+  const totalTextLength = domPlainTextLength(dom);
+  if (totalTextLength === 0) {
+    return false;
+  }
+  const tableTextLength = dom(table).text().trim().length;
+  if (tableTextLength / totalTextLength < DOMINANT_TABLE_MIN_TEXT_SHARE) {
+    return false;
+  }
+  let dataRows = 0;
+  dom(table)
+    .find('tr')
+    .each((_index, row) => {
+      if (dom(row).closest('table').get(0) !== table) {
+        return;
+      }
+      const cells = dom(row)
+        .children('td,th')
+        .toArray()
+        .filter((cell): cell is Element => (cell as Element).type === 'tag');
+      if (cells.length >= 2 && !isHeaderRow(dom, row, cells)) {
+        dataRows += 1;
+      }
+    });
+  return dataRows >= DOMINANT_TABLE_MIN_DATA_ROWS;
+}
+
 export function domPlainTextLength(dom: CheerioAPI): number {
   const pageBody: Cheerio<Element> = dom('.page-body');
   const scope = pageBody.length > 0 ? pageBody : dom('body');

--- a/src/lib/parser/induction/qualityFloor.ts
+++ b/src/lib/parser/induction/qualityFloor.ts
@@ -18,6 +18,16 @@ export function clearsQualityFloor(
   if (score.cardCount < FLOOR_MIN_CARDS) {
     return false;
   }
+  return clearsQualityFloorExceptCount(cards, score);
+}
+
+// The floor minus FLOOR_MIN_CARDS, for the dominant-table branch: an explicit
+// two-column table legitimately yields two cards, but a table of repeated
+// fronts or blank backs is still the bad deck the floor exists to reject.
+export function clearsQualityFloorExceptCount(
+  cards: readonly ScorableCard[],
+  score: DeckScore
+): boolean {
   if (detectOverSplit(cards.map((card) => card.name))) {
     return false;
   }

--- a/src/services/mcp/McpServerFactory.ts
+++ b/src/services/mcp/McpServerFactory.ts
@@ -511,7 +511,9 @@ export function buildMcpServer(context: McpRequestContext): McpServer {
           )
           .min(1)
           .max(500)
-          .describe('The Basic front/back cards to put in the deck.'),
+          .describe(
+            "The Basic front/back cards to put in the deck. Preserve the source's own card boundaries: a table row or a question/answer pair is ONE card — keep its whole answer (bullet lists included) together on the back, never one card per bullet."
+          ),
         deckName: z
           .string()
           .optional()

--- a/web/src/pages/WhatsNewPage/changelog/2026-09-08-table-rows-become-cards.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-09-08-table-rows-become-cards.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-09-08-table-rows-become-cards",
+  "date": "2026-09-08",
+  "type": "fix",
+  "title": "A document built as a question/answer table now becomes one card per row — bullets stay together on the back"
+}


### PR DESCRIPTION
Closes #4366

## Root cause

Two mechanisms behind "bullets in the answer column each became a separate card":

1. **Web docx/html uploads (parser bug, this PR's main fix).** A body that is one two-column Q/A table produces zero cards from the normal parse, so every `<li>` fans out into a front-only note. The `columns` rescue then produces the correct one-card-per-row deck — but with fewer than 3 data rows it is rejected by `FLOOR_MIN_CARDS = 3` and the fan-out ships. Fixture-verified red/green: the 2-row case failed exactly this way; the 4-row case already passed via rescue. Prod corpus: 191 docx + 23 html fan-out conversions in the last 30 days (median back length 0).
2. **The reporter's actual path (MCP).** `create_deck` receives pre-split `{front, back}` cards — the calling model chose one card per bullet before 2anki was involved. The `cards` schema description now instructs the caller to preserve the source's card boundaries (a table row = one card, bullets together on the back). Tool descriptions are the only server-side lever on that path.

## Changes

- `hasDominantTable(dom)` (induction module): exactly one non-nested table, ≥80% of body plain text, ≥2 data rows of **exactly two cells** (header rows excluded; any wider data row disqualifies — a timetable/data matrix is not a Q/A pairing and stays on the old pipeline).
- `DeckParser.induceDominantTableCards`: runs first in the zero-cards path, routes straight to the existing `columns` rule, exempt from `FLOOR_MIN_CARDS` **only** — every other floor check (over-split, duplicate fronts, blank backs) still applies via `clearsQualityFloorExceptCount`. Predicate miss or floor fail → identical fall-through.
- MCP `create_deck` `cards` description: card-boundary guidance.
- Changelog entry.

## Decisions

- Reused the existing `columns` / `rescue_shipped` corpus vocabulary — the closed `InducedRescue` outcome set is unchanged.
- Floor exemption is `FLOOR_MIN_CARDS` only, behind the dominance predicate; thresholds are named constants (0.8 share, 2 rows). Adversarial review (executed probes) forced both this narrowing and the two-column restriction; accepted-and-noted residuals: first-cell `rowspan` continuation rows drop (inherent to the columns rule, rare), and the 80% share is a hard boundary. Pre-existing, out of scope: the Downloads structure-rescued notice only fires for Notion jobs, not uploads.
- No Card Options toggle — trio-unanimous (undiscoverable at the moment of failure; not reachable on the MCP path at all).

## Testing

- Full server suite: 7090 passed, 2 failed = documented `getPageCount` pdfinfo environmental exception only.
- Web: vitest 3558 passed, typecheck clean, lint warnings pre-existing only.
- `pnpm format:check` clean; server `tsc -p .` clean; arch 0 errors.
- New: 8 DeckParser dominant-table cases (incl. incidental-table, cherry-pick, repeated-front floor, wide-matrix guards) + 8 `hasDominantTable` unit cases.

Browser check: not applicable — server-side parser and MCP schema change; the only web diff is the changelog JSON.

Sonar: not run locally; PR decoration will report.

## Verification watch (post-deploy)

`conversion_rule_scores`: `columns rescue_shipped` share up, `unclassified shipped` (docx/html) down, other formats flat.
