### PR TITLE
fix: convert .tsv uploads as tab-separated CSV instead of an empty deck

### DIFF
--- a/src/lib/parser/experimental/FallbackParser.test.ts
+++ b/src/lib/parser/experimental/FallbackParser.test.ts
@@ -356,3 +356,19 @@ describe('FallbackParser deck naming', () => {
     expect(decks[0].name).toBe('vocab');
   });
 });
+
+describe('FallbackParser TSV uploads', () => {
+  it('reads a tab-separated .tsv file as cards', () => {
+    const tsv = 'front\tback\nHola\tHello\nAdiós\tGoodbye';
+    const parser = new FallbackParser([
+      { name: 'vocab.tsv', contents: Buffer.from(tsv) },
+    ]);
+    const decks = parser.run({} as any);
+    expect(decks).toHaveLength(1);
+    expect(decks[0].cards).toHaveLength(2);
+    expect(decks[0].cards[0].name).toBe('Hola');
+    expect(decks[0].cards[0].back).toBe('Hello');
+    expect(decks[0].cards[1].name).toBe('Adiós');
+    expect(decks[0].cards[1].back).toBe('Goodbye');
+  });
+});

--- a/src/lib/storage/checks.test.ts
+++ b/src/lib/storage/checks.test.ts
@@ -1,4 +1,5 @@
 import {
+  isCSVFile,
   hasMarkdownFileName,
   isCompressedFile,
   isAnkiDeckFile,
@@ -85,4 +86,16 @@ test('isAnkiAppExportXml rejects non-deck content', () => {
   expect(isAnkiAppExportXml('<decks><deck/></decks>')).toBe(false);
   expect(isAnkiAppExportXml('plain text')).toBe(false);
   expect(isAnkiAppExportXml(Buffer.from([0x50, 0x4b, 0x03, 0x04]))).toBe(false);
+});
+
+test('isCSVFile accepts .csv and .tsv regardless of case', () => {
+  expect(Boolean(isCSVFile('cards.csv'))).toBe(true);
+  expect(Boolean(isCSVFile('cards.TSV'))).toBe(true);
+  expect(Boolean(isCSVFile('cards.tsv'))).toBe(true);
+});
+
+test('isCSVFile rejects other extensions and bare names', () => {
+  expect(Boolean(isCSVFile('cards.txt'))).toBe(false);
+  expect(Boolean(isCSVFile('csv'))).toBe(false);
+  expect(Boolean(isCSVFile('mycsv'))).toBe(false);
 });

--- a/src/lib/storage/checks.ts
+++ b/src/lib/storage/checks.ts
@@ -22,7 +22,7 @@ export const isImageFileEmbedable = (url: string) => {
   return isLocalPath && !hasTraversal;
 };
 
-export const isCSVFile = (fileName: string) => /.csv$/i.exec(fileName);
+export const isCSVFile = (fileName: string) => /\.(csv|tsv)$/i.exec(fileName);
 
 export const isDocxFile = (fileName: string) => /\.(docx|doc)$/i.exec(fileName);
 

--- a/web/src/pages/UploadPage/helpers/getAcceptedContentTypes.ts
+++ b/web/src/pages/UploadPage/helpers/getAcceptedContentTypes.ts
@@ -9,6 +9,7 @@ export default function getAcceptedContentTypes(): string {
     '.zip',
     '.html',
     '.csv',
+    '.tsv',
     '.md',
     '.pdf',
     '.ppt',

--- a/web/src/pages/WhatsNewPage/changelog/2026-09-12-tsv-files-convert-like-csv.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-09-12-tsv-files-convert-like-csv.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-09-12-tsv-files-convert-like-csv",
+  "date": "2026-09-12",
+  "type": "fix",
+  "title": "Tab-separated .tsv files convert to decks the same way .csv files do"
+}


### PR DESCRIPTION
## What

`.tsv` uploads convert through the existing CSV reader (which already sniffs the delimiter), and the upload file picker accepts `.tsv`. One regex in `isCSVFile`, one entry in the accept list, a changelog entry, and tests.

## Why

Closes #4399. Prod events, 30 days to 2026-09-11: 26 `.tsv` attempts, 0 successes, all `empty_deck`; `.csv` in the same window had 271 successes. Simpler: a common export format stops dead-ending. Metric: `conversion_failed{input_format: tsv}` in the ops funnel at the next weekly check.

## Tests

- `FallbackParser.test.ts`: a tab-separated `.tsv` with a header yields two cards with the right front/back (fails on `main`, passes here).
- `checks.test.ts`: `isCSVFile` accepts `.csv`/`.tsv` any case, rejects `.txt` and bare names.
- Full server suite green apart from the documented `getPageCount` pdfinfo environment case. Server `tsc`, tree-wide `format:check`, web typecheck and lint clean (two pre-existing lint warnings in MindmapEditor untouched).

Sonar: not run locally; PR decoration will report.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: `pnpm --filter 2anki-web test:golden-path` 4/4 green on this branch (the machine-backed form of the attestation). The only web change is one extension added to the file picker's accept list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4itmNnsVzTPhUUYevBZUR
