### PR TITLE
feat: add semesterpass.120d to the Apple IAP redeem catalogue

### DIFF
--- a/src/usecases/iap/RedeemAppleTransactionUseCase.test.ts
+++ b/src/usecases/iap/RedeemAppleTransactionUseCase.test.ts
@@ -88,6 +88,12 @@ describe('RedeemAppleTransactionUseCase', () => {
       message: 'Week Pass active — unlimited cards for the next 7 days',
       durationMs: 7 * DAY_MS,
     },
+    {
+      productId: 'semesterpass.120d',
+      kind: '120d',
+      message: 'Semester Pass active — unlimited cards for the next 120 days',
+      durationMs: 120 * DAY_MS,
+    },
   ])(
     'grants $kind for a valid $productId transaction',
     async ({ productId, kind, message, durationMs }) => {

--- a/src/usecases/iap/products.ts
+++ b/src/usecases/iap/products.ts
@@ -3,7 +3,7 @@ import type { PassKind } from '../../data_layer/UserPassRepository';
 export interface ConsumableProduct {
   kind: 'consumable';
   productId: string;
-  passKind: Extract<PassKind, '24h' | '7d'>;
+  passKind: Extract<PassKind, '24h' | '7d' | '120d'>;
   durationMs: number;
   successMessage: string;
 }
@@ -33,6 +33,14 @@ export const APPLE_PRODUCTS: Record<string, AppleProduct> = {
     passKind: '7d',
     durationMs: 7 * DAY_MS,
     successMessage: 'Week Pass active — unlimited cards for the next 7 days',
+  },
+  'semesterpass.120d': {
+    kind: 'consumable',
+    productId: 'semesterpass.120d',
+    passKind: '120d',
+    durationMs: 120 * DAY_MS,
+    successMessage:
+      'Semester Pass active — unlimited cards for the next 120 days',
   },
   'unlimited.monthly': {
     kind: 'subscription',


### PR DESCRIPTION
Closes #4347

**Payments-adjacent, opened overnight and left for you to merge.** The hard-rail path check does not flag `src/usecases/iap/`, but this credits paid access on an Apple transaction, so I did not run it through the merge step. Review verdict is posted; merge from the UI when you are happy.

## What

- `src/usecases/iap/products.ts`: new `APPLE_PRODUCTS['semesterpass.120d']` (consumable, `passKind: '120d'`, 120 days, "Semester Pass active — unlimited cards for the next 120 days").
- `ConsumableProduct.passKind` widened from `'24h' | '7d'` to include `'120d'`.
- `RedeemAppleTransactionUseCase.test.ts`: third row in the product-map `it.each` (grants `120d`, correct message, expiry = now + 120 days). Verified the row fails without the catalogue entry and passes with it.

## Why

Exactly what #4347 specifies: the Stripe side of the Semester Pass shipped in #4322/#4342; the native app cannot add the matching IAP until the redeem map knows the product ID. Downstream (`PASS_DURATION_MS`, `passKindLabel`, `mapEntitlement`, `PassUnlockMonitorService`, the `user_passes.kind` text column) already handles `120d`.

## Checks

- `RedeemAppleTransactionUseCase.test.ts`: 16/16.
- Server `tsc -p . --noEmit` clean; `pnpm format:check` clean.
- Sonar: not run locally; PR decoration will report.

No changelog entry — nothing is user-visible until the app adds the IAP in App Store Connect (tracked in the app repo).

## Decisions made overnight (please review)

- Success message: "Semester Pass active — unlimited cards for the next 120 days", mirroring the Day/Week pass strings. Swap if you want the /pricing wording ("semester") instead of the day count.
- Scope: catalogue entry + type + test only. Did not touch `src/lib/limits.ts` or any app-side code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4itmNnsVzTPhUUYevBZUR
