### PR TITLE
refactor: collapse the Growth and System ops pages into lazy sections

### DIFF
--- a/web/src/pages/OpsPage/CollapsibleSection.test.tsx
+++ b/web/src/pages/OpsPage/CollapsibleSection.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, expect, test, vi } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import CollapsibleSection from './CollapsibleSection';
 import { ScoreRow } from './todayTypes';
@@ -34,6 +34,12 @@ const renderAt = (
   );
 
 describe('CollapsibleSection', () => {
+  const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+
+  afterEach(() => {
+    HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+  });
+
   test('starts collapsed and does not mount its body', () => {
     renderAt('/ops/growth');
     expect(screen.getByText('Upload funnel')).toBeInTheDocument();
@@ -59,6 +65,17 @@ describe('CollapsibleSection', () => {
     expect(document.querySelector('details')).toHaveAttribute('open');
     expect(screen.getByTestId('body')).toBeInTheDocument();
     expect(scrollIntoView).toHaveBeenCalled();
+  });
+
+  test('lets the user close a section the hash opened', () => {
+    HTMLElement.prototype.scrollIntoView = vi.fn();
+    renderAt('/ops/growth#upload-funnel');
+    const details = document.querySelector('details') as HTMLDetailsElement;
+    expect(details).toHaveAttribute('open');
+    details.open = false;
+    fireEvent(details, new Event('toggle'));
+    expect(details).not.toHaveAttribute('open');
+    expect(screen.getByTestId('body')).toBeInTheDocument();
   });
 
   test('shows the headline metric, value and target in the summary row', () => {

--- a/web/src/pages/OpsPage/CollapsibleSection.test.tsx
+++ b/web/src/pages/OpsPage/CollapsibleSection.test.tsx
@@ -1,0 +1,90 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, test, vi } from 'vitest';
+
+import CollapsibleSection from './CollapsibleSection';
+import { ScoreRow } from './todayTypes';
+
+const summary: ScoreRow = {
+  id: 'upload_to_download_7d',
+  lever: 'acquisition',
+  label: 'Upload → download',
+  format: 'percent',
+  window_label: '7d',
+  value: 61.5,
+  delta: null,
+  delta_good: null,
+  target: null,
+  target_direction: null,
+  status: 'none',
+  link: '/ops/growth',
+};
+
+const renderAt = (
+  path: string,
+  props: Partial<Parameters<typeof CollapsibleSection>[0]> = {}
+) =>
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <CollapsibleSection slug="upload-funnel" title="Upload funnel" {...props}>
+        <div data-testid="body">body</div>
+      </CollapsibleSection>
+    </MemoryRouter>
+  );
+
+describe('CollapsibleSection', () => {
+  test('starts collapsed and does not mount its body', () => {
+    renderAt('/ops/growth');
+    expect(screen.getByText('Upload funnel')).toBeInTheDocument();
+    expect(screen.queryByTestId('body')).toBeNull();
+    expect(document.querySelector('details')).not.toHaveAttribute('open');
+  });
+
+  test('mounts the body on first open and keeps it mounted after closing', () => {
+    renderAt('/ops/growth');
+    const details = document.querySelector('details') as HTMLDetailsElement;
+    details.open = true;
+    fireEvent(details, new Event('toggle'));
+    expect(screen.getByTestId('body')).toBeInTheDocument();
+    details.open = false;
+    fireEvent(details, new Event('toggle'));
+    expect(screen.getByTestId('body')).toBeInTheDocument();
+  });
+
+  test('opens and scrolls to the section when the hash names it', () => {
+    const scrollIntoView = vi.fn();
+    HTMLElement.prototype.scrollIntoView = scrollIntoView;
+    renderAt('/ops/growth#upload-funnel');
+    expect(document.querySelector('details')).toHaveAttribute('open');
+    expect(screen.getByTestId('body')).toBeInTheDocument();
+    expect(scrollIntoView).toHaveBeenCalled();
+  });
+
+  test('shows the headline metric, value and target in the summary row', () => {
+    renderAt('/ops/growth', {
+      summary: {
+        ...summary,
+        status: 'amber',
+        target: 65,
+        target_direction: 'at_least',
+      },
+    });
+    expect(screen.getByText('61.5%')).toBeInTheDocument();
+    expect(screen.getByText('≥65.0%')).toBeInTheDocument();
+    expect(document.querySelector('summary')).toHaveAttribute(
+      'data-status',
+      'amber'
+    );
+    expect(screen.getByText(', status amber')).toBeInTheDocument();
+  });
+
+  test('renders a plain title when there is no headline metric', () => {
+    renderAt('/ops/growth', { summary: null });
+    expect(screen.queryByText('≥')).toBeNull();
+    expect(document.querySelector('summary')).toHaveAttribute(
+      'data-status',
+      'none'
+    );
+  });
+});

--- a/web/src/pages/OpsPage/CollapsibleSection.tsx
+++ b/web/src/pages/OpsPage/CollapsibleSection.tsx
@@ -1,0 +1,96 @@
+import { ReactNode, useEffect, useRef, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+
+import sharedStyles from '../../styles/shared.module.css';
+import styles from './OpsPage.module.css';
+import {
+  describeDelta,
+  formatScoreDelta,
+  formatScoreTarget,
+  formatScoreValue,
+} from './todayScore';
+import { ScoreRow } from './todayTypes';
+
+interface CollapsibleSectionProps {
+  slug: string;
+  title: string;
+  summary?: ScoreRow | null;
+  children: ReactNode;
+}
+
+export default function CollapsibleSection({
+  slug,
+  title,
+  summary,
+  children,
+}: Readonly<CollapsibleSectionProps>) {
+  const { hash } = useLocation();
+  const targeted = hash === `#${slug}`;
+  const [toggledOpen, setToggledOpen] = useState(false);
+  const [everOpened, setEverOpened] = useState(false);
+  const element = useRef<HTMLDetailsElement>(null);
+  const open = toggledOpen || targeted;
+  const mounted = everOpened || targeted;
+
+  useEffect(() => {
+    if (targeted) {
+      element.current?.scrollIntoView?.({ block: 'start' });
+    }
+  }, [targeted]);
+
+  const status = summary?.status ?? 'none';
+
+  return (
+    <details
+      id={slug}
+      ref={element}
+      className={styles.collapsible}
+      open={open}
+      onToggle={(event) => {
+        const next = event.currentTarget.open;
+        setToggledOpen(next);
+        if (next) setEverOpened(true);
+      }}
+    >
+      <summary className={styles.sectionSummary} data-status={status}>
+        <span className={styles.scoreBar} aria-hidden="true" />
+        <span className={styles.sectionSummaryTitle}>
+          {title}
+          {summary != null && status !== 'none' && (
+            <span className={sharedStyles.srOnly}>, status {status}</span>
+          )}
+        </span>
+        {summary == null ? (
+          <span className={styles.sectionSummaryMetric} />
+        ) : (
+          <>
+            <span className={styles.sectionSummaryMetric}>
+              {summary.label}
+              <span aria-hidden="true"> · </span>
+              <span className={sharedStyles.srOnly}>, window </span>
+              {summary.window_label}
+            </span>
+            <span className={styles.scoreValue}>
+              {formatScoreValue(summary)}
+            </span>
+            <span
+              className={styles.scoreDelta}
+              data-good={
+                summary.delta_good == null
+                  ? undefined
+                  : String(summary.delta_good)
+              }
+              aria-label={describeDelta(summary)}
+            >
+              {formatScoreDelta(summary)}
+            </span>
+            <span className={styles.scoreTarget}>
+              {formatScoreTarget(summary)}
+            </span>
+          </>
+        )}
+      </summary>
+      {mounted && <div className={styles.collapsibleBody}>{children}</div>}
+    </details>
+  );
+}

--- a/web/src/pages/OpsPage/CollapsibleSection.tsx
+++ b/web/src/pages/OpsPage/CollapsibleSection.tsx
@@ -11,6 +11,12 @@ import {
 } from './todayScore';
 import { ScoreRow } from './todayTypes';
 
+interface SectionState {
+  open: boolean;
+  mounted: boolean;
+  openedForHash: string | null;
+}
+
 interface CollapsibleSectionProps {
   slug: string;
   title: string;
@@ -26,17 +32,24 @@ export default function CollapsibleSection({
 }: Readonly<CollapsibleSectionProps>) {
   const { hash } = useLocation();
   const targeted = hash === `#${slug}`;
-  const [toggledOpen, setToggledOpen] = useState(false);
-  const [everOpened, setEverOpened] = useState(false);
+  const [state, setState] = useState<SectionState>({
+    open: targeted,
+    mounted: targeted,
+    openedForHash: targeted ? hash : null,
+  });
   const element = useRef<HTMLDetailsElement>(null);
-  const open = toggledOpen || targeted;
-  const mounted = everOpened || targeted;
+
+  if (targeted && state.openedForHash !== hash) {
+    setState({ open: true, mounted: true, openedForHash: hash });
+  }
 
   useEffect(() => {
     if (targeted) {
       element.current?.scrollIntoView?.({ block: 'start' });
     }
   }, [targeted]);
+
+  const { open, mounted } = state;
 
   const status = summary?.status ?? 'none';
 
@@ -48,18 +61,21 @@ export default function CollapsibleSection({
       open={open}
       onToggle={(event) => {
         const next = event.currentTarget.open;
-        setToggledOpen(next);
-        if (next) setEverOpened(true);
+        setState((current) => ({
+          ...current,
+          open: next,
+          mounted: current.mounted || next,
+        }));
       }}
     >
       <summary className={styles.sectionSummary} data-status={status}>
         <span className={styles.scoreBar} aria-hidden="true" />
-        <span className={styles.sectionSummaryTitle}>
+        <h2 className={styles.sectionSummaryTitle}>
           {title}
           {summary != null && status !== 'none' && (
             <span className={sharedStyles.srOnly}>, status {status}</span>
           )}
-        </span>
+        </h2>
         {summary == null ? (
           <span className={styles.sectionSummaryMetric} />
         ) : (
@@ -67,7 +83,7 @@ export default function CollapsibleSection({
             <span className={styles.sectionSummaryMetric}>
               {summary.label}
               <span aria-hidden="true"> · </span>
-              <span className={sharedStyles.srOnly}>, window </span>
+              <span className={sharedStyles.srOnly}>, </span>
               {summary.window_label}
             </span>
             <span className={styles.scoreValue}>

--- a/web/src/pages/OpsPage/CustomerSignalsTab.tsx
+++ b/web/src/pages/OpsPage/CustomerSignalsTab.tsx
@@ -117,7 +117,6 @@ export default function CustomerSignalsTab() {
 
   return (
     <>
-      <p className={styles.panelTitle}>Customer signals</p>
       <p className={styles.panelSubtitle}>
         Evidence-ranked feature discovery. First-party voice — cancellation
         reasons and comments, deck-ready feedback — plus revealed pain from

--- a/web/src/pages/OpsPage/GrowthTab.test.tsx
+++ b/web/src/pages/OpsPage/GrowthTab.test.tsx
@@ -6,13 +6,13 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import GrowthTab from './GrowthTab';
 
-const renderTab = () => {
+const renderTab = (path = '/ops/growth') => {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   return render(
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter>
+      <MemoryRouter initialEntries={[path]}>
         <GrowthTab />
       </MemoryRouter>
     </QueryClientProvider>
@@ -36,17 +36,29 @@ describe('GrowthTab', () => {
     vi.restoreAllMocks();
   });
 
-  test('stacks the conversions, upload funnel, and return rate sections', () => {
+  test('lists every growth section collapsed, with only the summaries mounted', () => {
     renderTab();
 
-    expect(
-      screen.getByRole('heading', { level: 2, name: 'Conversions' })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('heading', { level: 2, name: 'Upload funnel' })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('heading', { level: 2, name: 'Return rate' })
-    ).toBeInTheDocument();
+    for (const title of [
+      'Conversions',
+      'Upload funnel',
+      'Landing page yield',
+      'Customer signals',
+      'Return rate',
+    ]) {
+      expect(screen.getByText(title)).toBeInTheDocument();
+    }
+    expect(document.querySelectorAll('details')).toHaveLength(5);
+    expect(document.querySelectorAll('details[open]')).toHaveLength(0);
+    expect(screen.queryByText('Upload to download')).toBeNull();
+  });
+
+  test('opens only the section named in the hash', () => {
+    renderTab('/ops/growth#return-rate');
+    expect(document.querySelectorAll('details[open]')).toHaveLength(1);
+    expect(document.querySelector('details[open]')).toHaveAttribute(
+      'id',
+      'return-rate'
+    );
   });
 });

--- a/web/src/pages/OpsPage/GrowthTab.test.tsx
+++ b/web/src/pages/OpsPage/GrowthTab.test.tsx
@@ -46,7 +46,9 @@ describe('GrowthTab', () => {
       'Customer signals',
       'Return rate',
     ]) {
-      expect(screen.getByText(title)).toBeInTheDocument();
+      expect(
+        screen.getByRole('heading', { level: 2, name: title })
+      ).toBeInTheDocument();
     }
     expect(document.querySelectorAll('details')).toHaveLength(5);
     expect(document.querySelectorAll('details[open]')).toHaveLength(0);

--- a/web/src/pages/OpsPage/GrowthTab.tsx
+++ b/web/src/pages/OpsPage/GrowthTab.tsx
@@ -1,62 +1,42 @@
+import CollapsibleSection from './CollapsibleSection';
 import ConversionsTab from './ConversionsTab';
+import CustomerSignalsTab from './CustomerSignalsTab';
+import LandingPageYieldTab from './LandingPageYieldTab';
 import ReturnRateTab from './ReturnRateTab';
 import UploadFunnelTab from './UploadFunnelTab';
-import LandingPageYieldTab from './LandingPageYieldTab';
-import CustomerSignalsTab from './CustomerSignalsTab';
-import styles from './OpsPage.module.css';
+import { useSectionSummaries } from './useSectionSummary';
 
 export default function GrowthTab() {
+  const summaryFor = useSectionSummaries();
   return (
     <>
-      <section
-        className={styles.compositeSection}
-        aria-labelledby="growth-conversions"
+      <CollapsibleSection
+        slug="conversions"
+        title="Conversions"
+        summary={summaryFor('conversion_success_7d_pct')}
       >
-        <h2 id="growth-conversions" className={styles.compositeHeading}>
-          Conversions
-        </h2>
         <ConversionsTab />
-      </section>
-
-      <section
-        className={styles.compositeSection}
-        aria-labelledby="growth-upload-funnel"
+      </CollapsibleSection>
+      <CollapsibleSection
+        slug="upload-funnel"
+        title="Upload funnel"
+        summary={summaryFor('upload_to_download_7d')}
       >
-        <h2 id="growth-upload-funnel" className={styles.compositeHeading}>
-          Upload funnel
-        </h2>
         <UploadFunnelTab />
-      </section>
-
-      <section
-        className={styles.compositeSection}
-        aria-labelledby="growth-landing-page-yield"
+      </CollapsibleSection>
+      <CollapsibleSection
+        slug="landing-page-yield"
+        title="Landing page yield"
+        summary={summaryFor('signups_7d')}
       >
-        <h2 id="growth-landing-page-yield" className={styles.compositeHeading}>
-          Landing page yield
-        </h2>
         <LandingPageYieldTab />
-      </section>
-
-      <section
-        className={styles.compositeSection}
-        aria-labelledby="growth-customer-signals"
-      >
-        <h2 id="growth-customer-signals" className={styles.compositeHeading}>
-          Customer signals
-        </h2>
+      </CollapsibleSection>
+      <CollapsibleSection slug="customer-signals" title="Customer signals">
         <CustomerSignalsTab />
-      </section>
-
-      <section
-        className={styles.compositeSection}
-        aria-labelledby="growth-return-rate"
-      >
-        <h2 id="growth-return-rate" className={styles.compositeHeading}>
-          Return rate
-        </h2>
+      </CollapsibleSection>
+      <CollapsibleSection slug="return-rate" title="Return rate">
         <ReturnRateTab />
-      </section>
+      </CollapsibleSection>
     </>
   );
 }

--- a/web/src/pages/OpsPage/LandingPageYieldTab.tsx
+++ b/web/src/pages/OpsPage/LandingPageYieldTab.tsx
@@ -57,7 +57,6 @@ export default function LandingPageYieldTab() {
 
   return (
     <>
-      <p className={styles.panelTitle}>Landing page yield</p>
       <p className={styles.panelSubtitle}>
         Signups and paid conversions per landing page, by where the account
         first arrived.

--- a/web/src/pages/OpsPage/OpsPage.module.css
+++ b/web/src/pages/OpsPage/OpsPage.module.css
@@ -282,13 +282,14 @@
 }
 
 .sectionSummaryTitle {
+  margin: 0;
   font-size: var(--text-base);
   font-weight: var(--font-semibold);
   color: var(--color-text-primary);
 }
 
 .sectionSummaryTitle::before {
-  content: '▸';
+  content: '▸' / '';
   display: inline-block;
   width: 1rem;
   color: var(--color-text-tertiary);

--- a/web/src/pages/OpsPage/OpsPage.module.css
+++ b/web/src/pages/OpsPage/OpsPage.module.css
@@ -240,6 +240,90 @@
   padding-top: 1.5rem;
 }
 
+.collapsible {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-secondary);
+}
+
+.collapsible + .collapsible {
+  margin-top: 0.375rem;
+}
+
+.sectionSummary {
+  display: grid;
+  grid-template-columns: 3px minmax(0, 1fr) auto auto auto auto;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.625rem 0.75rem;
+  cursor: pointer;
+  list-style: none;
+}
+
+.sectionSummary::-webkit-details-marker {
+  display: none;
+}
+
+.sectionSummary::before {
+  content: '';
+  order: -1;
+}
+
+.sectionSummary[data-status='red'] .scoreBar {
+  background: var(--color-danger);
+}
+
+.sectionSummary[data-status='amber'] .scoreBar {
+  background: var(--color-warning);
+}
+
+.sectionSummary[data-status='green'] .scoreBar {
+  background: var(--color-success);
+}
+
+.sectionSummaryTitle {
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+}
+
+.sectionSummaryTitle::before {
+  content: '▸';
+  display: inline-block;
+  width: 1rem;
+  color: var(--color-text-tertiary);
+  transition: transform 120ms ease;
+}
+
+.collapsible[open] .sectionSummaryTitle::before {
+  transform: rotate(90deg);
+}
+
+.sectionSummaryMetric {
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+  text-align: right;
+  white-space: nowrap;
+}
+
+.collapsibleBody {
+  padding: 0.5rem 1rem 1.25rem;
+  border-top: 1px solid var(--color-border);
+  background: var(--color-bg-primary);
+  border-radius: 0 0 var(--radius-md) var(--radius-md);
+}
+
+@media (max-width: 640px) {
+  .sectionSummary {
+    grid-template-columns: 3px minmax(0, 1fr) auto auto;
+  }
+
+  .sectionSummary .scoreTarget,
+  .sectionSummary .sectionSummaryMetric {
+    display: none;
+  }
+}
+
 .compositeHeading {
   font-size: var(--text-lg);
   font-weight: var(--font-semibold);

--- a/web/src/pages/OpsPage/PerformanceTab.tsx
+++ b/web/src/pages/OpsPage/PerformanceTab.tsx
@@ -8,7 +8,6 @@ import { formatCount } from './opsHelpers';
 import {
   JobDurationPercentiles,
   PerformanceMetricsResponse,
-  SignupCountryBreakdownItem,
 } from './performanceTypes';
 
 interface JobIdCellProps {
@@ -60,8 +59,6 @@ const STATUS_COLORS: Record<string, string> = {
   cancelled: '#9ca3af',
   interrupted: '#f59e0b',
 };
-
-const COUNTRY_BAR_COLOR = '#3b82f6';
 
 const renderDurationsTable = (rows: JobDurationPercentiles[]) => (
   <div className={styles.tableScroll}>
@@ -176,51 +173,6 @@ const renderSlowestJobs = (
   );
 };
 
-const renderCountries = (
-  rows: SignupCountryBreakdownItem[],
-  othersCount: number
-) => {
-  if (rows.length === 0) {
-    return (
-      <p className={styles.emptyHint}>
-        No countries captured yet. New signups populate this within minutes.
-      </p>
-    );
-  }
-  const max = Math.max(...rows.map((row) => row.count));
-  return (
-    <ul className={styles.statusList} aria-label="Signup country breakdown">
-      {rows.map((row) => {
-        const pct = max === 0 ? 0 : (row.count / max) * 100;
-        return (
-          <li key={row.country} className={styles.statusRow}>
-            <span className={styles.statusLabel}>{row.country}</span>
-            <span className={styles.statusBarWrap}>
-              <span
-                className={styles.statusBar}
-                style={{
-                  width: `${pct}%`,
-                  backgroundColor: COUNTRY_BAR_COLOR,
-                }}
-              />
-            </span>
-            <span className={styles.numeric}>{formatCount(row.count)}</span>
-          </li>
-        );
-      })}
-      {othersCount > 0 && (
-        <li className={styles.statusRow}>
-          <span className={`${styles.statusLabel} ${styles.numericMuted}`}>
-            +{othersCount} others
-          </span>
-          <span className={styles.statusBarWrap} />
-          <span className={styles.numericMuted}>—</span>
-        </li>
-      )}
-    </ul>
-  );
-};
-
 export default function PerformanceTab() {
   const { data, error, isLoading } = usePerformanceMetrics();
   const isInitial = isLoading && data == null;
@@ -264,21 +216,6 @@ export default function PerformanceTab() {
           autoHeight
         >
           {data != null && renderSlowestJobs(data.slowest_jobs_24h)}
-        </ChartPanel>
-
-        <ChartPanel
-          title="Signup countries, last 7d"
-          subtitle="ISO 3166 codes from CloudFront-Viewer-Country at signup"
-          isLoading={isInitial}
-          isEmpty={(data?.signup_countries_7d.length ?? 0) === 0}
-          emptyText="No countries captured yet."
-          autoHeight
-        >
-          {data != null &&
-            renderCountries(
-              data.signup_countries_7d,
-              data.signup_countries_7d_others ?? 0
-            )}
         </ChartPanel>
       </div>
     </>

--- a/web/src/pages/OpsPage/SystemTab.test.tsx
+++ b/web/src/pages/OpsPage/SystemTab.test.tsx
@@ -36,14 +36,18 @@ describe('SystemTab', () => {
     vi.restoreAllMocks();
   });
 
-  test('stacks the engineering and performance sections', () => {
+  test('lists every system section collapsed', () => {
     renderTab();
 
-    expect(
-      screen.getByRole('heading', { level: 2, name: 'Engineering' })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('heading', { level: 2, name: 'Performance' })
-    ).toBeInTheDocument();
+    for (const title of [
+      'Engineering',
+      'Performance',
+      'AI usage',
+      'Email delivery',
+    ]) {
+      expect(screen.getByText(title)).toBeInTheDocument();
+    }
+    expect(document.querySelectorAll('details')).toHaveLength(4);
+    expect(document.querySelectorAll('details[open]')).toHaveLength(0);
   });
 });

--- a/web/src/pages/OpsPage/SystemTab.tsx
+++ b/web/src/pages/OpsPage/SystemTab.tsx
@@ -1,51 +1,30 @@
+import AiUsageSection from './AiUsageSection';
+import CollapsibleSection from './CollapsibleSection';
+import EmailDeliverySection from './EmailDeliverySection';
 import EngineeringTab from './EngineeringTab';
 import PerformanceTab from './PerformanceTab';
-import AiUsageSection from './AiUsageSection';
-import EmailDeliverySection from './EmailDeliverySection';
-import styles from './OpsPage.module.css';
+import { useSectionSummaries } from './useSectionSummary';
 
 export default function SystemTab() {
+  const summaryFor = useSectionSummaries();
   return (
     <>
-      <section
-        className={styles.compositeSection}
-        aria-labelledby="system-ai-usage"
+      <CollapsibleSection
+        slug="engineering"
+        title="Engineering"
+        summary={summaryFor('unresolved_error_groups')}
       >
-        <h2 id="system-ai-usage" className={styles.compositeHeading}>
-          AI usage
-        </h2>
-        <AiUsageSection />
-      </section>
-
-      <section
-        className={styles.compositeSection}
-        aria-labelledby="system-email-delivery"
-      >
-        <h2 id="system-email-delivery" className={styles.compositeHeading}>
-          Email delivery
-        </h2>
-        <EmailDeliverySection />
-      </section>
-
-      <section
-        className={styles.compositeSection}
-        aria-labelledby="system-engineering"
-      >
-        <h2 id="system-engineering" className={styles.compositeHeading}>
-          Engineering
-        </h2>
         <EngineeringTab />
-      </section>
-
-      <section
-        className={styles.compositeSection}
-        aria-labelledby="system-performance"
-      >
-        <h2 id="system-performance" className={styles.compositeHeading}>
-          Performance
-        </h2>
+      </CollapsibleSection>
+      <CollapsibleSection slug="performance" title="Performance">
         <PerformanceTab />
-      </section>
+      </CollapsibleSection>
+      <CollapsibleSection slug="ai-usage" title="AI usage">
+        <AiUsageSection />
+      </CollapsibleSection>
+      <CollapsibleSection slug="email-delivery" title="Email delivery">
+        <EmailDeliverySection />
+      </CollapsibleSection>
     </>
   );
 }

--- a/web/src/pages/OpsPage/UploadFunnelTab.tsx
+++ b/web/src/pages/OpsPage/UploadFunnelTab.tsx
@@ -142,7 +142,6 @@ export default function UploadFunnelTab() {
 
   return (
     <>
-      <p className={styles.panelTitle}>Upload funnel</p>
       <p className={styles.panelSubtitle}>
         Distinct-identity counts per stage, from upload through signup to paid.
       </p>

--- a/web/src/pages/OpsPage/useSectionSummary.test.ts
+++ b/web/src/pages/OpsPage/useSectionSummary.test.ts
@@ -1,0 +1,55 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactNode, createElement } from 'react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { useSectionSummaries } from './useSectionSummary';
+
+const wrapper = ({ children }: { children: ReactNode }) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return createElement(QueryClientProvider, { client: queryClient }, children);
+};
+
+describe('useSectionSummaries', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        rows: [
+          {
+            id: 'new_paid_7d',
+            lever: 'revenue',
+            label: 'New paid',
+            format: 'count',
+            window_label: '7d',
+            value: 15,
+            delta: null,
+            delta_good: null,
+            target: 70,
+            target_direction: 'at_least',
+            status: 'red',
+            link: '/ops/business',
+          },
+        ],
+        as_of: '2026-09-09T10:00:00.000Z',
+        cache_age_seconds: 0,
+        stale: false,
+        errors: [],
+      }),
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test('returns the snapshot row for a known id and null otherwise', async () => {
+    const { result } = renderHook(() => useSectionSummaries(), { wrapper });
+    await waitFor(() => expect(result.current('new_paid_7d')?.value).toBe(15));
+    expect(result.current('missing')).toBeNull();
+  });
+});

--- a/web/src/pages/OpsPage/useSectionSummary.ts
+++ b/web/src/pages/OpsPage/useSectionSummary.ts
@@ -3,5 +3,5 @@ import { useTodaySnapshot } from './useTodaySnapshot';
 
 export const useSectionSummaries = (): ((rowId: string) => ScoreRow | null) => {
   const { data } = useTodaySnapshot();
-  return (rowId) => data?.rows.find((row) => row.id === rowId) ?? null;
+  return (rowId) => data?.rows?.find((row) => row.id === rowId) ?? null;
 };

--- a/web/src/pages/OpsPage/useSectionSummary.ts
+++ b/web/src/pages/OpsPage/useSectionSummary.ts
@@ -1,0 +1,7 @@
+import { ScoreRow } from './todayTypes';
+import { useTodaySnapshot } from './useTodaySnapshot';
+
+export const useSectionSummaries = (): ((rowId: string) => ScoreRow | null) => {
+  const { data } = useTodaySnapshot();
+  return (rowId) => data?.rows.find((row) => row.id === rowId) ?? null;
+};


### PR DESCRIPTION
## What

Third PR of the `/ops` consolidation (after https://github.com/2anki/server/pull/4369 and https://github.com/2anki/server/pull/4370). Growth and System stop being stacked dashboards.

- **`CollapsibleSection`**: a native `<details>` whose `<summary>` reuses the scoreboard row grid (status stripe · title · headline metric · value · Δ · target). Collapsed by default; the body mounts on first open, so a section's hooks do not fire until someone opens it. `#slug` in the URL opens and scrolls to that section (`/ops/growth#upload-funnel`).
- **Headline numbers come from the Today snapshot** (`useSectionSummaries`), which is already cached and already fetched on Today: Conversions ← conversion success, Upload funnel ← upload→download, Landing page yield ← signups, Engineering ← unresolved error groups. Sections without a snapshot row show a plain title.
- **Growth** = Conversions, Upload funnel, Landing page yield, Customer signals, Return rate as five collapsed sections. **System** = Engineering, Performance, AI usage, Email delivery as four.
- **Dedupe**: Performance loses its 7-day signup-country list (Business keeps the 90-day one). The three sub-tabs that carried their own title line lose it.

Not in this PR: Business page sections (its charts are one fetch; collapsing them saves density, not load — PR 4 territory), Commands regroup.

## Why

Two of the three composite pages were the density offenders in the inventory: nine stacked sub-dashboards, each fetching on load. The return-rate query in particular (a window function over every `conversion_succeeded` event in 90 days, no cache) ran on every Growth load; now it runs only when Return rate is opened. Closed headers still carry the one number that decides whether to open them, so the collapse is not a slower version of the old stack.

## Measuring success

None — internal tooling. Load-side: Growth on open now fires one cached snapshot read instead of five aggregate endpoints.

## Testing

- New: `CollapsibleSection.test.tsx` (collapsed by default with no body mounted, lazy mount that survives close, hash open + scroll, summary row rendering, plain title), `useSectionSummary.test.ts`.
- Updated: `GrowthTab.test.tsx` (five closed sections, hash opens exactly one), `SystemTab.test.tsx` (four closed sections).
- Full web vitest: 402 files / 3604 tests green; web lint only pre-existing warnings. Web `tsc --noEmit` clean. `pnpm format:check` clean.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: `pnpm --filter 2anki-web test:golden-path` run locally on this branch: 4/4 passed at 375px, no console errors. `/ops` itself is auth-gated and covered by the component suite (GrowthTab, SystemTab, CollapsibleSection).

## Changelog

No changelog entry — internal ops tooling, not user-visible.

## Sonar

Sonar: not run locally; PR decoration will report.

## Risks

Low. Composition over unchanged section components; every old section is one click away and deep-linkable. Rollback is a straight revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KRx1TvKhs21ee4M6BcNtcd
