### PR TITLE
fix: stop the pre-push format hook rejecting kanel-only pushes

### DIFF
--- a/.claude/hooks/pre-push-format.py
+++ b/.claude/hooks/pre-push-format.py
@@ -23,7 +23,9 @@ Two gates:
 
 Skips pushes to main/master (safety.py owns those). oxfmt applies its own
 ignorePatterns from .oxfmtrc.json (templates, fixtures, generated, etc.), so we
-don't re-implement that filter here.
+don't re-implement that filter here — but when EVERY passed file is ignored,
+oxfmt exits 2 with "Expected at least one target file"; that is treated as
+clean, not as a format failure (kanel-regenerated data_layer/public files).
 
 Bypass: CLAUDE_SKIP_FORMAT_CHECK=1 git push ...   (env var, or inline in the
         command string — both honored, mirroring the typecheck hook).
@@ -45,6 +47,14 @@ PROTECTED_BRANCH = re.compile(r"\b(main|master)\b")
 SKIP_IN_COMMAND = re.compile(r"\bCLAUDE_SKIP_FORMAT_CHECK=1\b")
 NOT_INSTALLED = re.compile(
     r"command not found|ENOENT|not found|No such file|not be found",
+    re.IGNORECASE,
+)
+# oxfmt exits 2 (not 0) when every file passed explicitly is excluded by the
+# config's ignorePatterns — e.g. a push whose only formattable change is a
+# kanel-regenerated src/data_layer/public/*.ts. CI never sees those files, so
+# this is a clean result, not a format failure.
+ALL_FILES_IGNORED = re.compile(
+    r"All matched files may have been excluded by ignore rules",
     re.IGNORECASE,
 )
 
@@ -128,6 +138,8 @@ def run_oxfmt_check(files, project_dir):
     if result.returncode == 0:
         return True
     output = result.stdout or result.stderr or "(no output)"
+    if ALL_FILES_IGNORED.search(output):
+        return True
     if NOT_INSTALLED.search(output):
         sys.stderr.write(
             "[pre-push-format] oxfmt isn't installed in this checkout "

--- a/.claude/hooks/pre-push-format.py
+++ b/.claude/hooks/pre-push-format.py
@@ -138,7 +138,7 @@ def run_oxfmt_check(files, project_dir):
     if result.returncode == 0:
         return True
     output = result.stdout or result.stderr or "(no output)"
-    if ALL_FILES_IGNORED.search(output):
+    if result.returncode == 2 and ALL_FILES_IGNORED.search(output):
         return True
     if NOT_INSTALLED.search(output):
         sys.stderr.write(

--- a/.claude/hooks/pre-push-format.test.py
+++ b/.claude/hooks/pre-push-format.test.py
@@ -4,6 +4,7 @@ import json
 import os
 import sys
 import unittest
+import unittest.mock
 from unittest.mock import patch
 
 HOOKS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -166,6 +167,31 @@ class TestFormatGate(unittest.TestCase):
         )
         self.assertEqual(result["result"], "allow")
         self.assertTrue(result["oxfmt_called"])
+
+
+class TestOxfmtOutputClassification(unittest.TestCase):
+    def test_all_files_ignored_by_config_is_clean(self):
+        completed = unittest.mock.Mock(
+            returncode=2,
+            stdout="Checking formatting...\n\nExpected at least one target "
+            "file. All matched files may have been excluded by ignore rules.\n",
+            stderr="",
+        )
+        with patch.object(hook.subprocess, "run", return_value=completed):
+            result = hook.run_oxfmt_check(
+                ["src/data_layer/public/DeckShares.ts"], "/tmp"
+            )
+        self.assertIs(result, True)
+
+    def test_real_format_diff_is_returned_as_output(self):
+        completed = unittest.mock.Mock(
+            returncode=1,
+            stdout="Checking formatting...\n[warn] src/server.ts\n",
+            stderr="",
+        )
+        with patch.object(hook.subprocess, "run", return_value=completed):
+            result = hook.run_oxfmt_check(["src/server.ts"], "/tmp")
+        self.assertIn("src/server.ts", result)
 
 
 class TestFormattableFilter(unittest.TestCase):

--- a/.claude/hooks/pre-push-format.test.py
+++ b/.claude/hooks/pre-push-format.test.py
@@ -4,8 +4,7 @@ import json
 import os
 import sys
 import unittest
-import unittest.mock
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 HOOKS_DIR = os.path.dirname(os.path.abspath(__file__))
 spec = importlib.util.spec_from_file_location(
@@ -171,7 +170,7 @@ class TestFormatGate(unittest.TestCase):
 
 class TestOxfmtOutputClassification(unittest.TestCase):
     def test_all_files_ignored_by_config_is_clean(self):
-        completed = unittest.mock.Mock(
+        completed = Mock(
             returncode=2,
             stdout="Checking formatting...\n\nExpected at least one target "
             "file. All matched files may have been excluded by ignore rules.\n",
@@ -184,14 +183,27 @@ class TestOxfmtOutputClassification(unittest.TestCase):
         self.assertIs(result, True)
 
     def test_real_format_diff_is_returned_as_output(self):
-        completed = unittest.mock.Mock(
+        completed = Mock(
             returncode=1,
-            stdout="Checking formatting...\n[warn] src/server.ts\n",
+            stdout="Checking formatting...\n\nsrc/server.ts (4ms)\n"
+            "Format issues found in above 1 files.\n",
             stderr="",
         )
         with patch.object(hook.subprocess, "run", return_value=completed):
             result = hook.run_oxfmt_check(["src/server.ts"], "/tmp")
         self.assertIn("src/server.ts", result)
+
+
+    def test_ignored_sentence_without_exit_two_is_not_clean(self):
+        completed = Mock(
+            returncode=1,
+            stdout="src/All matched files may have been excluded by ignore "
+            "rules.ts (1ms)\nFormat issues found in above 1 files.\n",
+            stderr="",
+        )
+        with patch.object(hook.subprocess, "run", return_value=completed):
+            result = hook.run_oxfmt_check(["src/x.ts"], "/tmp")
+        self.assertIsInstance(result, str)
 
 
 class TestFormattableFilter(unittest.TestCase):


### PR DESCRIPTION
**Hard rail: `.claude/hooks/` — waits for Alexander.**

## Summary

`.claude/hooks/pre-push-format.py` refused the push for https://github.com/2anki/server/pull/4385 even though CI's `pnpm format:check` accepts it. The hook runs before the command, so with an uncommitted-only diff the formattable file list was just the kanel-regenerated `src/data_layer/public/DeckShares.ts`. That path is in `.oxfmtrc.json`'s `ignorePatterns`, and oxfmt exits **2** (not 0) with `Expected at least one target file. All matched files may have been excluded by ignore rules.` when every explicitly-passed file is ignored. The hook treated any non-zero exit as a format failure.

Fix: `run_oxfmt_check` returns clean when the output carries that sentence. A real format diff (exit 1 with offending files) still denies. Docstring updated to say so.

## Test plan

- `python3 .claude/hooks/pre-push-format.test.py` — 19 tests pass (2 new: all-files-ignored is clean; a real diff is still returned as offending output)
- Reproduced by hand on the #4385 branch: `pnpm exec oxfmt -c .oxfmtrc.json --threads 1 --check src/data_layer/public/DeckShares.ts` → exit 2 with that message; with a non-ignored file added to the list → exit 0
- No changelog entry — tooling only, no user-visible change
- Sonar: not run locally; PR decoration will report

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4itmNnsVzTPhUUYevBZUR
