### PR TITLE
test: keep the answers slug lists in lockstep

### DIFF
--- a/web/src/pages/AnswersPage/answersConfig.parity.test.ts
+++ b/web/src/pages/AnswersPage/answersConfig.parity.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { ANSWERS_PAGES } from './answersConfig';
+
+const REPO_ROOT = join(__dirname, '../../../..');
+
+function readServerAnswersSlugs(): Set<string> {
+  const source = readFileSync(
+    join(REPO_ROOT, 'src/routes/knownRoutes.ts'),
+    'utf8'
+  );
+  const block = source.match(
+    /const ANSWERS_SLUGS = new Set<string>\(\[([\s\S]*?)\]\);/
+  );
+  if (block == null) {
+    throw new Error('ANSWERS_SLUGS block not found in knownRoutes.ts');
+  }
+  return new Set(Array.from(block[1].matchAll(/'([a-z0-9-]+)'/g), (m) => m[1]));
+}
+
+function readSitemapAnswersSlugs(): Set<string> {
+  const sitemap = readFileSync(
+    join(REPO_ROOT, 'web/public/sitemap.xml'),
+    'utf8'
+  );
+  return new Set(
+    Array.from(
+      sitemap.matchAll(
+        /<loc>https:\/\/2anki\.net\/answers\/([a-z0-9-]+)\/<\/loc>/g
+      ),
+      (m) => m[1]
+    )
+  );
+}
+
+describe('answers slug parity', () => {
+  const configSlugs = new Set(ANSWERS_PAGES.keys());
+
+  it('every answers page is in the server route allowlist', () => {
+    const serverSlugs = readServerAnswersSlugs();
+    const missing = [...configSlugs].filter((slug) => !serverSlugs.has(slug));
+    expect(missing).toEqual([]);
+  });
+
+  it('the server route allowlist has no slug without a page', () => {
+    const serverSlugs = readServerAnswersSlugs();
+    const orphaned = [...serverSlugs].filter((slug) => !configSlugs.has(slug));
+    expect(orphaned).toEqual([]);
+  });
+
+  it('every answers page is in the sitemap', () => {
+    const sitemapSlugs = readSitemapAnswersSlugs();
+    const missing = [...configSlugs].filter((slug) => !sitemapSlugs.has(slug));
+    expect(missing).toEqual([]);
+  });
+
+  it('the sitemap lists no answers URL without a page', () => {
+    const sitemapSlugs = readSitemapAnswersSlugs();
+    const orphaned = [...sitemapSlugs].filter((slug) => !configSlugs.has(slug));
+    expect(orphaned).toEqual([]);
+  });
+});


### PR DESCRIPTION
Follow-up from https://github.com/2anki/server/pull/4381.

## What

`web/src/pages/AnswersPage/answersConfig.parity.test.ts` asserts, in both directions, that the three hand-maintained answers lists agree:

- `ANSWERS_PAGES` (the config map) ⇄ `ANSWERS_SLUGS` in `src/routes/knownRoutes.ts` (read as text, same pattern as `events.parity.test.ts`)
- `ANSWERS_PAGES` ⇄ `/answers/<slug>/` URLs in `web/public/sitemap.xml`

## Why

A slug missing from the server allowlist makes direct loads of the page return a 404 status to crawlers; a slug missing from the sitemap never gets discovered. Both lists are maintained by hand and nothing caught a miss until now. Verified the test fails when a sitemap entry is removed and passes on `main`.

## Checks

- Web: parity test 4/4; typecheck clean; lint clean; `pnpm format:check` clean.
- No changelog entry — test-only, no user-visible change.
- Sonar: not run locally; PR decoration will report.

Browser check: not applicable — test-only file under `web/src/`, no rendered output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4itmNnsVzTPhUUYevBZUR
