### PR TITLE
feat: happy score in ops and one-tap reasons on deck feedback

### DIFF
--- a/src/lib/happyScore.test.ts
+++ b/src/lib/happyScore.test.ts
@@ -1,0 +1,91 @@
+import {
+  computeHappyScore,
+  HAPPY_SCORE_ASK_EVENT,
+  MIN_HAPPY_SCORE_SAMPLE,
+} from './happyScore';
+
+describe('computeHappyScore', () => {
+  it('counts love as rating 5 and low as ratings 1 and 2', () => {
+    const window = computeHappyScore(
+      '30d',
+      [
+        { rating: 1, count: 4 },
+        { rating: 2, count: 2 },
+        { rating: 5, count: 14 },
+      ],
+      null
+    );
+    expect(window).toEqual({
+      window: '30d',
+      love: 14,
+      low: 6,
+      n: 20,
+      score_pct: 70,
+      asks: null,
+      response_rate_pct: null,
+    });
+  });
+
+  it('hides the score below the minimum sample but keeps the counts', () => {
+    const window = computeHappyScore(
+      '7d',
+      [
+        { rating: 1, count: 3 },
+        { rating: 5, count: MIN_HAPPY_SCORE_SAMPLE - 4 },
+      ],
+      12
+    );
+    expect(window).toMatchObject({
+      love: MIN_HAPPY_SCORE_SAMPLE - 4,
+      low: 3,
+      n: MIN_HAPPY_SCORE_SAMPLE - 1,
+      score_pct: null,
+    });
+  });
+
+  it('ignores ratings outside the three widget values', () => {
+    const window = computeHappyScore(
+      '90d',
+      [
+        { rating: 3, count: 50 },
+        { rating: 4, count: 50 },
+        { rating: 5, count: 10 },
+      ],
+      null
+    );
+    expect(window).toMatchObject({ love: 10, low: 0, n: 10, score_pct: 100 });
+  });
+
+  it('derives the response rate from asks when they are known', () => {
+    const window = computeHappyScore(
+      '30d',
+      [
+        { rating: 1, count: 5 },
+        { rating: 5, count: 5 },
+      ],
+      200
+    );
+    expect(window).toMatchObject({ asks: 200, response_rate_pct: 5 });
+  });
+
+  it('reports no response rate when nobody was asked', () => {
+    const window = computeHappyScore('30d', [{ rating: 5, count: 1 }], 0);
+    expect(window).toMatchObject({ asks: 0, response_rate_pct: null });
+  });
+
+  it('rounds the score to one decimal', () => {
+    const window = computeHappyScore(
+      '30d',
+      [
+        { rating: 1, count: 1 },
+        { rating: 5, count: 11 },
+      ],
+      null
+    );
+    expect(window.score_pct).toBe(91.7);
+  });
+
+  it('names the ask event that the prompt fires', () => {
+    expect(HAPPY_SCORE_ASK_EVENT).toBe('happy_score_ask_shown');
+  });
+});

--- a/src/lib/happyScore.ts
+++ b/src/lib/happyScore.ts
@@ -1,0 +1,50 @@
+import type { EmojiFeedbackRatingCount } from '../data_layer/EmojiFeedbackRepository';
+
+export type HappyScoreWindowLabel = '7d' | '30d' | '90d';
+
+export const HAPPY_SCORE_WINDOWS: ReadonlyArray<{
+  label: HappyScoreWindowLabel;
+  days: number;
+}> = [
+  { label: '7d', days: 7 },
+  { label: '30d', days: 30 },
+  { label: '90d', days: 90 },
+];
+
+export const MIN_HAPPY_SCORE_SAMPLE = 10;
+
+export const HAPPY_SCORE_ASK_EVENT = 'happy_score_ask_shown';
+
+const LOVE_RATING = 5;
+const LOW_RATINGS = new Set([1, 2]);
+
+export interface HappyScoreWindow {
+  window: HappyScoreWindowLabel;
+  love: number;
+  low: number;
+  n: number;
+  score_pct: number | null;
+  asks: number | null;
+  response_rate_pct: number | null;
+}
+
+const roundOneDecimal = (value: number): number => Math.round(value * 10) / 10;
+
+export function computeHappyScore(
+  window: HappyScoreWindowLabel,
+  counts: EmojiFeedbackRatingCount[],
+  asks: number | null
+): HappyScoreWindow {
+  let love = 0;
+  let low = 0;
+  for (const entry of counts) {
+    if (entry.rating === LOVE_RATING) love += entry.count;
+    if (LOW_RATINGS.has(entry.rating)) low += entry.count;
+  }
+  const n = love + low;
+  const score_pct =
+    n >= MIN_HAPPY_SCORE_SAMPLE ? roundOneDecimal((love / n) * 100) : null;
+  const response_rate_pct =
+    asks != null && asks > 0 ? roundOneDecimal((n / asks) * 100) : null;
+  return { window, love, low, n, score_pct, asks, response_rate_pct };
+}

--- a/src/routes/OpsRouter.ts
+++ b/src/routes/OpsRouter.ts
@@ -110,6 +110,7 @@ const OpsRouter = () => {
     cacheRepository: new BusinessMetricsCacheRepository(database),
     cancellationRepository: new CancellationFeedbackRepository(database),
     emojiFeedbackRepository: new EmojiFeedbackRepository(database),
+    happyScoreAskRepository: new EventsRepository(database),
     reengagementRepository: new ReEngagementFeedbackRepository(database),
     signupCountryRepository: new UsersRepository(database),
     signupCountsRepository: new UsersRepository(database),

--- a/src/services/ops/BusinessMetricsService.test.ts
+++ b/src/services/ops/BusinessMetricsService.test.ts
@@ -2,6 +2,7 @@ jest.mock('../../lib/integrations/stripe', () => ({
   getStripe: jest.fn(),
 }));
 
+import { InMemoryEmojiFeedbackRepository } from '../../data_layer/EmojiFeedbackRepository';
 import {
   BusinessMetricsService,
   BusinessMetricsServiceDeps,
@@ -150,6 +151,59 @@ describe('BusinessMetricsService', () => {
     expect(response.pass_sales_7d).toEqual({ day_passes: 5, week_passes: 2 });
     const since = passSalesSince.mock.calls[0][0] as Date;
     expect(Date.now() - since.getTime()).toBe(7 * 24 * 60 * 60 * 1000);
+  });
+
+  it('computes happy score for 7, 30 and 90 day windows with asks from the events repo', async () => {
+    const emoji = new InMemoryEmojiFeedbackRepository();
+    for (let i = 0; i < 12; i += 1) {
+      await emoji.insert({ rating: 5, comment: null, page: 'p', email: null });
+    }
+    for (let i = 0; i < 3; i += 1) {
+      await emoji.insert({ rating: 1, comment: null, page: 'p', email: null });
+    }
+    const countByName = jest.fn(async (name: string, since: Date) => {
+      expect(name).toBe('happy_score_ask_shown');
+      const days = Math.round((NOW_MS - since.getTime()) / 86_400_000);
+      return days * 10;
+    });
+    const { service } = buildService(
+      {},
+      {
+        emojiFeedbackRepository: emoji,
+        happyScoreAskRepository: { countByName },
+      }
+    );
+
+    const response = await service.getMetrics();
+
+    expect(response.happy_score).toEqual([
+      expect.objectContaining({
+        window: '7d',
+        love: 12,
+        low: 3,
+        n: 15,
+        score_pct: 80,
+        asks: 70,
+        response_rate_pct: 21.4,
+      }),
+      expect.objectContaining({ window: '30d', asks: 300, score_pct: 80 }),
+      expect.objectContaining({ window: '90d', asks: 900, score_pct: 80 }),
+    ]);
+  });
+
+  it('reports happy score windows with unknown asks when no events repo is injected', async () => {
+    const { service } = buildService();
+    const response = await service.getMetrics();
+    expect(response.happy_score).toEqual([
+      expect.objectContaining({
+        window: '7d',
+        n: 0,
+        score_pct: null,
+        asks: null,
+      }),
+      expect.objectContaining({ window: '30d', asks: null }),
+      expect.objectContaining({ window: '90d', asks: null }),
+    ]);
   });
 
   it('returns null pass sales without a repository', async () => {

--- a/src/services/ops/BusinessMetricsService.ts
+++ b/src/services/ops/BusinessMetricsService.ts
@@ -22,6 +22,12 @@ import {
   InMemoryEmojiFeedbackRepository,
 } from '../../data_layer/EmojiFeedbackRepository';
 import {
+  computeHappyScore,
+  HAPPY_SCORE_ASK_EVENT,
+  HAPPY_SCORE_WINDOWS,
+  HappyScoreWindow,
+} from '../../lib/happyScore';
+import {
   IReEngagementFeedbackRepository,
   InMemoryReEngagementFeedbackRepository,
   ReEngagementCommentEntry,
@@ -56,6 +62,7 @@ export type BusinessMetricKey =
   | 'cancellation_comments_recent'
   | 'emoji_feedback_ratings'
   | 'emoji_feedback_comments'
+  | 'happy_score'
   | 'reengagement_reasons_top'
   | 'reengagement_comments_recent'
   | 'signup_countries_90d'
@@ -106,6 +113,7 @@ export interface BusinessMetricsResponse {
   cancellation_comments_recent: CancellationCommentEntry[] | null;
   emoji_feedback_ratings: EmojiFeedbackRatingCount[] | null;
   emoji_feedback_comments: EmojiFeedbackCommentEntry[] | null;
+  happy_score: HappyScoreWindow[] | null;
   reengagement_reasons_top: ReEngagementReasonCount[] | null;
   reengagement_comments_recent: ReEngagementCommentEntry[] | null;
   signup_countries_90d: SignupCountryCount[] | null;
@@ -129,12 +137,17 @@ export const SIGNUP_COUNTRIES_LIMIT = 10;
 export const SIGNUPS_24H_LOOKBACK_DAYS = 1;
 export const SIGNUPS_7D_LOOKBACK_DAYS = 7;
 
+export interface IHappyScoreAskRepository {
+  countByName(name: string, since: Date): Promise<number>;
+}
+
 export interface BusinessMetricsServiceDeps {
   stripeFactory?: () => Stripe;
   cacheTtlMs?: number;
   cacheRepository?: IBusinessMetricsCacheRepository;
   cancellationRepository?: ICancellationFeedbackRepository;
   emojiFeedbackRepository?: IEmojiFeedbackRepository;
+  happyScoreAskRepository?: IHappyScoreAskRepository;
   reengagementRepository?: IReEngagementFeedbackRepository;
   signupCountryRepository?: ISignupCountryRepository;
   signupCountsRepository?: IUserSignupCountsRepository;
@@ -217,6 +230,8 @@ export class BusinessMetricsService {
 
   private readonly emojiFeedbackRepository: IEmojiFeedbackRepository;
 
+  private readonly happyScoreAskRepository: IHappyScoreAskRepository | null;
+
   private readonly reengagementRepository: IReEngagementFeedbackRepository;
 
   private readonly signupCountryRepository: ISignupCountryRepository | null;
@@ -239,6 +254,7 @@ export class BusinessMetricsService {
       new InMemoryCancellationFeedbackRepository();
     this.emojiFeedbackRepository =
       deps.emojiFeedbackRepository ?? new InMemoryEmojiFeedbackRepository();
+    this.happyScoreAskRepository = deps.happyScoreAskRepository ?? null;
     this.reengagementRepository =
       deps.reengagementRepository ??
       new InMemoryReEngagementFeedbackRepository();
@@ -339,6 +355,7 @@ export class BusinessMetricsService {
       emoji_feedback_comments: dbValueByKey.get('emoji_feedback_comments') as
         | EmojiFeedbackCommentEntry[]
         | null,
+      happy_score: dbValueByKey.get('happy_score') as HappyScoreWindow[] | null,
       reengagement_reasons_top: dbValueByKey.get('reengagement_reasons_top') as
         | ReEngagementReasonCount[]
         | null,
@@ -394,6 +411,24 @@ export class BusinessMetricsService {
     }
   }
 
+  private async fetchHappyScoreWindows(now: Date): Promise<HappyScoreWindow[]> {
+    return Promise.all(
+      HAPPY_SCORE_WINDOWS.map(async ({ label, days }) => {
+        const since = new Date(now.getTime() - days * SECONDS_PER_DAY * 1000);
+        const [counts, asks] = await Promise.all([
+          this.emojiFeedbackRepository.countByRating(since),
+          this.happyScoreAskRepository == null
+            ? Promise.resolve(null)
+            : this.happyScoreAskRepository.countByName(
+                HAPPY_SCORE_ASK_EVENT,
+                since
+              ),
+        ]);
+        return computeHappyScore(label, counts, asks);
+      })
+    );
+  }
+
   private buildDbMetricTasks(
     now: Date
   ): Array<{ key: BusinessMetricKey; fetch: () => Promise<unknown> }> {
@@ -434,6 +469,10 @@ export class BusinessMetricsService {
           this.emojiFeedbackRepository.recentComments(
             EMOJI_FEEDBACK_COMMENTS_LIMIT
           ),
+      },
+      {
+        key: 'happy_score',
+        fetch: () => this.fetchHappyScoreWindows(now),
       },
       {
         key: 'reengagement_reasons_top',

--- a/src/services/ops/CustomerSignalsService.test.ts
+++ b/src/services/ops/CustomerSignalsService.test.ts
@@ -242,6 +242,24 @@ describe('CustomerSignalsService', () => {
     expect(highRating?.convergence).toBe(1);
   });
 
+  it('labels a low rating with the reason chip the user picked', async () => {
+    const service = buildService({
+      emojiComments: [
+        {
+          rating: 1,
+          comment: '[images_missing] captions did not come through',
+          page: 'downloads/deck_done',
+          created_at: '2026-06-16T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const result = await service.getSignals(since);
+
+    const row = find(result.signals, (r) => r.source === 'emoji_feedback');
+    expect(row?.label).toBe('Deck-ready rating 1 · images missing');
+  });
+
   it('maps buckets for structured signals and truncates verbatim quotes', async () => {
     const longComment = 'x'.repeat(250);
     const service = buildService({

--- a/src/services/ops/CustomerSignalsService.ts
+++ b/src/services/ops/CustomerSignalsService.ts
@@ -304,6 +304,14 @@ function toCancelCommentRows(
     }));
 }
 
+const REASON_TAG = /^\[([a-z_]+)\]\s*/;
+
+function emojiRowLabel(row: EmojiFeedbackCommentEntry): string {
+  const base = `Deck-ready rating ${row.rating}`;
+  const tag = REASON_TAG.exec(row.comment)?.[1];
+  return tag == null ? base : `${base} · ${tag.replaceAll('_', ' ')}`;
+}
+
 function toEmojiCommentRows(
   comments: EmojiFeedbackCommentEntry[],
   since: Date
@@ -313,7 +321,7 @@ function toEmojiCommentRows(
     .slice(0, SAMPLE_LIMIT)
     .map((row) => ({
       source: 'emoji_feedback' as const,
-      label: `Deck-ready rating ${row.rating}`,
+      label: emojiRowLabel(row),
       count: 1,
       bucket: 'unknown' as const,
       sampleQuote: truncateQuote(row.comment),

--- a/src/services/ops/TodaySnapshotService.test.ts
+++ b/src/services/ops/TodaySnapshotService.test.ts
@@ -34,6 +34,7 @@ const business = (
     cancellation_comments_recent: null,
     emoji_feedback_ratings: null,
     emoji_feedback_comments: null,
+    happy_score: null,
     reengagement_reasons_top: null,
     reengagement_comments_recent: null,
     signup_countries_90d: null,
@@ -204,6 +205,70 @@ describe('buildScoreRows', () => {
     });
   });
 
+  it('reads the 90-day happy score off the business metrics', () => {
+    const rows = buildScoreRows({
+      business: business({
+        happy_score: [
+          {
+            window: '7d',
+            love: 2,
+            low: 1,
+            n: 3,
+            score_pct: null,
+            asks: 20,
+            response_rate_pct: 15,
+          },
+          {
+            window: '90d',
+            love: 40,
+            low: 20,
+            n: 60,
+            score_pct: 66.7,
+            asks: 500,
+            response_rate_pct: 12,
+          },
+        ],
+      }),
+      conversion: null,
+      unresolvedErrorGroups: null,
+      passUnlock: null,
+      paidValue: null,
+    });
+    const row = rows.find((r) => r.id === 'happy_score_90d_pct');
+    expect(row).toMatchObject({
+      value: 66.7,
+      target: 60,
+      status: 'green',
+      lever: 'health',
+      window_label: '90d',
+      link: '/ops/business#happy-score',
+    });
+  });
+
+  it('leaves the happy score row unscored while the sample is too small', () => {
+    const rows = buildScoreRows({
+      business: business({
+        happy_score: [
+          {
+            window: '90d',
+            love: 5,
+            low: 2,
+            n: 7,
+            score_pct: null,
+            asks: null,
+            response_rate_pct: null,
+          },
+        ],
+      }),
+      conversion: null,
+      unresolvedErrorGroups: null,
+      passUnlock: null,
+      paidValue: null,
+    });
+    const row = rows.find((r) => r.id === 'happy_score_90d_pct');
+    expect(row).toMatchObject({ value: null, status: 'none' });
+  });
+
   it('renders every row with a null value when a source is missing', () => {
     const empty = buildScoreRows({
       business: null,
@@ -212,7 +277,7 @@ describe('buildScoreRows', () => {
       passUnlock: null,
       paidValue: null,
     });
-    expect(empty).toHaveLength(10);
+    expect(empty).toHaveLength(11);
     for (const row of empty) {
       expect(row.value).toBeNull();
       expect(row.status).toBe('none');
@@ -248,7 +313,7 @@ describe('TodaySnapshotService', () => {
       () => t0
     );
     const snapshot = await service.getSnapshot();
-    expect(snapshot.rows).toHaveLength(10);
+    expect(snapshot.rows).toHaveLength(11);
     expect(snapshot).toMatchObject({
       as_of: t0.toISOString(),
       cache_age_seconds: 0,
@@ -340,7 +405,7 @@ describe('TodaySnapshotService', () => {
     const stale = await service.getSnapshot();
     expect(stale.stale).toBe(true);
     expect(stale.cache_age_seconds).toBe(600);
-    expect(stale.rows).toHaveLength(10);
+    expect(stale.rows).toHaveLength(11);
   });
 
   it('throws when every source fails and nothing is cached', async () => {

--- a/src/services/ops/TodaySnapshotService.ts
+++ b/src/services/ops/TodaySnapshotService.ts
@@ -269,6 +269,18 @@ export function buildScoreRows(inputs: TodaySnapshotInputs): ScoreRow[] {
       link: '/ops/growth#conversions',
     },
     {
+      id: 'happy_score_90d_pct',
+      lever: 'health',
+      label: 'Happy score (users who rated a finished deck)',
+      format: 'percent',
+      window_label: '90d',
+      value:
+        business?.happy_score?.find((w) => w.window === '90d')?.score_pct ??
+        null,
+      target: TODAY_TARGETS.happy_score_90d_pct,
+      link: '/ops/business#happy-score',
+    },
+    {
       id: 'unresolved_error_groups',
       lever: 'health',
       label: 'Unresolved error groups',

--- a/src/services/ops/todayThresholds.ts
+++ b/src/services/ops/todayThresholds.ts
@@ -10,6 +10,7 @@ export const TODAY_TARGETS = {
   pass_sales_7d: { at_least: 23 },
   churn_30d_pct: { at_most: 7 },
   conversion_success_7d_pct: { at_least: 90 },
+  happy_score_90d_pct: { at_least: 60 },
   unresolved_error_groups: { at_most: 0 },
   missing_pass_unlocks_7d: { at_most: 0 },
   zero_value_paid_7d: { at_most: 0, missedSeverity: 'amber' },

--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -21,6 +21,7 @@ export const KNOWN_EVENTS = new Set([
   'email_clicked',
   'email_batch_sent',
   'vision_photo_converted',
+  'happy_score_ask_shown',
   'photo_entry_point_viewed',
   'photo_entry_point_clicked',
   'photo_upload_started',

--- a/src/usecases/ops/GetBusinessMetricsUseCase.test.ts
+++ b/src/usecases/ops/GetBusinessMetricsUseCase.test.ts
@@ -22,6 +22,7 @@ describe('GetBusinessMetricsUseCase', () => {
       cancellation_comments_recent: [],
       emoji_feedback_ratings: [],
       emoji_feedback_comments: [],
+      happy_score: [],
       reengagement_reasons_top: [],
       reengagement_comments_recent: [],
       signup_countries_90d: [],

--- a/web/src/lib/analytics/events.ts
+++ b/web/src/lib/analytics/events.ts
@@ -1,4 +1,5 @@
 export const KNOWN_EVENTS = new Set([
+  'happy_score_ask_shown',
   'upload_started',
   'conversion_succeeded',
   'conversion_failed',

--- a/web/src/lib/i18n/locales/de/downloadsx.json
+++ b/web/src/lib/i18n/locales/de/downloadsx.json
@@ -14,7 +14,11 @@
     "sending": "Wird gesendet",
     "received": "Feedback erhalten.",
     "error": "Das ließ sich nicht senden.",
-    "tryAgain": "Erneut versuchen"
+    "tryAgain": "Erneut versuchen",
+    "reasonImagesMissing": "Bilder fehlen",
+    "reasonWrongCards": "Falsche Karten",
+    "reasonTooFewCards": "Zu wenige Karten",
+    "reasonOther": "Etwas anderes"
   },
   "ankify": {
     "sending": "Wird an dein Anki gesendet…",

--- a/web/src/lib/i18n/locales/en/downloadsx.json
+++ b/web/src/lib/i18n/locales/en/downloadsx.json
@@ -14,7 +14,11 @@
     "sending": "Sending",
     "received": "Feedback received.",
     "error": "Couldn't send that.",
-    "tryAgain": "Try again"
+    "tryAgain": "Try again",
+    "reasonImagesMissing": "Images missing",
+    "reasonWrongCards": "Wrong cards",
+    "reasonTooFewCards": "Too few cards",
+    "reasonOther": "Something else"
   },
   "ankify": {
     "sending": "Sending to your Anki…",

--- a/web/src/lib/i18n/locales/es/downloadsx.json
+++ b/web/src/lib/i18n/locales/es/downloadsx.json
@@ -14,7 +14,11 @@
     "sending": "Enviando",
     "received": "Comentarios recibidos.",
     "error": "No se pudo enviar.",
-    "tryAgain": "Intentar de nuevo"
+    "tryAgain": "Intentar de nuevo",
+    "reasonImagesMissing": "Faltan imágenes",
+    "reasonWrongCards": "Tarjetas incorrectas",
+    "reasonTooFewCards": "Muy pocas tarjetas",
+    "reasonOther": "Otra cosa"
   },
   "ankify": {
     "sending": "Enviando a tu Anki…",

--- a/web/src/lib/i18n/locales/fr/downloadsx.json
+++ b/web/src/lib/i18n/locales/fr/downloadsx.json
@@ -14,7 +14,11 @@
     "sending": "Envoi en cours",
     "received": "Retour reçu.",
     "error": "Impossible d'envoyer.",
-    "tryAgain": "Réessayer"
+    "tryAgain": "Réessayer",
+    "reasonImagesMissing": "Images manquantes",
+    "reasonWrongCards": "Mauvaises cartes",
+    "reasonTooFewCards": "Trop peu de cartes",
+    "reasonOther": "Autre chose"
   },
   "ankify": {
     "sending": "Envoi vers votre Anki…",

--- a/web/src/lib/i18n/locales/it/downloadsx.json
+++ b/web/src/lib/i18n/locales/it/downloadsx.json
@@ -14,7 +14,11 @@
     "sending": "Invio in corso",
     "received": "Feedback ricevuto.",
     "error": "Impossibile inviare.",
-    "tryAgain": "Riprova"
+    "tryAgain": "Riprova",
+    "reasonImagesMissing": "Immagini mancanti",
+    "reasonWrongCards": "Carte sbagliate",
+    "reasonTooFewCards": "Troppo poche carte",
+    "reasonOther": "Altro"
   },
   "ankify": {
     "sending": "Invio al tuo Anki…",

--- a/web/src/lib/i18n/locales/ja/downloadsx.json
+++ b/web/src/lib/i18n/locales/ja/downloadsx.json
@@ -14,7 +14,11 @@
     "sending": "送信中",
     "received": "フィードバックを受け取りました。",
     "error": "送信できませんでした。",
-    "tryAgain": "再試行"
+    "tryAgain": "再試行",
+    "reasonImagesMissing": "画像がない",
+    "reasonWrongCards": "カードが間違っている",
+    "reasonTooFewCards": "カードが少なすぎる",
+    "reasonOther": "その他"
   },
   "ankify": {
     "sending": "あなたの Anki に送信中…",

--- a/web/src/lib/i18n/locales/nl/downloadsx.json
+++ b/web/src/lib/i18n/locales/nl/downloadsx.json
@@ -14,7 +14,11 @@
     "sending": "Bezig met verzenden",
     "received": "Feedback ontvangen.",
     "error": "Kon dat niet verzenden.",
-    "tryAgain": "Opnieuw proberen"
+    "tryAgain": "Opnieuw proberen",
+    "reasonImagesMissing": "Afbeeldingen ontbreken",
+    "reasonWrongCards": "Verkeerde kaarten",
+    "reasonTooFewCards": "Te weinig kaarten",
+    "reasonOther": "Iets anders"
   },
   "ankify": {
     "sending": "Verzenden naar je Anki…",

--- a/web/src/lib/i18n/locales/pl/downloadsx.json
+++ b/web/src/lib/i18n/locales/pl/downloadsx.json
@@ -14,7 +14,11 @@
     "sending": "Wysyłanie",
     "received": "Opinia otrzymana.",
     "error": "Nie udało się wysłać.",
-    "tryAgain": "Spróbuj ponownie"
+    "tryAgain": "Spróbuj ponownie",
+    "reasonImagesMissing": "Brak obrazów",
+    "reasonWrongCards": "Błędne karty",
+    "reasonTooFewCards": "Za mało kart",
+    "reasonOther": "Coś innego"
   },
   "ankify": {
     "sending": "Wysyłanie do Twojego Anki…",

--- a/web/src/lib/i18n/locales/pt/downloadsx.json
+++ b/web/src/lib/i18n/locales/pt/downloadsx.json
@@ -14,7 +14,11 @@
     "sending": "Enviando",
     "received": "Feedback recebido.",
     "error": "Não foi possível enviar.",
-    "tryAgain": "Tentar de novo"
+    "tryAgain": "Tentar de novo",
+    "reasonImagesMissing": "Imagens faltando",
+    "reasonWrongCards": "Cartões errados",
+    "reasonTooFewCards": "Poucos cartões",
+    "reasonOther": "Outra coisa"
   },
   "ankify": {
     "sending": "Enviando para o seu Anki…",

--- a/web/src/lib/i18n/locales/ru/downloadsx.json
+++ b/web/src/lib/i18n/locales/ru/downloadsx.json
@@ -14,7 +14,11 @@
     "sending": "Отправка",
     "received": "Отзыв получен.",
     "error": "Не удалось отправить.",
-    "tryAgain": "Повторить"
+    "tryAgain": "Повторить",
+    "reasonImagesMissing": "Нет изображений",
+    "reasonWrongCards": "Неправильные карточки",
+    "reasonTooFewCards": "Слишком мало карточек",
+    "reasonOther": "Другое"
   },
   "ankify": {
     "sending": "Отправка в ваш Anki…",

--- a/web/src/pages/DownloadsPage/components/DeckFeedbackPrompt.module.css
+++ b/web/src/pages/DownloadsPage/components/DeckFeedbackPrompt.module.css
@@ -73,6 +73,35 @@
   border-color: var(--color-text-tertiary);
 }
 
+.reasons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.reason {
+  padding: 0.375rem 0.75rem;
+  border-radius: var(--radius-full, 999px);
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-text-primary);
+  font-size: var(--text-sm);
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.reason:hover {
+  border-color: var(--color-text-tertiary);
+}
+
+.reasonSelected {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: var(--color-text-on-primary, white);
+}
+
 .textarea {
   width: 100%;
   padding: 0.625rem 0.75rem;

--- a/web/src/pages/DownloadsPage/components/DeckFeedbackPrompt.test.tsx
+++ b/web/src/pages/DownloadsPage/components/DeckFeedbackPrompt.test.tsx
@@ -22,8 +22,11 @@ vi.mock('../../../lib/analytics/track', () => ({
 }));
 
 import {
+  ANSWERED_SUPPRESSION_MS,
   DeckFeedbackPrompt,
+  DISMISSED_SUPPRESSION_MS,
   isDeckFeedbackSuppressed,
+  tagComment,
 } from './DeckFeedbackPrompt';
 
 const SUPPRESSED_UNTIL_KEY = '2anki_deck_feedback_suppressed_until';
@@ -147,10 +150,80 @@ describe('DeckFeedbackPrompt', () => {
     expect(await screen.findByText('Feedback received.')).toBeInTheDocument();
   });
 
-  it('writes a 14-day suppression timestamp on dismiss', () => {
+  it('fires the ask event once when the prompt is shown', () => {
     render(<DeckFeedbackPrompt />);
+    expect(mockTrack).toHaveBeenCalledTimes(1);
+    expect(mockTrack).toHaveBeenCalledWith('happy_score_ask_shown');
+  });
+
+  it('tags the comment with the reason chip the user picked', async () => {
+    render(<DeckFeedbackPrompt />);
+    fireEvent.click(screen.getByRole('button', { name: 'Something was off' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Images missing' }));
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'captions vanished' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+    await waitFor(() => {
+      expect(submitEmojiFeedback).toHaveBeenCalledWith(
+        1,
+        'downloads/deck_done',
+        '[images_missing] captions vanished'
+      );
+    });
+  });
+
+  it('sends the reason tag alone when the user picks a chip and skips the text', async () => {
+    render(<DeckFeedbackPrompt />);
+    fireEvent.click(screen.getByRole('button', { name: 'Something was off' }));
+    const chip = screen.getByRole('button', { name: 'Too few cards' });
+    fireEvent.click(chip);
+    expect(chip).toHaveAttribute('aria-pressed', 'true');
+    fireEvent.click(screen.getByRole('button', { name: 'Skip' }));
+    await waitFor(() => {
+      expect(submitEmojiFeedback).toHaveBeenCalledWith(
+        1,
+        'downloads/deck_done',
+        '[too_few_cards]'
+      );
+    });
+  });
+
+  it('shows no reason chips on the positive path', () => {
+    render(<DeckFeedbackPrompt />);
+    fireEvent.click(screen.getByRole('button', { name: 'Yes, it worked' }));
+    expect(
+      screen.queryByRole('button', { name: 'Images missing' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('suppresses for 90 days on dismiss and 180 days on an answer', async () => {
+    const now = Date.now();
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+    const { unmount } = render(<DeckFeedbackPrompt />);
     fireEvent.click(screen.getByLabelText('Dismiss'));
-    expect(isDeckFeedbackSuppressed()).toBe(true);
+    expect(localStorage.getItem(SUPPRESSED_UNTIL_KEY)).toBe(
+      String(now + DISMISSED_SUPPRESSION_MS)
+    );
+    unmount();
+    localStorage.clear();
+    render(<DeckFeedbackPrompt />);
+    fireEvent.click(screen.getByRole('button', { name: 'Yes, it worked' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Skip' }));
+    await waitFor(() => {
+      expect(localStorage.getItem(SUPPRESSED_UNTIL_KEY)).toBe(
+        String(now + ANSWERED_SUPPRESSION_MS)
+      );
+    });
+    vi.restoreAllMocks();
+  });
+
+  it('tagComment trims, caps, and prefixes', () => {
+    expect(tagComment(null, '  hi  ')).toBe('hi');
+    expect(tagComment('other', '')).toBe('[other]');
+    expect(tagComment('wrong_cards', 'x'.repeat(2500))).toHaveLength(
+      '[wrong_cards] '.length + 2000
+    );
   });
 
   it('writes the suppression timestamp on successful submit', async () => {

--- a/web/src/pages/DownloadsPage/components/DeckFeedbackPrompt.tsx
+++ b/web/src/pages/DownloadsPage/components/DeckFeedbackPrompt.tsx
@@ -1,15 +1,34 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { track } from '../../../lib/analytics/track';
 import { get2ankiApi } from '../../../lib/backend/get2ankiApi';
 import styles from './DeckFeedbackPrompt.module.css';
 
 const SUPPRESSED_UNTIL_KEY = '2anki_deck_feedback_suppressed_until';
-const SUPPRESSION_MS = 14 * 24 * 60 * 60 * 1000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+export const DISMISSED_SUPPRESSION_MS = 90 * DAY_MS;
+export const ANSWERED_SUPPRESSION_MS = 180 * DAY_MS;
+export const HAPPY_SCORE_ASK_EVENT = 'happy_score_ask_shown';
 const FEEDBACK_PAGE = 'downloads/deck_done';
 const POSITIVE_RATING = 5;
 const NEGATIVE_RATING = 1;
 const COMMENT_MAX = 2000;
+
+export const NEGATIVE_REASONS = [
+  { tag: 'images_missing', labelKey: 'feedback.reasonImagesMissing' },
+  { tag: 'wrong_cards', labelKey: 'feedback.reasonWrongCards' },
+  { tag: 'too_few_cards', labelKey: 'feedback.reasonTooFewCards' },
+  { tag: 'other', labelKey: 'feedback.reasonOther' },
+] as const;
+
+type ReasonTag = (typeof NEGATIVE_REASONS)[number]['tag'];
+
+export function tagComment(reason: ReasonTag | null, comment: string): string {
+  const text = comment.slice(0, COMMENT_MAX).trim();
+  if (reason == null) return text;
+  return text.length > 0 ? `[${reason}] ${text}` : `[${reason}]`;
+}
 
 type Stage =
   | { kind: 'prompt' }
@@ -18,9 +37,9 @@ type Stage =
   | { kind: 'sent'; rating: number }
   | { kind: 'error'; retry: () => void };
 
-function suppressForWindow(): void {
+function suppressFor(durationMs: number): void {
   try {
-    const until = Date.now() + SUPPRESSION_MS;
+    const until = Date.now() + durationMs;
     localStorage.setItem(SUPPRESSED_UNTIL_KEY, String(until));
   } catch {
     // localStorage may be disabled. Best-effort suppression only.
@@ -43,12 +62,17 @@ export function DeckFeedbackPrompt() {
   const { t } = useTranslation('downloadsx');
   const [stage, setStage] = useState<Stage>({ kind: 'prompt' });
   const [comment, setComment] = useState('');
+  const [reason, setReason] = useState<ReasonTag | null>(null);
   const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    track(HAPPY_SCORE_ASK_EVENT);
+  }, []);
 
   if (dismissed) return null;
 
   const handleDismiss = () => {
-    suppressForWindow();
+    suppressFor(DISMISSED_SUPPRESSION_MS);
     setDismissed(true);
   };
 
@@ -60,7 +84,7 @@ export function DeckFeedbackPrompt() {
         FEEDBACK_PAGE,
         withComment != null && withComment.length > 0 ? withComment : undefined
       );
-      suppressForWindow();
+      suppressFor(ANSWERED_SUPPRESSION_MS);
       setStage({ kind: 'sent', rating });
     } catch {
       setStage({
@@ -78,12 +102,15 @@ export function DeckFeedbackPrompt() {
     setStage({ kind: 'follow-up', rating: NEGATIVE_RATING });
   };
 
+  const reasonFor = (rating: number): ReasonTag | null =>
+    rating === NEGATIVE_RATING ? reason : null;
+
   const handleSend = (rating: number) => {
-    void sendRating(rating, comment.slice(0, COMMENT_MAX));
+    void sendRating(rating, tagComment(reasonFor(rating), comment));
   };
 
   const handleSkip = (rating: number) => {
-    void sendRating(rating);
+    void sendRating(rating, tagComment(reasonFor(rating), ''));
   };
 
   return (
@@ -126,6 +153,25 @@ export function DeckFeedbackPrompt() {
               ? t('feedback.followUpPositive')
               : t('feedback.followUpNegative')}
           </label>
+          {stage.rating === NEGATIVE_RATING && (
+            <div className={styles.reasons}>
+              {NEGATIVE_REASONS.map((item) => (
+                <button
+                  key={item.tag}
+                  type="button"
+                  className={`${styles.reason} ${reason === item.tag ? styles.reasonSelected : ''}`}
+                  aria-pressed={reason === item.tag}
+                  onClick={() =>
+                    setReason((current) =>
+                      current === item.tag ? null : item.tag
+                    )
+                  }
+                >
+                  {t(item.labelKey)}
+                </button>
+              ))}
+            </div>
+          )}
           <textarea
             id="deck-feedback-comment"
             className={styles.textarea}

--- a/web/src/pages/OpsPage/BusinessTab.test.tsx
+++ b/web/src/pages/OpsPage/BusinessTab.test.tsx
@@ -72,6 +72,7 @@ const buildSampleMetrics = (
     { rating: 4, count: 5 },
     { rating: 5, count: 3 },
   ],
+  happy_score: null,
   emoji_feedback_comments: [
     {
       rating: 5,
@@ -131,7 +132,7 @@ describe('BusinessTab', () => {
         </MemoryRouter>
       </QueryClientProvider>
     );
-    expect(document.querySelectorAll('details')).toHaveLength(7);
+    expect(document.querySelectorAll('details')).toHaveLength(8);
     expect(document.querySelectorAll('details[open]')).toHaveLength(0);
     expect(screen.getByText('Pass unlocks')).toBeInTheDocument();
     expect(screen.getByText('Paid value')).toBeInTheDocument();

--- a/web/src/pages/OpsPage/BusinessTab.tsx
+++ b/web/src/pages/OpsPage/BusinessTab.tsx
@@ -164,16 +164,16 @@ export default function BusinessTab() {
         summary={summaryFor('happy_score_90d_pct')}
       >
         <p className={styles.sectionHint}>
-          Share of deck-done ratings that were positive, among users who
-          answered. Hidden under 10 answers. Response rate needs the ask event,
-          which ships with this table.
+          Positive share of deck-done ratings, among people who answered. Hidden
+          under 10 answers. Asked and response rate start counting from this
+          release.
         </p>
         <div className={styles.tableScroll}>
           <table className={styles.table}>
             <thead>
               <tr>
                 <th>Window</th>
-                <th className={styles.numeric}>Happy</th>
+                <th className={styles.numeric}>Score</th>
                 <th className={styles.numeric}>Positive</th>
                 <th className={styles.numeric}>Negative</th>
                 <th className={styles.numeric}>Asked</th>

--- a/web/src/pages/OpsPage/BusinessTab.tsx
+++ b/web/src/pages/OpsPage/BusinessTab.tsx
@@ -158,6 +158,53 @@ export default function BusinessTab() {
         />
       </div>
 
+      <CollapsibleSection
+        slug="happy-score"
+        title="Happy score"
+        summary={summaryFor('happy_score_90d_pct')}
+      >
+        <p className={styles.sectionHint}>
+          Share of deck-done ratings that were positive, among users who
+          answered. Hidden under 10 answers. Response rate needs the ask event,
+          which ships with this table.
+        </p>
+        <div className={styles.tableScroll}>
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th>Window</th>
+                <th className={styles.numeric}>Happy</th>
+                <th className={styles.numeric}>Positive</th>
+                <th className={styles.numeric}>Negative</th>
+                <th className={styles.numeric}>Asked</th>
+                <th className={styles.numeric}>Response rate</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(visible?.happy_score ?? []).map((w) => (
+                <tr key={w.window}>
+                  <td>{w.window}</td>
+                  <td className={styles.numeric}>
+                    {formatNumberOrDash(w.score_pct, formatPercentOneDecimal)}
+                  </td>
+                  <td className={styles.numeric}>{formatInteger(w.love)}</td>
+                  <td className={styles.numeric}>{formatInteger(w.low)}</td>
+                  <td className={styles.numeric}>
+                    {formatNumberOrDash(w.asks, formatInteger)}
+                  </td>
+                  <td className={styles.numeric}>
+                    {formatNumberOrDash(
+                      w.response_rate_pct,
+                      formatPercentOneDecimal
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </CollapsibleSection>
+
       <CollapsibleSection slug="emoji-feedback" title="Emoji feedback">
         <p className={styles.sectionHint}>
           Ratings and comments from the in-app emoji widget

--- a/web/src/pages/OpsPage/TodayTab.test.tsx
+++ b/web/src/pages/OpsPage/TodayTab.test.tsx
@@ -64,6 +64,7 @@ const business = {
     },
   ],
   emoji_feedback_ratings: null,
+  happy_score: null,
   emoji_feedback_comments: null,
   reengagement_reasons_top: null,
   reengagement_comments_recent: null,

--- a/web/src/pages/OpsPage/buildClaudePrompt.test.ts
+++ b/web/src/pages/OpsPage/buildClaudePrompt.test.ts
@@ -35,6 +35,7 @@ function makeBusiness(
       },
     ],
     emoji_feedback_ratings: [{ rating: 5, count: 3 }],
+    happy_score: null,
     emoji_feedback_comments: [],
     reengagement_reasons_top: [],
     reengagement_comments_recent: [],
@@ -205,6 +206,7 @@ describe('buildClaudePrompt — business', () => {
       makeBusiness({
         cancellation_comments_recent: [],
         reengagement_comments_recent: [],
+        happy_score: null,
         emoji_feedback_comments: [],
       })
     );

--- a/web/src/pages/OpsPage/businessTypes.ts
+++ b/web/src/pages/OpsPage/businessTypes.ts
@@ -13,6 +13,7 @@ export type BusinessMetricKey =
   | 'cancellation_comments_recent'
   | 'emoji_feedback_ratings'
   | 'emoji_feedback_comments'
+  | 'happy_score'
   | 'reengagement_reasons_top'
   | 'reengagement_comments_recent'
   | 'signup_countries_90d';
@@ -66,6 +67,18 @@ export interface EmojiFeedbackCommentPoint {
   created_at: string;
 }
 
+export type HappyScoreWindowLabel = '7d' | '30d' | '90d';
+
+export interface HappyScoreWindow {
+  window: HappyScoreWindowLabel;
+  love: number;
+  low: number;
+  n: number;
+  score_pct: number | null;
+  asks: number | null;
+  response_rate_pct: number | null;
+}
+
 export interface ReEngagementReasonPoint {
   stopped_reason: string;
   count: number;
@@ -103,6 +116,7 @@ export interface BusinessMetricsResponse {
   cancellation_comments_recent: CancellationCommentPoint[] | null;
   emoji_feedback_ratings: EmojiFeedbackRatingPoint[] | null;
   emoji_feedback_comments: EmojiFeedbackCommentPoint[] | null;
+  happy_score: HappyScoreWindow[] | null;
   reengagement_reasons_top: ReEngagementReasonPoint[] | null;
   reengagement_comments_recent: ReEngagementCommentPoint[] | null;
   signup_countries_90d: SignupCountryPoint[] | null;

--- a/web/src/pages/WhatsNewPage/changelog/2026-09-11-tell-us-what-went-wrong-with-one-tap.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-09-11-tell-us-what-went-wrong-with-one-tap.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-09-11-tell-us-what-went-wrong-with-one-tap",
+  "date": "2026-09-11",
+  "type": "feature",
+  "title": "When a deck comes out wrong, say what went wrong with one tap"
+}


### PR DESCRIPTION
## Summary

Deck ratings skewed negative and every low rating was free text: 29 of the last 45 deck-done ratings were low, and each one had to be read before it could be triaged. There was also no number that said whether finished decks made people happy over time.

This PR ships the measurement half of the Happy Score plan (the eligibility engine that decides *when* to ask is a follow-up):

- **One-tap reasons on the negative path.** After "Something was off", four chips: Images missing, Wrong cards, Too few cards, Something else. The pick is stored as a `[tag]` prefix on the comment; `CustomerSignalsService` surfaces it in the label (`Deck-ready rating 1 · images missing`) so Ops groups defects without reading prose. No new table, no migration.
- **`happy_score_ask_shown` event**, fired once per show, in both event allowlists. Without an "asked" denominator the response rate is unbackable.
- **Longer suppression**: dismiss = 90 days, answered = 180 days (was 14). Still localStorage; server-side per-user suppression is the follow-up.
- **Ops: Happy score section** on Business with 7d / 30d / 90d windows: positive ÷ (positive + negative) among answered ratings, hidden under 10 answers, plus asked count and response rate.
- **Today row `happy_score_90d_pct`**, lever health, target ≥ 60%, labeled "Happy score (users who rated a finished deck)".

Simpler/faster/more beautiful: one tap instead of a sentence when a deck is wrong. Scale: defects become triaged signals, which is what raises conversion success. Metric: 90d happy score on Today (target ≥ 60% by 2026-11-10); defect chips triaged ≥ 3/week.

## Decisions

- Score is share-of-positive, not mean rating (the widget only emits 1/2/5, a mean is meaningless).
- Headline window is 90d, not 30d: at n ≥ 10 the 30d row would grey out most weeks on today's volume.
- Label says who is being scored. PM flagged the gated ask as inflating the ratio by construction; the honesty lives in the label and the fixed gate, not in a hidden denominator.
- Testimonial comp on the positive path: cut (PM). One tap, done.
- Return-visit trigger: cut (Designer). The follow-up gates on the second successful uncapped download only.
- Prompt copy unchanged: the existing "Did this deck come out right?" / "Yes, it worked" / "Something was off" already matches the designer's two-button recommendation in all 10 locales; rewriting it would have cost 10 locale edits for no user-visible gain.

## Test plan

- `src/lib/happyScore.test.ts` (7): love/low counting, sample floor, response rate, rounding.
- `BusinessMetricsService.test.ts` (+2): three windows with asks from the events repo; null asks without a repo.
- `TodaySnapshotService.test.ts` (+2, row count 10→11): 90d row reads the score; unscored under the sample floor.
- `CustomerSignalsService.test.ts` (+1): reason tag in the label.
- `DeckFeedbackPrompt.test.tsx` (+6): ask event once, chip tags the comment, chip-only skip, no chips on positive path, 90/180-day suppression, `tagComment` trims and caps.
- Locale parity: `feedback.*` has 19 keys in all 10 `downloadsx.json` files.
- Full server suite 7192 pass (2 fail in `getPageCount`, the documented pdfinfo environmental failure). Full web suite 3624 pass. `tsc`, web typecheck, oxlint, `pnpm format:check`, `pnpm arch` clean.
- Sonar: not run locally; PR decoration will report.

## Browser check

- [x] Golden path on localhost:3000 at 375px: `/upload` → markdown file → "Convert anyway" → 2-card `.apkg` downloaded, both signed out and after registering a local account; `/downloads` renders for the signed-in user.
- [x] No console errors at 375px from this change (the only error is the pre-existing signed-out 401 on `/api/users/me/preferences`).
- Not rendered locally: the deck-done prompt itself. Local dev has no S3 credentials, so a signed-in deck never persists (`StorageHandler.uploadFile` fails in `persistSyncDeck`) and `/downloads` shows "No decks yet", which is the gate for the prompt. The chip row is covered by the 17 component tests in `DeckFeedbackPrompt.test.tsx`, and the UX reviewer checked the `flex-wrap` CSS at 375px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4itmNnsVzTPhUUYevBZUR
