### PR TITLE
test: await the paywall_shown assertion in the nudge test

### DIFF
--- a/web/src/components/PostDownloadNudge/PostDownloadNudge.test.tsx
+++ b/web/src/components/PostDownloadNudge/PostDownloadNudge.test.tsx
@@ -74,7 +74,7 @@ describe('PostDownloadNudge', () => {
       'href',
       '/pricing?source=post_download_nudge'
     );
-    expect(trackMock).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(trackMock).toHaveBeenCalledTimes(1));
     expect(trackMock).toHaveBeenCalledWith('paywall_shown', {
       surface: 'post_download_nudge',
       page: 'upload',


### PR DESCRIPTION
## What

`PostDownloadNudge.test.tsx` waited for the card to render and then asserted the `paywall_shown` analytics call synchronously. The call fires in a passive effect after the commit that rendered the card, so under CI load the assertion sometimes ran first. The assertion is now awaited. No component change.

## Why

Two merge-queue runs failed on this test in one day (https://github.com/2anki/server/pull/4371 and https://github.com/2anki/server/pull/4372, the second a server-only diff), each costing a dequeue and a re-run. The test was passing locally every time; the race only shows on a loaded runner.

## Measuring success

None — CI hygiene. Success is no further dequeues on this test.

## Testing

`pnpm --filter 2anki-web test src/components/PostDownloadNudge`: 7/7. `pnpm format:check` clean.

Browser check: not applicable — test-only change, no rendered output.

## Changelog

No changelog entry — not user-visible.

## Sonar

Sonar: not run locally; PR decoration will report.

## Risks

None. One assertion wrapped in `waitFor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KRx1TvKhs21ee4M6BcNtcd
