### PR TITLE
fix: name the trashed destination page on apkg-to-Notion import

### DIFF
--- a/src/usecases/apkg/ImportApkgToNotionUseCase.test.ts
+++ b/src/usecases/apkg/ImportApkgToNotionUseCase.test.ts
@@ -367,6 +367,61 @@ describe('ImportApkgToNotionUseCase', () => {
     );
   });
 
+  it('surfaces a trashed-page message on a Notion archived-ancestor 400', async () => {
+    previewService.parse.mockResolvedValue(makeParsed(1));
+    notionApi.createPage.mockRejectedValue(
+      new APIResponseError({
+        code: APIErrorCode.ValidationError,
+        message:
+          "Can't edit page on block with an archived ancestor. You must unarchive the ancestor before editing page.",
+        status: 400,
+        headers: {},
+        rawBodyText: '',
+        additional_data: undefined,
+        request_id: undefined,
+      })
+    );
+
+    await useCase.execute(
+      Buffer.from('fake'),
+      'parent-page',
+      'user-1',
+      notionApi,
+      'job-1',
+      { maxNotes: 10000 }
+    );
+
+    const failCall = jobRepository.updateJobStatus.mock.calls.find(
+      (c) => c[2] === 'failed'
+    );
+    expect(failCall![3]).toBe(
+      'The Notion page you picked is in the trash. Restore it in Notion or pick a different destination page.'
+    );
+  });
+
+  it('keeps the generic message for other Notion 400 validation errors', async () => {
+    previewService.parse.mockResolvedValue(makeParsed(1));
+    notionApi.createPage.mockRejectedValue(
+      makeNotionError(APIErrorCode.ValidationError, 400)
+    );
+
+    await useCase.execute(
+      Buffer.from('fake'),
+      'parent-page',
+      'user-1',
+      notionApi,
+      'job-1',
+      { maxNotes: 10000 }
+    );
+
+    const failCall = jobRepository.updateJobStatus.mock.calls.find(
+      (c) => c[2] === 'failed'
+    );
+    expect(failCall![3]).toBe(
+      'Import failed. Please try again or contact support.'
+    );
+  });
+
   it.each([
     [APIErrorCode.InternalServerError, 500],
     [APIErrorCode.ServiceUnavailable, 503],

--- a/src/usecases/apkg/ImportApkgToNotionUseCase.ts
+++ b/src/usecases/apkg/ImportApkgToNotionUseCase.ts
@@ -61,6 +61,12 @@ function resolveFailureMessage(error: unknown): string {
       return 'Notion is rate-limiting this account. Try again in a minute.';
     }
     if (
+      error.code === APIErrorCode.ValidationError &&
+      error.message.includes('archived ancestor')
+    ) {
+      return 'The Notion page you picked is in the trash. Restore it in Notion or pick a different destination page.';
+    }
+    if (
       error.code === APIErrorCode.InternalServerError ||
       error.code === APIErrorCode.ServiceUnavailable ||
       error.code === APIErrorCode.GatewayTimeout

--- a/src/usecases/apkg/ImportApkgToNotionUseCase.ts
+++ b/src/usecases/apkg/ImportApkgToNotionUseCase.ts
@@ -43,36 +43,40 @@ const SQLITE_ERROR_CODES = new Set([
   'SQLITE_CANTOPEN',
 ]);
 
+const NOTION_OUTAGE_MESSAGE =
+  'Notion is having issues. Try again in a few minutes.';
+
+const NOTION_ERROR_MESSAGES: Partial<Record<APIErrorCode, string>> = {
+  [APIErrorCode.Unauthorized]:
+    'Notion sign-in expired. Reconnect Notion and try again.',
+  [APIErrorCode.RestrictedResource]:
+    "2anki can't write to this Notion page. Share it with the 2anki integration.",
+  [APIErrorCode.ObjectNotFound]:
+    'The Notion page is gone. Pick a different destination page.',
+  [APIErrorCode.RateLimited]:
+    'Notion is rate-limiting this account. Try again in a minute.',
+  [APIErrorCode.InternalServerError]: NOTION_OUTAGE_MESSAGE,
+  [APIErrorCode.ServiceUnavailable]: NOTION_OUTAGE_MESSAGE,
+  [APIErrorCode.GatewayTimeout]: NOTION_OUTAGE_MESSAGE,
+};
+
+function resolveNotionFailureMessage(error: APIResponseError): string | null {
+  if (
+    error.code === APIErrorCode.ValidationError &&
+    error.message.includes('archived ancestor')
+  ) {
+    return 'The Notion page you picked is in the trash. Restore it in Notion or pick a different destination page.';
+  }
+  return NOTION_ERROR_MESSAGES[error.code] ?? null;
+}
+
 function resolveFailureMessage(error: unknown): string {
   if (error instanceof Error && error.message.includes('Upgrade')) {
     return error.message;
   }
   if (error instanceof APIResponseError) {
-    if (error.code === APIErrorCode.Unauthorized) {
-      return 'Notion sign-in expired. Reconnect Notion and try again.';
-    }
-    if (error.code === APIErrorCode.RestrictedResource) {
-      return "2anki can't write to this Notion page. Share it with the 2anki integration.";
-    }
-    if (error.code === APIErrorCode.ObjectNotFound) {
-      return 'The Notion page is gone. Pick a different destination page.';
-    }
-    if (error.code === APIErrorCode.RateLimited) {
-      return 'Notion is rate-limiting this account. Try again in a minute.';
-    }
-    if (
-      error.code === APIErrorCode.ValidationError &&
-      error.message.includes('archived ancestor')
-    ) {
-      return 'The Notion page you picked is in the trash. Restore it in Notion or pick a different destination page.';
-    }
-    if (
-      error.code === APIErrorCode.InternalServerError ||
-      error.code === APIErrorCode.ServiceUnavailable ||
-      error.code === APIErrorCode.GatewayTimeout
-    ) {
-      return 'Notion is having issues. Try again in a few minutes.';
-    }
+    const notionMessage = resolveNotionFailureMessage(error);
+    if (notionMessage != null) return notionMessage;
   }
   const errorCode = (error as { code?: string })?.code;
   if (typeof errorCode === 'string' && SQLITE_ERROR_CODES.has(errorCode)) {

--- a/web/src/pages/WhatsNewPage/changelog/2026-09-10-apkg-import-trashed-page.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-09-10-apkg-import-trashed-page.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-09-10-apkg-import-trashed-page",
+  "date": "2026-09-10",
+  "type": "fix",
+  "title": "Anki to Notion import says when the destination page is in the trash, instead of a generic failure"
+}

--- a/web/src/pages/WhatsNewPage/changelog/2026-09-10-apkg-import-trashed-page.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-09-10-apkg-import-trashed-page.json
@@ -2,5 +2,5 @@
   "id": "2026-09-10-apkg-import-trashed-page",
   "date": "2026-09-10",
   "type": "fix",
-  "title": "Anki to Notion import says when the destination page is in the trash, instead of a generic failure"
+  "title": "Anki to Notion import tells you when the destination page is in the trash"
 }


### PR DESCRIPTION
Closes #4355

## What

`resolveFailureMessage` in the apkg-to-Notion import use case now maps Notion's 400 `ValidationError` whose message mentions an archived ancestor to:

> The Notion page you picked is in the trash. Restore it in Notion or pick a different destination page.

Other validation errors keep the generic "Import failed" fallback.

## Why

Seen in prod on 2026-09-06: a user picked a destination page under a trashed ancestor. The generic copy invited a retry that cannot succeed and a support email for a self-serve fix.

## Tests

- New: archived-ancestor 400 surfaces the trash copy.
- New: other 400 validation errors keep the generic message.
- `ImportApkgToNotionUseCase.test.ts`: 18/18. Server `tsc` clean, `pnpm format:check` clean, web suite 3610/3610.

Sonar: not run locally; PR decoration will report.

## Changelog

`2026-09-10-apkg-import-trashed-page.json`.

## Browser check

Backend-only string change; the only `web/src/` file is the changelog JSON. No runtime-visible UI change to verify in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4itmNnsVzTPhUUYevBZUR
