### PR TITLE
fix: group the return-rate cohort by output position

### DIFF
--- a/src/services/ops/ReturnRateMetricsService.test.ts
+++ b/src/services/ops/ReturnRateMetricsService.test.ts
@@ -37,8 +37,15 @@ describe('ReturnRateMetricsService — generated SQL', () => {
         'MAX(created_at) as last_success_at from "events" ' +
         'where "name" = \'conversion_succeeded\' and "created_at" >= \'<CUTOFF>\' ' +
         'and COALESCE(user_id::text, anonymous_id) IS NOT NULL ' +
-        "group by COALESCE(user_id::text, anonymous_id), COALESCE(props->>'source', 'unknown')"
+        'group by 1, 2'
     );
+  });
+
+  it('groups the cohort by output position so the source expression binds once', () => {
+    const { sql, bindings } = service.buildCohortQuery(NOW).toSQL().toNative();
+    expect(sql).toContain('group by 1, 2');
+    expect(sql).not.toMatch(/group by .*\$/);
+    expect(bindings).toHaveLength(3);
   });
 
   it('builds the returns query as a single scan with a LEAD window, never a correlated subquery', () => {

--- a/src/services/ops/ReturnRateMetricsService.ts
+++ b/src/services/ops/ReturnRateMetricsService.ts
@@ -181,10 +181,7 @@ export class ReturnRateMetricsService {
         ]),
         this.database.raw('MAX(created_at) as last_success_at')
       )
-      .groupByRaw(
-        "COALESCE(user_id::text, anonymous_id), COALESCE(props->>'source', ?)",
-        [UNKNOWN_SOURCE]
-      );
+      .groupByRaw('1, 2');
   }
 
   buildReturnsQuery(now: Date): Knex.QueryBuilder {


### PR DESCRIPTION
## What

`/api/ops/return-rate/metrics` has been returning an error payload on prod: `column "events.props" must appear in the GROUP BY clause or be used in an aggregate function`. The cohort query in `ReturnRateMetricsService.buildCohortQuery` bound `UNKNOWN_SOURCE` twice — once in the `SELECT` and once in `GROUP BY` — and Knex numbers each `?` independently (`$1` and `$4`), so Postgres saw two different expressions. This PR groups by output position (`group by 1, 2`) so the fallback binds once.

## Why

The ops owner hit the red banner on `/ops/growth` today. The bug dates from #4067 (2026-08-11), which rewrote this query; its SQL-shape test compared `toString()` output, where Knex inlines the literal on both sides and the text reads identically, so the test passed while the prepared statement failed. The new test reads `toSQL().toNative()` — the native SQL and the bindings array — and asserts three bindings with no placeholder inside `GROUP BY`.

Runtime entry point checked: `GET /api/ops/return-rate/metrics` → `GetReturnRateMetricsUseCase` → `ReturnRateMetricsService.getMetrics` → `buildCohortQuery`. Single construction site (`OpsRouter.ts`). Prod access log shows the route answering 200 with the error payload at 11:14 UTC today.

## Measuring success

None — internal ops tooling. The Return rate section on `/ops/growth` renders numbers instead of the banner after deploy.

## Testing

- `ReturnRateMetricsService.test.ts`: cohort SQL-shape expectation updated; new test asserts native SQL has `group by 1, 2`, no `$n` in the group clause, and exactly three bindings. 9/9 green. Server `tsc -p .` clean. `pnpm format:check` clean.

Browser check: not applicable — server-only query change, no rendered output.

## Changelog

No changelog entry — internal ops tooling, not user-visible.

## Sonar

Sonar: not run locally; PR decoration will report.

## Risks

Low. Same result set, one fewer bind parameter. Rollback is a straight revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KRx1TvKhs21ee4M6BcNtcd
