### PR TITLE
fix: show one App Store badge on the app page

### DIFF
--- a/web/src/pages/NativeAppPage/NativeAppPage.badge.test.ts
+++ b/web/src/pages/NativeAppPage/NativeAppPage.badge.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// The two App Store badges are theme variants; exactly one may render. Vitest
+// does not apply CSS modules, so this locks the stylesheet's selector
+// specificity instead: a bare `.badge img` rule that sets `display` outranks
+// `.badgeDark { display: none }` and shows both badges side by side.
+const css = readFileSync(
+  resolve(__dirname, 'NativeAppPage.module.css'),
+  'utf8'
+).replaceAll(/\/\*[\s\S]*?\*\//g, '');
+
+const ruleBodies = (selector: string): string[] =>
+  [...css.matchAll(/([^{}]+)\{([^}]*)\}/g)]
+    .filter(([, sel]) => sel.trim() === selector)
+    .map(([, , body]) => body);
+
+describe('NativeAppPage badge stylesheet', () => {
+  it('does not set display on the shared .badge img rule', () => {
+    const bodies = ruleBodies('.badge img');
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0]).not.toMatch(/display\s*:/);
+  });
+
+  it('hides the dark badge with a selector at least as specific as the light one', () => {
+    expect(ruleBodies('.badge .badgeDark')[0]).toMatch(/display\s*:\s*none/);
+    expect(ruleBodies('.badge .badgeLight')[0]).toMatch(/display\s*:\s*block/);
+  });
+
+  it('swaps the badges under the dark theme', () => {
+    expect(ruleBodies("[data-theme='dark'] .badge .badgeLight")[0]).toMatch(
+      /display\s*:\s*none/
+    );
+    expect(ruleBodies("[data-theme='dark'] .badge .badgeDark")[0]).toMatch(
+      /display\s*:\s*block/
+    );
+  });
+});

--- a/web/src/pages/NativeAppPage/NativeAppPage.module.css
+++ b/web/src/pages/NativeAppPage/NativeAppPage.module.css
@@ -68,20 +68,26 @@
 }
 
 .badge img {
-  display: block;
   height: 52px;
   width: auto;
 }
 
-.badgeDark {
+/* One badge at a time. Both selectors carry the same specificity as the
+   theme overrides below minus the attribute, so the theme always wins and
+   `.badge img` never re-shows the hidden variant. */
+.badge .badgeLight {
+  display: block;
+}
+
+.badge .badgeDark {
   display: none;
 }
 
-[data-theme='dark'] .badgeLight {
+[data-theme='dark'] .badge .badgeLight {
   display: none;
 }
 
-[data-theme='dark'] .badgeDark {
+[data-theme='dark'] .badge .badgeDark {
   display: block;
 }
 

--- a/web/src/pages/WhatsNewPage/changelog/2026-09-10-app-page-shows-one-app-store-badge.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-09-10-app-page-shows-one-app-store-badge.json
@@ -2,5 +2,5 @@
   "id": "2026-09-10-app-page-shows-one-app-store-badge",
   "date": "2026-09-10",
   "type": "fix",
-  "title": "The app page shows one App Store badge, matched to your theme, instead of two side by side"
+  "title": "App page shows one App Store badge, matched to your theme"
 }

--- a/web/src/pages/WhatsNewPage/changelog/2026-09-10-app-page-shows-one-app-store-badge.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-09-10-app-page-shows-one-app-store-badge.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-09-10-app-page-shows-one-app-store-badge",
+  "date": "2026-09-10",
+  "type": "fix",
+  "title": "The app page shows one App Store badge, matched to your theme, instead of two side by side"
+}


### PR DESCRIPTION
## Summary

On https://2anki.net/app/ both App Store badges (the black light-theme one and the white dark-theme one) rendered side by side in the light theme. Cause: `.badge img { display: block }` has higher specificity (0,1,1) than `.badgeDark { display: none }` (0,1,0), so the "hide the other variant" rule lost. Dark mode only worked because its `[data-theme='dark'] .badgeLight` selector happened to be more specific.

Fix: the shared `.badge img` rule only sizes; visibility lives on `.badge .badgeLight` / `.badge .badgeDark` with the theme overrides one attribute selector above them. `NativeAppPage.badge.test.ts` locks the specificity by reading the stylesheet (vitest does not apply CSS modules); it fails on `main`'s CSS and passes on this branch.

Simpler/more beautiful: one badge, matching the theme, on an acquisition page for the native app. Metric: none beyond the page looking right; `native_app_store_clicked` is unchanged.

## Test plan

- `vitest src/pages/NativeAppPage` — 3 files, 15 tests pass (new: 3 stylesheet assertions, verified red against `main`'s CSS)
- `pnpm format:check` clean
- Sonar: not run locally; PR decoration will report

## Browser check

- [x] Golden path on localhost:3000 — loaded `/app/` at 375px on `pnpm dev`: light theme renders only `/badges/app-store.svg`, `data-theme="dark"` renders only `/badges/app-store-white.svg`, and switching back restores the light badge — in both CTA placements (hero and bottom).
- [x] No console errors at 375px from this change (the only error is the pre-existing signed-out 401 on `/api/users/me/preferences`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4itmNnsVzTPhUUYevBZUR

