### PR TITLE
fix: count chat deck downloads against the monthly card cap

### DIFF
--- a/src/controllers/ChatDeckController.test.ts
+++ b/src/controllers/ChatDeckController.test.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
 import ChatDeckController from './ChatDeckController';
+import { MonthlyLimitError } from '../usecases/users/CheckMonthlyCardLimitUseCase';
 
 function buildRes(): Response {
   return {
@@ -155,6 +156,8 @@ describe('ChatDeckController.generate', () => {
       ],
       deckName: 'Quiz',
       templateSlug: null,
+      userId: 42,
+      isPaying: false,
     });
     expect(res.send).toHaveBeenCalledWith(fakeBuffer);
   });
@@ -212,6 +215,8 @@ describe('ChatDeckController.generate', () => {
       cards: validCards,
       deckName: 'My Deck',
       templateSlug: null,
+      userId: 42,
+      isPaying: false,
     });
     expect(res.setHeader).toHaveBeenCalledWith(
       'Content-Type',
@@ -222,5 +227,30 @@ describe('ChatDeckController.generate', () => {
       'attachment; filename="My Deck.apkg"; filename*=UTF-8\'\'My%20Deck.apkg'
     );
     expect(res.send).toHaveBeenCalledWith(fakeBuffer);
+  });
+
+  it('maps a MonthlyLimitError to a 402 with the monthly_limit shape and sends no deck', async () => {
+    const resetOn = '2026-10-01T00:00:00.000Z';
+    const useCase = {
+      execute: jest
+        .fn()
+        .mockRejectedValue(new MonthlyLimitError(100, 100, 2, resetOn)),
+    };
+    const controller = new ChatDeckController(useCase as never);
+    const res = buildRes();
+
+    await controller.generate(
+      buildReq({ cards: validCards, deckName: 'My Deck' }),
+      res
+    );
+
+    expect(res.status).toHaveBeenCalledWith(402);
+    expect(res.json).toHaveBeenCalledWith({
+      code: 'monthly_limit',
+      cards_used: 100,
+      limit: 100,
+      reset_on: resetOn,
+    });
+    expect(res.send).not.toHaveBeenCalled();
   });
 });

--- a/src/controllers/ChatDeckController.ts
+++ b/src/controllers/ChatDeckController.ts
@@ -3,7 +3,10 @@ import {
   ChatDeckUseCase,
   type ChatDeckCard,
 } from '../usecases/chat/ChatDeckUseCase';
+import { MonthlyLimitError } from '../usecases/users/CheckMonthlyCardLimitUseCase';
 import { buildContentDisposition } from '../lib/buildContentDisposition';
+import { getOwner } from '../lib/User/getOwner';
+import { isPaying } from '../lib/isPaying';
 
 const MAX_DECK_NAME_LENGTH = 120;
 const MAX_CARDS = 200;
@@ -127,11 +130,27 @@ class ChatDeckController {
     const templateSlug =
       typeof rawTemplateSlug === 'string' ? rawTemplateSlug : null;
 
-    const buffer = await this.useCase.execute({
-      cards: parsedCards as ChatDeckCard[],
-      deckName,
-      templateSlug,
-    });
+    let buffer: Buffer;
+    try {
+      buffer = await this.useCase.execute({
+        cards: parsedCards as ChatDeckCard[],
+        deckName,
+        templateSlug,
+        userId: getOwner(res),
+        isPaying: isPaying(res.locals),
+      });
+    } catch (error) {
+      if (error instanceof MonthlyLimitError) {
+        res.status(402).json({
+          code: 'monthly_limit',
+          cards_used: error.cards_used,
+          limit: error.limit,
+          reset_on: error.reset_on,
+        });
+        return;
+      }
+      throw error;
+    }
 
     res.setHeader('Content-Type', 'application/octet-stream');
     res.setHeader(

--- a/src/routes/ChatRouter.ts
+++ b/src/routes/ChatRouter.ts
@@ -292,6 +292,12 @@ const ChatRouter = () => {
    *               $ref: '#/components/schemas/Error'
    *       401:
    *         description: Authentication required
+   *       402:
+   *         description: |
+   *           Free monthly card allowance exceeded. Body is
+   *           `{ code: 'monthly_limit', cards_used, limit, reset_on }`, the
+   *           same shape the upload and Notion conversion paths return.
+   *           Paying users are exempt.
    */
   router.post('/api/chat/deck', RequireAuthentication, (req, res) =>
     deckController.generate(req, res)

--- a/src/routes/ChatRouter.ts
+++ b/src/routes/ChatRouter.ts
@@ -47,7 +47,7 @@ const ChatRouter = () => {
   const controller = new ChatController(useCase);
   const consentUseCase = new SetChatConsentUseCase(usersRepo);
   const consentController = new ChatConsentController(consentUseCase);
-  const deckUseCase = new ChatDeckUseCase();
+  const deckUseCase = new ChatDeckUseCase(usersRepo);
   const deckController = new ChatDeckController(deckUseCase);
   const tagCardsUseCase = new TagCardsUseCase(anthropic, messagesRepo);
   const tagCardsController = new TagCardsController(tagCardsUseCase);

--- a/src/usecases/chat/ChatDeckUseCase.test.ts
+++ b/src/usecases/chat/ChatDeckUseCase.test.ts
@@ -7,8 +7,23 @@ import {
   type ChatDeckCard,
 } from './ChatDeckUseCase';
 import CustomExporter from '../../lib/parser/exporters/CustomExporter';
+import UsersRepository from '../../data_layer/UsersRepository';
+import { MonthlyLimitError } from '../users/CheckMonthlyCardLimitUseCase';
 
 jest.mock('../../lib/parser/exporters/CustomExporter');
+
+const usersRepo = {
+  getCardUsage: jest
+    .fn()
+    .mockResolvedValue({ cards_used: 0, month_started_at: null }),
+  incrementCardUsage: jest.fn().mockResolvedValue(0),
+} as unknown as UsersRepository;
+
+const OWNER = { userId: 42, isPaying: true } as const;
+
+function buildDeckUseCase(repo: UsersRepository = usersRepo) {
+  return new ChatDeckUseCase(repo);
+}
 
 describe('stripClozeFromStem', () => {
   it('replaces a single cloze span with a blank', () => {
@@ -50,8 +65,9 @@ describe('ChatDeckUseCase.execute MCQ handling', () => {
   });
 
   it('passes mcq:true with options and correctIndices to the exporter for MCQ cards', async () => {
-    const useCase = new ChatDeckUseCase();
+    const useCase = buildDeckUseCase();
     await useCase.execute({
+      ...OWNER,
       deckName: 'Quiz',
       cards: [
         {
@@ -83,8 +99,9 @@ describe('ChatDeckUseCase.execute MCQ handling', () => {
   });
 
   it('keeps basic shape for cards without MCQ fields', async () => {
-    const useCase = new ChatDeckUseCase();
+    const useCase = buildDeckUseCase();
     await useCase.execute({
+      ...OWNER,
       deckName: 'Mix',
       cards: [{ front: 'Q', back: 'A' }],
     });
@@ -98,8 +115,9 @@ describe('ChatDeckUseCase.execute MCQ handling', () => {
   });
 
   it('passes per-card tags through to the exporter', async () => {
-    const useCase = new ChatDeckUseCase();
+    const useCase = buildDeckUseCase();
     await useCase.execute({
+      ...OWNER,
       deckName: 'Tagged',
       cards: [
         { front: 'Capital?', back: 'Oslo', tags: ['geography', 'norway'] },
@@ -126,8 +144,9 @@ describe('ChatDeckUseCase.execute basic-and-reversed template', () => {
   });
 
   it('duplicates cards with swapped front/back when templateSlug is basic-and-reversed', async () => {
-    const useCase = new ChatDeckUseCase();
+    const useCase = buildDeckUseCase();
     await useCase.execute({
+      ...OWNER,
       deckName: 'Reversed',
       templateSlug: 'basic-and-reversed',
       cards: [{ front: 'Q', back: 'A' }],
@@ -143,8 +162,9 @@ describe('ChatDeckUseCase.execute basic-and-reversed template', () => {
   });
 
   it('does not add reversed card when back is empty', async () => {
-    const useCase = new ChatDeckUseCase();
+    const useCase = buildDeckUseCase();
     await useCase.execute({
+      ...OWNER,
       deckName: 'Empty back set',
       templateSlug: 'basic-and-reversed',
       cards: [{ front: 'A standalone prompt with no answer', back: '' }],
@@ -158,8 +178,9 @@ describe('ChatDeckUseCase.execute basic-and-reversed template', () => {
   });
 
   it('does not expand when templateSlug is basic', async () => {
-    const useCase = new ChatDeckUseCase();
+    const useCase = buildDeckUseCase();
     await useCase.execute({
+      ...OWNER,
       deckName: 'Basic set',
       templateSlug: 'basic',
       cards: [{ front: 'Q', back: 'A' }],
@@ -183,8 +204,9 @@ describe('ChatDeckUseCase.execute cloze content under a basic template label', (
   });
 
   it('exports a normalized basic card when stray cloze content arrives under templateSlug basic', async () => {
-    const useCase = new ChatDeckUseCase();
+    const useCase = buildDeckUseCase();
     await useCase.execute({
+      ...OWNER,
       deckName: 'Mismatched',
       templateSlug: 'basic',
       cards: [{ front: 'The capital of France is {{c1::Paris}}.', back: '' }],
@@ -202,8 +224,9 @@ describe('ChatDeckUseCase.execute cloze content under a basic template label', (
   });
 
   it('normalizes stray cloze when templateSlug is basic-and-reversed', async () => {
-    const useCase = new ChatDeckUseCase();
+    const useCase = buildDeckUseCase();
     await useCase.execute({
+      ...OWNER,
       deckName: 'Reversed mismatch',
       templateSlug: 'basic-and-reversed',
       cards: [{ front: 'The capital of France is {{c1::Paris}}.', back: '' }],
@@ -221,8 +244,9 @@ describe('ChatDeckUseCase.execute cloze content under a basic template label', (
   });
 
   it('keeps cloze:true when templateSlug is cloze', async () => {
-    const useCase = new ChatDeckUseCase();
+    const useCase = buildDeckUseCase();
     await useCase.execute({
+      ...OWNER,
       deckName: 'Cloze deck',
       templateSlug: 'cloze',
       cards: [{ front: 'The capital of France is {{c1::Paris}}.', back: '' }],
@@ -382,5 +406,98 @@ describe('transformBlankToCloze', () => {
       front: 'Two underscores too: {{c1::still works}}',
       back: '',
     });
+  });
+});
+
+describe('ChatDeckUseCase.execute monthly card limit', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (CustomExporter as unknown as jest.Mock).mockImplementation(() => ({
+      configure: jest.fn(),
+      save: jest.fn().mockResolvedValue(Buffer.from('apkg')),
+    }));
+  });
+
+  function buildRepo(cardsUsed: number) {
+    return {
+      getCardUsage: jest
+        .fn()
+        .mockResolvedValue({ cards_used: cardsUsed, month_started_at: null }),
+      incrementCardUsage: jest.fn().mockResolvedValue(0),
+    } as unknown as UsersRepository;
+  }
+
+  const twoCards: ChatDeckCard[] = [
+    { front: 'Q1', back: 'A1' },
+    { front: 'Q2', back: 'A2' },
+  ];
+
+  it('throws MonthlyLimitError for a free user over the cap and does not build or record usage', async () => {
+    const repo = buildRepo(99);
+    const useCase = buildDeckUseCase(repo);
+
+    await expect(
+      useCase.execute({
+        deckName: 'Over the cap',
+        cards: twoCards,
+        userId: 42,
+        isPaying: false,
+      })
+    ).rejects.toBeInstanceOf(MonthlyLimitError);
+
+    expect(CustomExporter).not.toHaveBeenCalled();
+    expect(repo.incrementCardUsage).not.toHaveBeenCalled();
+  });
+
+  it('carries cards_used, limit, and reset_on on the thrown MonthlyLimitError', async () => {
+    const repo = buildRepo(99);
+    const useCase = buildDeckUseCase(repo);
+
+    const error = await useCase
+      .execute({
+        deckName: 'Over the cap',
+        cards: twoCards,
+        userId: 42,
+        isPaying: false,
+      })
+      .catch((err: unknown) => err);
+
+    expect(error).toBeInstanceOf(MonthlyLimitError);
+    const limitError = error as MonthlyLimitError;
+    expect(limitError.cards_used).toBe(99);
+    expect(limitError.limit).toBe(100);
+    expect(typeof limitError.reset_on).toBe('string');
+  });
+
+  it('builds and records the request card count for a free user under the cap', async () => {
+    const repo = buildRepo(10);
+    const useCase = buildDeckUseCase(repo);
+
+    const buffer = await useCase.execute({
+      deckName: 'Under the cap',
+      cards: twoCards,
+      userId: 42,
+      isPaying: false,
+    });
+
+    expect(buffer).toEqual(Buffer.from('apkg'));
+    expect(CustomExporter).toHaveBeenCalledTimes(1);
+    expect(repo.incrementCardUsage).toHaveBeenCalledWith(42, 2);
+  });
+
+  it('builds and records usage for a paying user already over the cap', async () => {
+    const repo = buildRepo(500);
+    const useCase = buildDeckUseCase(repo);
+
+    const buffer = await useCase.execute({
+      deckName: 'Paying over the cap',
+      cards: twoCards,
+      userId: 42,
+      isPaying: true,
+    });
+
+    expect(buffer).toEqual(Buffer.from('apkg'));
+    expect(repo.getCardUsage).not.toHaveBeenCalled();
+    expect(repo.incrementCardUsage).toHaveBeenCalledWith(42, 2);
   });
 });

--- a/src/usecases/chat/ChatDeckUseCase.ts
+++ b/src/usecases/chat/ChatDeckUseCase.ts
@@ -3,6 +3,8 @@ import os from 'node:os';
 import path from 'node:path';
 import { randomUUID, createHash } from 'node:crypto';
 import CustomExporter from '../../lib/parser/exporters/CustomExporter';
+import UsersRepository from '../../data_layer/UsersRepository';
+import { CheckMonthlyCardLimitUseCase } from '../users/CheckMonthlyCardLimitUseCase';
 import { templateForbidsCloze } from './chatTemplates';
 
 export interface ChatDeckCard {
@@ -19,6 +21,8 @@ export interface ChatDeckInput {
   cards: ChatDeckCard[];
   deckName: string;
   templateSlug?: string | null;
+  userId: string | number;
+  isPaying: boolean;
 }
 
 function isMcqCard(card: ChatDeckCard): boolean {
@@ -91,8 +95,16 @@ function expandForTemplate(
 }
 
 export class ChatDeckUseCase {
+  constructor(private readonly usersRepository: UsersRepository) {}
+
   async execute(input: ChatDeckInput): Promise<Buffer> {
-    const { cards, deckName, templateSlug } = input;
+    const { cards, deckName, templateSlug, userId, isPaying } = input;
+    const cardCount = cards.length;
+    await new CheckMonthlyCardLimitUseCase(this.usersRepository).execute({
+      userId,
+      candidateCardCount: cardCount,
+      isPaying,
+    });
     const workspaceDir = path.join(os.tmpdir(), `chat-deck-${randomUUID()}`);
     fs.mkdirSync(workspaceDir, { recursive: true });
 
@@ -147,7 +159,9 @@ export class ChatDeckUseCase {
 
       const exporter = new CustomExporter(deckName, workspaceDir);
       exporter.configure(deckInfo as never);
-      return await exporter.save();
+      const buffer = await exporter.save();
+      await this.usersRepository.incrementCardUsage(userId, cardCount);
+      return buffer;
     } finally {
       fs.rmSync(workspaceDir, { recursive: true, force: true });
     }

--- a/web/src/pages/WhatsNewPage/changelog/2026-09-10-chat-deck-monthly-cap.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-09-10-chat-deck-monthly-cap.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-09-10-chat-deck-monthly-cap",
+  "date": "2026-09-10",
+  "type": "fix",
+  "title": "Decks built from the chat assistant count toward the free monthly card allowance, like every other conversion"
+}

--- a/web/src/pages/WhatsNewPage/changelog/2026-09-10-chat-deck-monthly-cap.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-09-10-chat-deck-monthly-cap.json
@@ -2,5 +2,5 @@
   "id": "2026-09-10-chat-deck-monthly-cap",
   "date": "2026-09-10",
   "type": "fix",
-  "title": "Decks built from the chat assistant count toward the free monthly card allowance, like every other conversion"
+  "title": "Decks built from the chat assistant count toward the free 100 cards per month, like every other conversion"
 }


### PR DESCRIPTION
## What
`POST /api/chat/deck` builds an `.apkg` from a client-supplied card list without calling Claude, capped at 200 cards per request by the controller. Until now a signed-in **free** account could package up to 200 cards per request with no monthly limit, while every other conversion path enforces the 100-card free monthly cap. This wires `/api/chat/deck` into that same cap: it checks the request's card count before building, records a successful build against the user's monthly usage, and returns the same typed `monthly_limit` error the async paths write. Paying users stay exempt.

## Why
Closes #4358. The chat-deck route never writes a `jobs`/`uploads` row, so the shared `CheckMonthlyCardLimitUseCase` (which reads `users.cards_used_this_month`) saw nothing for this path — free users got unlimited chat-deck downloads while `performConversion`, `UploadService`, and the MCP path all enforce the cap. User-visible outcome: a free account hitting its monthly allowance gets the same limit response on chat decks as on any other conversion, and chat-deck downloads now count toward that allowance.

## How
- `ChatDeckUseCase` takes a `UsersRepository` and now receives `userId` + `isPaying`. It runs `CheckMonthlyCardLimitUseCase` (candidate = request card count) **before** creating the workspace, then `incrementCardUsage(userId, cardCount)` **after** a successful `exporter.save()` — the exact check-then-build-then-record order used by `handleSyncUpload` / `promoteClaudeJobToUpload` and `McpToolsService.createSubdeckDeck`.
- `ChatDeckController` reads `owner`/`isPaying` off `res.locals`, passes them through, and maps a thrown `MonthlyLimitError` to HTTP **402** with the payload `{ code: 'monthly_limit', cards_used, limit, reset_on }` — the exact shape `performConversion` and `UploadService.resolveAsyncFailureReason` write, so the native app (which calls this route) gets a typed limit error. Status 402 matches `NotionController`'s synchronous limit response.
- `ChatRouter` wires the already-constructed `usersRepo` into `new ChatDeckUseCase(usersRepo)`.
- No env flag, no Stripe/auth changes, no change to the 200-card request cap.

**LLM/large-file cost:** none — this route does not call Claude and does not process Notion exports. No latency, token, or cost delta; prompt caching N/A.

## Measuring success
Prod-observable without a new event: count of `POST /api/chat/deck` responses returning HTTP 402 with `code: 'monthly_limit'`, and `users.cards_used_this_month` incrementing on chat-deck downloads (the same counter the funnel already reads for other paths). No new analytics event was added — that would need the web/server `KNOWN_EVENTS` parity dance, and this mirrors `NotionController`'s synchronous 402 path, which fires none.

## Testing
- `src/usecases/chat/ChatDeckUseCase.test.ts` — added: free user over cap throws `MonthlyLimitError` (no build, no increment); the error carries `cards_used`/`limit`/`reset_on`; free user under cap builds and records `incrementCardUsage(userId, 2)`; paying user over cap builds and records without reading usage.
- `src/controllers/ChatDeckController.test.ts` — added: `MonthlyLimitError` maps to a 402 with the `monthly_limit` shape and sends no deck; updated existing call-arg assertions for the new `userId`/`isPaying` input fields.
- Targeted: `ChatDeckUseCase` + `ChatDeckController` + `ChatRouter` → **3 suites, 58 tests, all green.**
- Full server suite (`pnpm test`): **Test Suites 720 passed / 2 skipped / 9 failed (731 total); Tests 7063 passed / 25 skipped / 7 todo / 81 failed (7176 total).** The 9 failing suites are the documented environmental failures only — `getPageCount` (pdfinfo not installed: `spawn /usr/local/bin/pdfinfo ENOENT`) and the `DeckParser*` / `golden` / `canary` suites that need the `create_deck` Python venv (`PythonExitError`), which a fresh worktree lacks. None touch chat/deck/limit code.
- `pnpm exec tsc -p . --noEmit`: clean. `pnpm format:check`: clean.
- Sonar: not run locally; PR decoration will report.

## Browser check
- [ ] Golden path on localhost:3000 — not run: this is a backend JSON API path consumed by the native app; no dev server available in this worktree. The only `web/src` change is the changelog data JSON, which renders in the What's New list.
- [ ] No console errors at 375px — N/A (no interactive web UI change).
Notes: change is a small, well-tested exact mirror of the existing upload/MCP monthly-cap enforcement.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-09-10-chat-deck-monthly-cap.json` — "Decks built from the chat assistant count toward the free monthly card allowance, like every other conversion"

## Risks
- A free user near their monthly cap who previously could still build chat decks will now be blocked at 100 cards/month — this is the intended fix, closing an unmetered path.
- Attribution: the request-card count (`cards.length`, pre-`basic-and-reversed` expansion) is used for both the limit check and the increment. This is deliberately lenient (a reversed template that doubles notes still counts as the submitted cards) and keeps check and increment symmetric, matching the task's "count the number of cards in the request."
- Rollback: revert the PR; the route returns to unmetered behavior.

## Decisions made overnight (please review)
- **Gate chosen: the monthly card cap (`CheckMonthlyCardLimitUseCase`), mirroring `performConversion`/`UploadService` — not `RequirePayingJson`.** The other chat routes (`/message`, `/tag-cards`, `/regenerate`) use `RequirePayingJson` (hard paywall), but `/api/chat/deck` is intentionally open to free users (existing `ChatRouter` test: "lets a free user build a deck from existing cards"). Blocking free users outright would change that product decision; the free 100-card/month allowance is the correct, consistent gate.
- **Response: HTTP 402 with `{ code: 'monthly_limit', cards_used, limit, reset_on }`** — the exact payload shape `performConversion`/`UploadService` write (no `reason` field, includes `reset_on`), so the native app gets the same typed error. 402 matches `NotionController`'s synchronous limit response.
- **Count attribution: `cards.length` (request card count, before template expansion), used for both the pre-build check and the post-build `incrementCardUsage`.** Paying users are exempt from the check but their usage is still recorded, mirroring `handleSyncUpload`/`createSubdeckDeck`.
- **Commit trailer:** used the session system-reminder's `Co-Authored-By: Claude Opus 4.8 (1M context)` (it states it replaces earlier attribution guidance) rather than the `Claude Fable 5.1` line in the task brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4itmNnsVzTPhUUYevBZUR
