### PR TITLE
refactor: group ops commands by intent and move the monitors to Business

### DIFF
--- a/src/services/ops/TodaySnapshotService.test.ts
+++ b/src/services/ops/TodaySnapshotService.test.ts
@@ -152,7 +152,7 @@ describe('buildScoreRows', () => {
       target: 70,
       target_direction: 'at_least',
       status: 'red',
-      link: '/ops/business',
+      link: '/ops/business#revenue',
     });
   });
 
@@ -191,7 +191,7 @@ describe('buildScoreRows', () => {
     expect(byId.missing_pass_unlocks_7d).toMatchObject({
       value: 1,
       status: 'red',
-      link: '/ops/commands',
+      link: '/ops/business#pass-unlocks',
     });
     expect(byId.zero_value_paid_7d).toMatchObject({
       value: 3,

--- a/src/services/ops/TodaySnapshotService.ts
+++ b/src/services/ops/TodaySnapshotService.ts
@@ -175,7 +175,7 @@ const failedPaymentsSpec = (
     value: latest,
     prior: priorAvg,
     target,
-    link: '/ops/business',
+    link: '/ops/business#revenue',
   };
 };
 
@@ -212,7 +212,7 @@ export function buildScoreRows(inputs: TodaySnapshotInputs): ScoreRow[] {
       window_label: '7d',
       value: business?.signups_7d ?? null,
       target: TODAY_TARGETS.signups_7d,
-      link: '/ops/growth',
+      link: '/ops/growth#landing-page-yield',
     },
     {
       id: 'upload_to_download_7d',
@@ -222,7 +222,7 @@ export function buildScoreRows(inputs: TodaySnapshotInputs): ScoreRow[] {
       window_label: '7d',
       value: conversion?.upload_to_download_rate_7d ?? null,
       target: null,
-      link: '/ops/growth',
+      link: '/ops/growth#upload-funnel',
     },
     {
       id: 'new_paid_7d',
@@ -232,7 +232,7 @@ export function buildScoreRows(inputs: TodaySnapshotInputs): ScoreRow[] {
       window_label: '7d',
       value: business?.new_paid_conversions_7d ?? null,
       target: TODAY_TARGETS.new_paid_7d,
-      link: '/ops/business',
+      link: '/ops/business#revenue',
     },
     {
       id: 'pass_sales_7d',
@@ -242,7 +242,7 @@ export function buildScoreRows(inputs: TodaySnapshotInputs): ScoreRow[] {
       window_label: '7d',
       value: sumPassSales(business?.pass_sales_7d ?? null),
       target: TODAY_TARGETS.pass_sales_7d,
-      link: '/ops/business',
+      link: '/ops/business#revenue',
     },
     failedPaymentsSpec(business),
     {
@@ -253,7 +253,7 @@ export function buildScoreRows(inputs: TodaySnapshotInputs): ScoreRow[] {
       window_label: '30d',
       value: business?.churn_30d_pct ?? null,
       target: TODAY_TARGETS.churn_30d_pct,
-      link: '/ops/business',
+      link: '/ops/business#cancellations',
     },
     {
       id: 'conversion_success_7d_pct',
@@ -266,7 +266,7 @@ export function buildScoreRows(inputs: TodaySnapshotInputs): ScoreRow[] {
         conversion?.paid_conversion_success_rate_7d ?? null
       ),
       target: TODAY_TARGETS.conversion_success_7d_pct,
-      link: '/ops/growth',
+      link: '/ops/growth#conversions',
     },
     {
       id: 'unresolved_error_groups',
@@ -286,7 +286,7 @@ export function buildScoreRows(inputs: TodaySnapshotInputs): ScoreRow[] {
       window_label: '7d',
       value: inputs.passUnlock?.missing ?? null,
       target: TODAY_TARGETS.missing_pass_unlocks_7d,
-      link: '/ops/commands',
+      link: '/ops/business#pass-unlocks',
     },
     {
       id: 'zero_value_paid_7d',
@@ -296,7 +296,7 @@ export function buildScoreRows(inputs: TodaySnapshotInputs): ScoreRow[] {
       window_label: '7d',
       value: zeroValuePaid(inputs.paidValue),
       target: TODAY_TARGETS.zero_value_paid_7d,
-      link: '/ops/commands',
+      link: '/ops/business#paid-value',
     },
   ];
   return specs

--- a/web/src/pages/OpsPage/BusinessTab.test.tsx
+++ b/web/src/pages/OpsPage/BusinessTab.test.tsx
@@ -105,6 +105,15 @@ const buildSampleMetrics = (
 describe('BusinessTab', () => {
   const originalFetch = globalThis.fetch;
 
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
   test('lists every business section collapsed until opened, including the paid access checks', () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
@@ -127,15 +136,6 @@ describe('BusinessTab', () => {
     expect(screen.getByText('Pass unlocks')).toBeInTheDocument();
     expect(screen.getByText('Paid value')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Check passes' })).toBeNull();
-  });
-
-  beforeEach(() => {
-    globalThis.fetch = vi.fn();
-  });
-
-  afterEach(() => {
-    globalThis.fetch = originalFetch;
-    vi.restoreAllMocks();
   });
 
   test('renders all six big-number cards from the response', async () => {

--- a/web/src/pages/OpsPage/BusinessTab.test.tsx
+++ b/web/src/pages/OpsPage/BusinessTab.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
@@ -7,17 +7,26 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import BusinessTab from './BusinessTab';
 import { BusinessMetricsResponse } from './businessTypes';
 
+const openAllSections = () => {
+  for (const details of document.querySelectorAll('details')) {
+    details.open = true;
+    fireEvent(details, new Event('toggle'));
+  }
+};
+
 const renderTab = () => {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
-  return render(
+  const result = render(
     <QueryClientProvider client={queryClient}>
       <MemoryRouter>
         <BusinessTab />
       </MemoryRouter>
     </QueryClientProvider>
   );
+  openAllSections();
+  return result;
 };
 
 const buildSampleMetrics = (
@@ -95,6 +104,30 @@ const buildSampleMetrics = (
 
 describe('BusinessTab', () => {
   const originalFetch = globalThis.fetch;
+
+  test('lists every business section collapsed until opened, including the paid access checks', () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({}),
+    });
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <BusinessTab />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+    expect(document.querySelectorAll('details')).toHaveLength(7);
+    expect(document.querySelectorAll('details[open]')).toHaveLength(0);
+    expect(screen.getByText('Pass unlocks')).toBeInTheDocument();
+    expect(screen.getByText('Paid value')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Check passes' })).toBeNull();
+  });
 
   beforeEach(() => {
     globalThis.fetch = vi.fn();
@@ -258,6 +291,20 @@ describe('BusinessTab', () => {
     let businessCallCount = 0;
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockImplementation(
       async (url: string) => {
+        if (typeof url === 'string' && url.includes('/api/ops/today')) {
+          return {
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            json: async () => ({
+              rows: [],
+              as_of: '',
+              cache_age_seconds: 0,
+              stale: false,
+              errors: [],
+            }),
+          };
+        }
         if (typeof url === 'string' && url.includes('cancel-funnel')) {
           return {
             ok: true,

--- a/web/src/pages/OpsPage/BusinessTab.tsx
+++ b/web/src/pages/OpsPage/BusinessTab.tsx
@@ -45,11 +45,27 @@ const buildMrrFootnote = (
   return `as of ${clock} (cache ${formatCacheAge(cacheAgeSeconds)})`;
 };
 
+function CancelFunnelPanel() {
+  const { data: cancelFunnel, isLoading } = useCancelFunnel();
+  return (
+    <ChartPanel
+      title="Cancel-flow funnel, last 30 days"
+      subtitle="How many cancels the pause offer saves"
+      isLoading={isLoading && cancelFunnel == null}
+      isEmpty={
+        cancelFunnel?.stages == null || cancelFunnel.stages.cancel_started === 0
+      }
+      emptyText="No cancel-flow activity in this window."
+      autoHeight
+    >
+      <CancelFunnelChart data={cancelFunnel ?? null} />
+    </ChartPanel>
+  );
+}
+
 export default function BusinessTab() {
   const summaryFor = useSectionSummaries();
   const { data, error, isLoading, isFetching } = useBusinessMetrics();
-  const { data: cancelFunnel, isLoading: cancelFunnelLoading } =
-    useCancelFunnel();
   const [lastSnapshot, setLastSnapshot] =
     useState<BusinessMetricsResponse | null>(null);
 
@@ -232,19 +248,7 @@ export default function BusinessTab() {
       >
         <p className={styles.sectionHint}>Cancel-survey reasons and comments</p>
         <div className={styles.grid}>
-          <ChartPanel
-            title="Cancel-flow funnel, last 30 days"
-            subtitle="How many cancels the pause offer saves"
-            isLoading={cancelFunnelLoading && cancelFunnel == null}
-            isEmpty={
-              cancelFunnel?.stages == null ||
-              cancelFunnel.stages.cancel_started === 0
-            }
-            emptyText="No cancel-flow activity in this window."
-            autoHeight
-          >
-            <CancelFunnelChart data={cancelFunnel ?? null} />
-          </ChartPanel>
+          <CancelFunnelPanel />
 
           <ChartPanel
             title="Why users cancel, last 90 days"

--- a/web/src/pages/OpsPage/BusinessTab.tsx
+++ b/web/src/pages/OpsPage/BusinessTab.tsx
@@ -25,6 +25,10 @@ import MrrTimeseriesChart from './charts/MrrTimeseriesChart';
 import ReEngagementCommentsList from './charts/ReEngagementCommentsList';
 import ReEngagementReasonsChart from './charts/ReEngagementReasonsChart';
 import SignupCountriesChart from './charts/SignupCountriesChart';
+import CollapsibleSection from './CollapsibleSection';
+import PaidValueMonitorTab from './PaidValueMonitorTab';
+import PassUnlockMonitorTab from './PassUnlockMonitorTab';
+import { useSectionSummaries } from './useSectionSummary';
 import styles from './OpsPage.module.css';
 import { useBusinessMetrics } from './useBusinessMetrics';
 import { useCancelFunnel } from './useCancelFunnel';
@@ -42,6 +46,7 @@ const buildMrrFootnote = (
 };
 
 export default function BusinessTab() {
+  const summaryFor = useSectionSummaries();
   const { data, error, isLoading, isFetching } = useBusinessMetrics();
   const { data: cancelFunnel, isLoading: cancelFunnelLoading } =
     useCancelFunnel();
@@ -137,15 +142,10 @@ export default function BusinessTab() {
         />
       </div>
 
-      <section className={styles.section} aria-labelledby="biz-section-emoji">
-        <header className={styles.sectionHeader}>
-          <h2 id="biz-section-emoji" className={styles.sectionTitle}>
-            Emoji feedback
-          </h2>
-          <p className={styles.sectionHint}>
-            Ratings and comments from the in-app emoji widget
-          </p>
-        </header>
+      <CollapsibleSection slug="emoji-feedback" title="Emoji feedback">
+        <p className={styles.sectionHint}>
+          Ratings and comments from the in-app emoji widget
+        </p>
         <div className={styles.grid}>
           <ChartPanel
             title="Emoji feedback, last 30 days"
@@ -170,17 +170,16 @@ export default function BusinessTab() {
             />
           </ChartPanel>
         </div>
-      </section>
+      </CollapsibleSection>
 
-      <section className={styles.section} aria-labelledby="biz-section-revenue">
-        <header className={styles.sectionHeader}>
-          <h2 id="biz-section-revenue" className={styles.sectionTitle}>
-            Revenue & subscriptions
-          </h2>
-          <p className={styles.sectionHint}>
-            MRR, active subs, churn, failed payments
-          </p>
-        </header>
+      <CollapsibleSection
+        slug="revenue"
+        title="Revenue & subscriptions"
+        summary={summaryFor('new_paid_7d')}
+      >
+        <p className={styles.sectionHint}>
+          MRR, active subs, churn, failed payments
+        </p>
         <div className={styles.grid}>
           <ChartPanel
             title="MRR, last 90 days"
@@ -224,20 +223,14 @@ export default function BusinessTab() {
             />
           </ChartPanel>
         </div>
-      </section>
+      </CollapsibleSection>
 
-      <section
-        className={styles.section}
-        aria-labelledby="biz-section-cancellations"
+      <CollapsibleSection
+        slug="cancellations"
+        title="Why users cancel"
+        summary={summaryFor('churn_30d_pct')}
       >
-        <header className={styles.sectionHeader}>
-          <h2 id="biz-section-cancellations" className={styles.sectionTitle}>
-            Why users cancel
-          </h2>
-          <p className={styles.sectionHint}>
-            Cancel-survey reasons and comments
-          </p>
-        </header>
+        <p className={styles.sectionHint}>Cancel-survey reasons and comments</p>
         <div className={styles.grid}>
           <ChartPanel
             title="Cancel-flow funnel, last 30 days"
@@ -276,20 +269,12 @@ export default function BusinessTab() {
             />
           </ChartPanel>
         </div>
-      </section>
+      </CollapsibleSection>
 
-      <section
-        className={styles.section}
-        aria-labelledby="biz-section-reengagement"
-      >
-        <header className={styles.sectionHeader}>
-          <h2 id="biz-section-reengagement" className={styles.sectionTitle}>
-            Re-engagement feedback
-          </h2>
-          <p className={styles.sectionHint}>
-            Why people stop engaging after a re-engagement email
-          </p>
-        </header>
+      <CollapsibleSection slug="reengagement" title="Re-engagement feedback">
+        <p className={styles.sectionHint}>
+          Why people stop engaging after a re-engagement email
+        </p>
         <div className={styles.grid}>
           <ChartPanel
             title="Why people stop, last 90 days"
@@ -314,18 +299,10 @@ export default function BusinessTab() {
             />
           </ChartPanel>
         </div>
-      </section>
+      </CollapsibleSection>
 
-      <section
-        className={styles.section}
-        aria-labelledby="biz-section-geography"
-      >
-        <header className={styles.sectionHeader}>
-          <h2 id="biz-section-geography" className={styles.sectionTitle}>
-            Geography
-          </h2>
-          <p className={styles.sectionHint}>Where new signups come from</p>
-        </header>
+      <CollapsibleSection slug="geography" title="Geography">
+        <p className={styles.sectionHint}>Where new signups come from</p>
         <div className={styles.grid}>
           <ChartPanel
             title="Signups by country, last 90 days"
@@ -339,7 +316,23 @@ export default function BusinessTab() {
             />
           </ChartPanel>
         </div>
-      </section>
+      </CollapsibleSection>
+
+      <CollapsibleSection
+        slug="pass-unlocks"
+        title="Pass unlocks"
+        summary={summaryFor('missing_pass_unlocks_7d')}
+      >
+        <PassUnlockMonitorTab />
+      </CollapsibleSection>
+
+      <CollapsibleSection
+        slug="paid-value"
+        title="Paid value"
+        summary={summaryFor('zero_value_paid_7d')}
+      >
+        <PaidValueMonitorTab />
+      </CollapsibleSection>
     </>
   );
 }

--- a/web/src/pages/OpsPage/CommandsTab.test.tsx
+++ b/web/src/pages/OpsPage/CommandsTab.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
@@ -188,6 +188,28 @@ describe('CommandsTab — change account email', () => {
     expect(deleteButton).toBeDisabled();
   });
 
+  test('re-locks the delete button when a later dry run fails', async () => {
+    let calls = 0;
+    mockFetch(() => {
+      calls += 1;
+      if (calls === 1) return { count: 3, dryRun: true };
+      throw new Error('db down');
+    });
+    renderTab();
+
+    const check = screen.getByRole('button', { name: 'Check candidates' });
+    fireEvent.click(check);
+    expect(
+      await screen.findByText('3 accounts would be deleted.')
+    ).toBeInTheDocument();
+    fireEvent.click(check);
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Delete inactive accounts' })
+      ).toBeDisabled()
+    );
+  });
+
   test('keeps the delete button locked when the dry run finds nothing', async () => {
     mockFetch(() => ({ count: 0, dryRun: true }));
     renderTab();
@@ -206,7 +228,7 @@ describe('CommandsTab — change account email', () => {
     renderTab();
 
     expect(
-      screen.getByRole('heading', { level: 2, name: /Support a user/ })
+      screen.getByRole('heading', { level: 2, name: 'Support a user' })
     ).toBeInTheDocument();
     expect(
       screen.getByRole('heading', { level: 2, name: /Run a job/ })

--- a/web/src/pages/OpsPage/CommandsTab.test.tsx
+++ b/web/src/pages/OpsPage/CommandsTab.test.tsx
@@ -157,4 +157,64 @@ describe('CommandsTab — change account email', () => {
       expect.anything()
     );
   });
+
+  test('keeps the delete button locked until a dry run finds candidates, then confirms with the count', async () => {
+    const confirmSpy = vi
+      .spyOn(globalThis, 'confirm')
+      .mockImplementation(() => true);
+    mockFetch((url) =>
+      url.includes('dryRun=true')
+        ? { count: 42, dryRun: true }
+        : { count: 42, dryRun: false }
+    );
+    renderTab();
+
+    const deleteButton = screen.getByRole('button', {
+      name: 'Delete inactive accounts',
+    });
+    expect(deleteButton).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Check candidates' }));
+    expect(
+      await screen.findByText('42 accounts would be deleted.')
+    ).toBeInTheDocument();
+    expect(deleteButton).toBeEnabled();
+
+    fireEvent.click(deleteButton);
+    expect(confirmSpy).toHaveBeenCalledWith(
+      'Permanently delete 42 accounts? This cannot be undone.'
+    );
+    expect(await screen.findByText('Deleted 42 accounts.')).toBeInTheDocument();
+    expect(deleteButton).toBeDisabled();
+  });
+
+  test('keeps the delete button locked when the dry run finds nothing', async () => {
+    mockFetch(() => ({ count: 0, dryRun: true }));
+    renderTab();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Check candidates' }));
+    expect(
+      await screen.findByText('0 accounts would be deleted.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Delete inactive accounts' })
+    ).toBeDisabled();
+  });
+
+  test('groups commands by intent and no longer hosts the monitors', () => {
+    mockFetch(() => ({}));
+    renderTab();
+
+    expect(
+      screen.getByRole('heading', { level: 2, name: /Support a user/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 2, name: /Run a job/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 2, name: /^Site/ })
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Check passes' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Check value' })).toBeNull();
+  });
 });

--- a/web/src/pages/OpsPage/CommandsTab.tsx
+++ b/web/src/pages/OpsPage/CommandsTab.tsx
@@ -18,8 +18,6 @@ import {
   OrphanedSubscriptionsResponse,
   ReconcileOrphanedSubscriptionsResponse,
 } from './orphanedSubscriptions';
-import PassUnlockMonitorTab from './PassUnlockMonitorTab';
-import PaidValueMonitorTab from './PaidValueMonitorTab';
 
 type Status = 'idle' | 'loading' | 'success' | 'error';
 
@@ -59,6 +57,7 @@ export default function CommandsTab() {
   const [syncMessage, setSyncMessage] = useState('');
   const [deleteStatus, setDeleteStatus] = useState<Status>('idle');
   const [deleteMessage, setDeleteMessage] = useState('');
+  const [deleteCandidates, setDeleteCandidates] = useState<number | null>(null);
   const [orphanStatus, setOrphanStatus] = useState<Status>('idle');
   const [orphanMessage, setOrphanMessage] = useState('');
   const [orphans, setOrphans] = useState<
@@ -218,12 +217,21 @@ export default function CommandsTab() {
   };
 
   const runDelete = async (dryRun: boolean) => {
+    if (
+      !dryRun &&
+      !globalThis.confirm(
+        `Permanently delete ${deleteCandidates ?? 0} account${deleteCandidates === 1 ? '' : 's'}? This cannot be undone.`
+      )
+    ) {
+      return;
+    }
     setDeleteStatus('loading');
     setDeleteMessage('');
     try {
       const result = await deleteInactiveUsers(dryRun);
       setDeleteStatus('success');
       setDeleteMessage(formatDeleteResult(result));
+      setDeleteCandidates(dryRun ? result.count : null);
     } catch (error) {
       setDeleteStatus('error');
       setDeleteMessage(
@@ -291,8 +299,13 @@ export default function CommandsTab() {
         Manual ops actions. Run dry-run first to validate counts before sending.
       </p>
 
+      <h2 className={styles.commandGroupHeading}>
+        Support a user
+        <span className={styles.commandGroupHint}>targets one account</span>
+      </h2>
+
       <section className={`${sharedStyles.surface} ${styles.card}`}>
-        <h2 className={styles.cardTitle}>Grant unclaimed pass</h2>
+        <h3 className={styles.cardTitle}>Grant unclaimed pass</h3>
         <p className={styles.panelSubtitle}>
           Attaches an unclaimed anonymous pass to an account by email and grants
           the full duration from now — for a buyer whose checkout redirect never
@@ -339,7 +352,7 @@ export default function CommandsTab() {
       )}
 
       <section className={`${sharedStyles.surface} ${styles.card}`}>
-        <h2 className={styles.cardTitle}>Match cards to Notion blocks</h2>
+        <h3 className={styles.cardTitle}>Match cards to Notion blocks</h3>
         <p className={styles.panelSubtitle}>
           Turns &quot;Match cards to their Notion blocks&quot; on or off for an
           account&apos;s future uploads, saved to their card options. Use when a
@@ -387,7 +400,7 @@ export default function CommandsTab() {
       )}
 
       <section className={`${sharedStyles.surface} ${styles.card}`}>
-        <h2 className={styles.cardTitle}>Change account email</h2>
+        <h3 className={styles.cardTitle}>Change account email</h3>
         <p className={styles.panelSubtitle}>
           Moves a user&apos;s login email to a new address (matched
           case-insensitively) and re-links their subscription in one step. For
@@ -433,8 +446,15 @@ export default function CommandsTab() {
         </div>
       )}
 
+      <h2 className={styles.commandGroupHeading}>
+        Run a job
+        <span className={styles.commandGroupHint}>
+          batch email or cleanup, capped per run
+        </span>
+      </h2>
+
       <section className={`${sharedStyles.surface} ${styles.card}`}>
-        <h2 className={styles.cardTitle}>Inactivity warnings</h2>
+        <h3 className={styles.cardTitle}>Inactivity warnings</h3>
         <p className={styles.panelSubtitle}>
           Finds free accounts inactive for 6+ months (excludes lifetime and
           active subscribers) and sends a deletion warning email. Capped at 500
@@ -472,7 +492,7 @@ export default function CommandsTab() {
       )}
 
       <section className={`${sharedStyles.surface} ${styles.card}`}>
-        <h2 className={styles.cardTitle}>Pass win-back</h2>
+        <h3 className={styles.cardTitle}>Pass win-back</h3>
         <p className={styles.panelSubtitle}>
           Emails lapsed Day/Week pass buyers whose pass expired with no active
           pass or subscription a seasonal nudge to come back. Excludes opted-out
@@ -519,8 +539,15 @@ export default function CommandsTab() {
         </div>
       )}
 
+      <h2 className={styles.commandGroupHeading}>
+        Site
+        <span className={styles.commandGroupHint}>
+          billing and storage plumbing
+        </span>
+      </h2>
+
       <section className={`${sharedStyles.surface} ${styles.card}`}>
-        <h2 className={styles.cardTitle}>Stripe subscriptions</h2>
+        <h3 className={styles.cardTitle}>Stripe subscriptions</h3>
         <p className={styles.panelSubtitle}>
           Pulls active Stripe subscriptions into the database and reconciles
           each active row against Stripe. Use this to provision a paying user
@@ -551,13 +578,14 @@ export default function CommandsTab() {
       )}
 
       <section className={`${sharedStyles.surface} ${styles.card}`}>
-        <h2 className={styles.cardTitle}>Delete inactive accounts</h2>
+        <h3 className={styles.cardTitle}>Delete inactive accounts</h3>
         <p className={styles.panelSubtitle}>
           Permanently deletes free accounts that were warned 14+ days ago and
           have not logged in since, plus inactive free accounts whose email
           address hard-bounced or was dropped — the warning email can never
           reach them. Excludes lifetime and active subscribers. Capped at 100
-          per run. Check candidates first — deletion cannot be undone.
+          per run. Check candidates first — the delete button unlocks only after
+          a check in this session finds accounts, and deletion cannot be undone.
         </p>
         <div className={styles.controls}>
           <button
@@ -572,7 +600,11 @@ export default function CommandsTab() {
             type="button"
             className={sharedStyles.btnDanger}
             onClick={() => runDelete(false)}
-            disabled={deleteStatus === 'loading'}
+            disabled={
+              deleteStatus === 'loading' ||
+              deleteCandidates == null ||
+              deleteCandidates === 0
+            }
           >
             Delete inactive accounts
           </button>
@@ -591,7 +623,7 @@ export default function CommandsTab() {
       )}
 
       <section className={`${sharedStyles.surface} ${styles.card}`}>
-        <h2 className={styles.cardTitle}>Chat attachment expiry</h2>
+        <h3 className={styles.cardTitle}>Chat attachment expiry</h3>
         <p className={styles.panelSubtitle}>
           Applies the 90-day expiry rule for persisted chat attachments to the
           storage bucket. Idempotent — existing lifecycle rules are kept, only
@@ -624,7 +656,7 @@ export default function CommandsTab() {
       )}
 
       <section className={`${sharedStyles.surface} ${styles.card}`}>
-        <h2 className={styles.cardTitle}>Orphaned subscriptions</h2>
+        <h3 className={styles.cardTitle}>Orphaned subscriptions</h3>
         <p className={styles.panelSubtitle}>
           Finds active subscriptions where the paid email, linked email, and
           Stripe customer id match no account — so the payer is not getting
@@ -672,9 +704,6 @@ export default function CommandsTab() {
           {orphanMessage}
         </div>
       )}
-
-      <PassUnlockMonitorTab />
-      <PaidValueMonitorTab />
     </>
   );
 }

--- a/web/src/pages/OpsPage/CommandsTab.tsx
+++ b/web/src/pages/OpsPage/CommandsTab.tsx
@@ -220,7 +220,7 @@ export default function CommandsTab() {
     if (
       !dryRun &&
       !globalThis.confirm(
-        `Permanently delete ${deleteCandidates ?? 0} account${deleteCandidates === 1 ? '' : 's'}? This cannot be undone.`
+        `Permanently delete ${deleteCandidates} account${deleteCandidates === 1 ? '' : 's'}? This cannot be undone.`
       )
     ) {
       return;
@@ -233,6 +233,7 @@ export default function CommandsTab() {
       setDeleteMessage(formatDeleteResult(result));
       setDeleteCandidates(dryRun ? result.count : null);
     } catch (error) {
+      setDeleteCandidates(null);
       setDeleteStatus('error');
       setDeleteMessage(
         error instanceof Error ? error.message : 'Unknown error'
@@ -299,10 +300,10 @@ export default function CommandsTab() {
         Manual ops actions. Run dry-run first to validate counts before sending.
       </p>
 
-      <h2 className={styles.commandGroupHeading}>
-        Support a user
-        <span className={styles.commandGroupHint}>targets one account</span>
-      </h2>
+      <div className={styles.commandGroupHeading}>
+        <h2 className={styles.commandGroupTitle}>Support a user</h2>
+        <p className={styles.commandGroupHint}>targets one account</p>
+      </div>
 
       <section className={`${sharedStyles.surface} ${styles.card}`}>
         <h3 className={styles.cardTitle}>Grant unclaimed pass</h3>
@@ -446,12 +447,12 @@ export default function CommandsTab() {
         </div>
       )}
 
-      <h2 className={styles.commandGroupHeading}>
-        Run a job
-        <span className={styles.commandGroupHint}>
+      <div className={styles.commandGroupHeading}>
+        <h2 className={styles.commandGroupTitle}>Run a job</h2>
+        <p className={styles.commandGroupHint}>
           batch email or cleanup, capped per run
-        </span>
-      </h2>
+        </p>
+      </div>
 
       <section className={`${sharedStyles.surface} ${styles.card}`}>
         <h3 className={styles.cardTitle}>Inactivity warnings</h3>
@@ -539,12 +540,10 @@ export default function CommandsTab() {
         </div>
       )}
 
-      <h2 className={styles.commandGroupHeading}>
-        Site
-        <span className={styles.commandGroupHint}>
-          billing and storage plumbing
-        </span>
-      </h2>
+      <div className={styles.commandGroupHeading}>
+        <h2 className={styles.commandGroupTitle}>Site</h2>
+        <p className={styles.commandGroupHint}>billing and storage plumbing</p>
+      </div>
 
       <section className={`${sharedStyles.surface} ${styles.card}`}>
         <h3 className={styles.cardTitle}>Stripe subscriptions</h3>

--- a/web/src/pages/OpsPage/OpsPage.module.css
+++ b/web/src/pages/OpsPage/OpsPage.module.css
@@ -325,6 +325,26 @@
   }
 }
 
+.commandGroupHeading {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  margin: 2rem 0 0.75rem;
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+}
+
+.commandGroupHint {
+  font-size: var(--text-xs);
+  font-weight: var(--font-normal);
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--color-text-tertiary);
+}
+
 .compositeHeading {
   font-size: var(--text-lg);
   font-weight: var(--font-semibold);

--- a/web/src/pages/OpsPage/OpsPage.module.css
+++ b/web/src/pages/OpsPage/OpsPage.module.css
@@ -330,6 +330,10 @@
   align-items: baseline;
   gap: 0.75rem;
   margin: 2rem 0 0.75rem;
+}
+
+.commandGroupTitle {
+  margin: 0;
   font-size: var(--text-sm);
   font-weight: var(--font-semibold);
   letter-spacing: 0.04em;
@@ -338,10 +342,8 @@
 }
 
 .commandGroupHint {
+  margin: 0;
   font-size: var(--text-xs);
-  font-weight: var(--font-normal);
-  letter-spacing: 0;
-  text-transform: none;
   color: var(--color-text-tertiary);
 }
 

--- a/web/src/pages/OpsPage/TodayTab.tsx
+++ b/web/src/pages/OpsPage/TodayTab.tsx
@@ -72,14 +72,20 @@ function VoiceOfUserBlock({
         ))}
         {recentCancellations.map((c) => (
           <li key={`${c.created_at}-${c.reason}`} className={styles.voiceRow}>
-            <Link to="/ops/business" className={styles.voicePreview}>
+            <Link
+              to="/ops/business#cancellations"
+              className={styles.voicePreview}
+            >
               Cancelled — {c.reason}: {c.comment}
             </Link>
           </li>
         ))}
         {recentEmoji.map((e) => (
           <li key={`${e.created_at}-${e.page}`} className={styles.voiceRow}>
-            <Link to="/ops/business" className={styles.voicePreview}>
+            <Link
+              to="/ops/business#emoji-feedback"
+              className={styles.voicePreview}
+            >
               {EMOJI_BY_RATING[e.rating] ?? e.rating} {e.comment} — {e.page}
             </Link>
           </li>


### PR DESCRIPTION
## What

Fourth and last PR of the `/ops` consolidation (after https://github.com/2anki/server/pull/4369, https://github.com/2anki/server/pull/4370 and the collapsed-sections PR).

- **Commands grouped by intent**: `Support a user` (grant pass, match cards to Notion blocks, change email) · `Run a job` (inactivity warnings, pass win-back, delete inactive accounts) · `Site` (Stripe sync, orphaned subscriptions, chat attachment expiry). Same cards, three headings with a blast-radius hint each. Card titles drop from `h2` to `h3` under the group headings.
- **Delete gate**: the red `Delete inactive accounts` button is disabled until `Check candidates` has run in this session and found at least one account; clicking it confirms with that exact count. A dry run that finds zero keeps it locked; a completed delete re-locks it.
- **Monitors leave Commands.** Pass unlocks and paid value become collapsed sections on Business, headed by the Today snapshot rows that already score them (missed unlocks, paid users with no deck).
- **Business sections collapse** (emoji feedback, revenue, cancellations, re-engagement, geography) with the same `CollapsibleSection`; revenue is headed by the new-paid row, cancellations by churn. The six headline cards stay visible above.
- **Deep links**: scoreboard rows and Today's Voice of user previews now target the owning section (`/ops/business#cancellations`, `/ops/growth#upload-funnel`, …).

## Why

The Commands page was the worst scannability offender in the inventory: sixteen buttons in one undifferentiated list, then two read-only monitors stacked under them. Grouping by intent tells the reader the blast radius before the label; moving the monitors puts the two revenue-leak detectors on the page that owns revenue, one click from their scoreboard rows. The delete gate makes the only irreversible action on the page a two-key operation instead of a single red button.

## Measuring success

None — internal tooling.

## Testing

- `CommandsTab.test.tsx`: three new tests — delete locked until a dry run finds candidates, then confirms with the count and re-locks; zero candidates keeps it locked; three intent groups present and no monitor buttons.
- `BusinessTab.test.tsx`: seven collapsed sections including the two monitors, none open; existing chart-title tests open every section first; the background-refetch test routes the snapshot fetch.
- `TodaySnapshotService.test.ts` updated for the hashed links. Full web vitest: 402 files / 3608 tests green; web lint only pre-existing warnings; server `tsc -p .` clean. `pnpm format:check` clean.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: `pnpm --filter 2anki-web test:golden-path` run locally on this branch: 4/4 passed at 375px, no console errors. `/ops` is auth-gated and covered by the component suite (CommandsTab, BusinessTab, TodayTab).

## Changelog

No changelog entry — internal ops tooling, not user-visible.

## Sonar

Sonar: not run locally; PR decoration will report.

## Risks

Low. No endpoint changes; the delete route is unchanged and the gate is client-side on top of the existing dry-run. Rollback is a straight revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KRx1TvKhs21ee4M6BcNtcd
