### PR TITLE
fix: reject an Anki package uploaded as .zip before any conversion

### DIFF
--- a/src/usecases/jobs/jobFailureReason.test.ts
+++ b/src/usecases/jobs/jobFailureReason.test.ts
@@ -452,3 +452,13 @@ describe('jobFailureReasonFromError on worker-flattened errors', () => {
     expect(reason).toMatch(/Job ID job-2/);
   });
 });
+
+describe('jobFailureReasonFromError — Anki deck uploads', () => {
+  it('passes the already-an-Anki-deck message through to the user', () => {
+    const message =
+      "This zip contains an Anki package, so it's already an Anki deck. 2anki converts source files like Notion HTML exports, not existing decks.";
+    expect(jobFailureReasonFromError(new Error(message), 'job-1')).toBe(
+      message
+    );
+  });
+});

--- a/src/usecases/jobs/jobFailureReason.ts
+++ b/src/usecases/jobs/jobFailureReason.ts
@@ -187,6 +187,9 @@ export function jobFailureReasonFromError(
   ) {
     return (error as Error).message;
   }
+  if (error instanceof Error && /already an Anki deck/.test(error.message)) {
+    return error.message;
+  }
   if (
     error instanceof EmptyContentError ||
     hasName(error, 'EmptyContentError')

--- a/src/usecases/uploads/getPackagesFromZip.test.ts
+++ b/src/usecases/uploads/getPackagesFromZip.test.ts
@@ -763,3 +763,29 @@ describe('getPackagesFromZip — encrypted PDFs', () => {
     );
   });
 });
+
+describe('getPackagesFromZip — Anki package renamed as zip', () => {
+  it('rejects the upload before any conversion runs', async () => {
+    const fileNames = ['collection.anki2', 'media', '0', '1', '2'];
+    mockZipHandlerClass.mockImplementation(() => ({
+      build: jest.fn().mockResolvedValue(undefined),
+      getFileNames: jest.fn().mockReturnValue(fileNames),
+      files: fileNames.map((name) => ({ name, contents: 'x' })),
+    }));
+
+    const settings = new CardOption({});
+    const workspace = { location: FAKE_WORKSPACE_LOCATION } as Workspace;
+
+    await expect(
+      getPackagesFromZip(
+        Buffer.from('fake-zip') as unknown as Uint8Array,
+        false,
+        settings,
+        workspace
+      )
+    ).rejects.toThrow(/already an Anki deck/);
+
+    expect(mockPrepareDeck).not.toHaveBeenCalled();
+    expect(mockPrepareDeckInfoOnly).not.toHaveBeenCalled();
+  });
+});

--- a/src/usecases/uploads/getPackagesFromZip.ts
+++ b/src/usecases/uploads/getPackagesFromZip.ts
@@ -18,6 +18,7 @@ import Workspace from '../../lib/parser/WorkSpace';
 import { getMaxUploadCount } from '../../lib/misc/getMaxUploadCount';
 
 import { isZipContentFileSupported } from './isZipContentFileSupported';
+import { ANKI_PACKAGE_ZIP_MESSAGE, isAnkiPackageZip } from './isAnkiPackageZip';
 import { convertAnkiAppDecksFromZip } from './convertAnkiAppDecksFromZip';
 import { getRelevantFiles } from './getRelevantFiles';
 import { enableMarkdownForMarkdownUploads } from './enableMarkdownForMarkdownUploads';
@@ -452,6 +453,10 @@ export const getPackagesFromZip = async (
     settings,
     workspace.location
   );
+
+  if (isAnkiPackageZip(zipHandler.getFileNames())) {
+    throw new Error(ANKI_PACKAGE_ZIP_MESSAGE);
+  }
 
   const ankiAppResult = await convertAnkiAppDecksFromZip(
     zipHandler.files,

--- a/src/usecases/uploads/getRelevantFiles.test.ts
+++ b/src/usecases/uploads/getRelevantFiles.test.ts
@@ -53,3 +53,22 @@ test('includes sibling image files for markdown in flat zip structure', () => {
 
   expect(result.length).toBe(3);
 });
+
+test('does not treat extensionless root entries as sibling images', () => {
+  const mdName = 'Notes.md';
+  const allFiles = [
+    { name: mdName, contents: '# Title' },
+    { name: 'image.png', contents: 'fake-image' },
+    { name: 'photo.webp', contents: 'fake-image' },
+    { name: '0', contents: 'binary' },
+    { name: 'media', contents: '{}' },
+  ];
+
+  const result = getRelevantFiles(mdName, allFiles);
+
+  expect(result.map((f) => f.name)).toEqual([
+    mdName,
+    'image.png',
+    'photo.webp',
+  ]);
+});

--- a/src/usecases/uploads/getRelevantFiles.ts
+++ b/src/usecases/uploads/getRelevantFiles.ts
@@ -1,5 +1,9 @@
 import { File } from '../../lib/zip/zip';
-import { isImageFileEmbedable } from '../../lib/storage/checks';
+
+// Root-level siblings only count as images by extension. An extensionless
+// root entry is never an image; treating it as one is how a renamed .apkg
+// turned every numbered media entry into a "relevant" file (#4409).
+const ROOT_IMAGE_RE = /\.(png|jpe?g|gif|bmp|svg|webp|avif)$/i;
 
 export function getRelevantFiles(fileName: string, allFiles: File[]): File[] {
   const baseName = fileName.replace(/\.[^.]+$/, '');
@@ -11,6 +15,6 @@ export function getRelevantFiles(fileName: string, allFiles: File[]): File[] {
       f.name === fileName ||
       f.name.startsWith(baseName + '/') ||
       f.name.startsWith(baseNameWithoutNotionId + '/') ||
-      (isRootFile && !f.name.includes('/') && isImageFileEmbedable(f.name))
+      (isRootFile && !f.name.includes('/') && ROOT_IMAGE_RE.test(f.name))
   );
 }

--- a/src/usecases/uploads/isAnkiPackageZip.test.ts
+++ b/src/usecases/uploads/isAnkiPackageZip.test.ts
@@ -1,0 +1,24 @@
+import { isAnkiPackageZip } from './isAnkiPackageZip';
+
+describe('isAnkiPackageZip', () => {
+  it.each([
+    ['collection.anki2'],
+    ['collection.anki21'],
+    ['collection.anki21b'],
+  ])('detects a package carrying %s', (collection) => {
+    const names = [collection, 'media', '0', '1', '2'];
+    expect(isAnkiPackageZip(names)).toBe(true);
+  });
+
+  it('ignores a Notion export that happens to contain extensionless files', () => {
+    expect(isAnkiPackageZip(['Page abc.html', 'Page abc/README', '0'])).toBe(
+      false
+    );
+  });
+
+  it('detects a package wrapped in a folder', () => {
+    expect(isAnkiPackageZip(['deck/collection.anki2', 'deck/media'])).toBe(
+      true
+    );
+  });
+});

--- a/src/usecases/uploads/isAnkiPackageZip.ts
+++ b/src/usecases/uploads/isAnkiPackageZip.ts
@@ -1,0 +1,19 @@
+const ANKI_COLLECTION_FILES = new Set([
+  'collection.anki2',
+  'collection.anki21',
+  'collection.anki21b',
+]);
+
+// An .apkg is a zip whose media entries are named by index ("0", "1", …)
+// beside a collection database. Renamed or re-wrapped as .zip it slips past
+// the .apkg extension check, and every numbered entry then looks like a
+// supported extensionless content file — 898 candidates each carrying the
+// other 897 as "relevant" files (#4409).
+export function isAnkiPackageZip(fileNames: readonly string[]): boolean {
+  return fileNames.some((name) =>
+    ANKI_COLLECTION_FILES.has(name.slice(name.lastIndexOf('/') + 1))
+  );
+}
+
+export const ANKI_PACKAGE_ZIP_MESSAGE =
+  "This zip contains an Anki package, so it's already an Anki deck. 2anki converts source files like Notion HTML exports, not existing decks.";

--- a/web/src/pages/WhatsNewPage/changelog/2026-09-12-zip-containing-anki-deck-gets-a-clear-message.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-09-12-zip-containing-anki-deck-gets-a-clear-message.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-09-12-zip-containing-anki-deck-gets-a-clear-message",
+  "date": "2026-09-12",
+  "type": "fix",
+  "title": "Zip uploads that hold an Anki deck get a clear message instead of an empty deck"
+}


### PR DESCRIPTION
## What

A zip that is really an Anki package (root or folder-wrapped `collection.anki2` / `anki21` / `anki21b`) is rejected before any conversion with the "already an Anki deck" message the upload form already renders as its dedicated block. The async failure-reason resolver passes that message through so job-mode uploads see it too. Root-level zip siblings now count as images only by extension, so an extensionless entry can never fan out as a "relevant" file.

## Why

Closes #4409. On 2026-09-11 one 11 MB upload of this shape ran about 800,000 no-op conversions twice, wrote 1 GB of log in six minutes, and gave the user an empty deck. Simpler: the user gets a real answer instead of an empty deck. Metric: `conversion_failed{reason: empty_deck, input_format: zip}` in the ops funnel, read at the next weekly check.

## Decisions made overnight (please review)

- Reject vs auto-route to apkg import: chose reject (pm). The phrase "already an Anki deck" already fires the upload form's dedicated block with the apkg pointers, so no new surface; auto-routing would guess intent. Assumption: a double-wrapped apkg is as often accidental as deliberate. If wrong, route to the apkg-import surface in `getPackagesFromZip` instead of throwing.
- Copy: "This zip contains an Anki package, so it's already an Anki deck. 2anki converts source files like Notion HTML exports, not existing decks." (designer). Second sentence is verbatim from the `.apkg` rejection.
- Scope: detection at any depth (engineer), root-sibling image allowlist widened to webp/avif so flat Notion exports keep those images. Deliberately did NOT change `isZipContentFileSupported`'s extensionless rule (a `README`-style entry is still a candidate) nor add a global candidate cap.

## Tests

- `isAnkiPackageZip.test.ts` (new), `getPackagesFromZip.test.ts` (rejects before PrepareDeck), `getRelevantFiles.test.ts` (extensionless root entries excluded, webp kept), `jobFailureReason.test.ts` (message pass-through). All three behaviour tests fail on `main` and pass here.
- Full server suite: 732 suites passed, 7192 tests; the only failure is the documented `getPageCount` pdfinfo environment case. Web suite: 404 files, 3624 tests green. `pnpm format:check` and `tsc -p . --noEmit` clean.

Sonar: not run locally; PR decoration will report.

Browser check: not applicable — server-side rejection plus a changelog JSON; the upload form block it triggers already exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4itmNnsVzTPhUUYevBZUR
