### PR TITLE
chore: log upload files as extension plus hash, not names

### DIFF
--- a/src/infrastracture/adapters/fileConversion/PrepareDeck.test.ts
+++ b/src/infrastracture/adapters/fileConversion/PrepareDeck.test.ts
@@ -721,8 +721,8 @@ describe('PrepareDeck — duplicate-name dedup', () => {
       '[PrepareDeck] received',
       expect.objectContaining({
         count: 1,
-        names: ['anatomy.pdf'],
-        sources: ['anatomy.pdf'],
+        extensions: { pdf: 1 },
+        sample: [expect.stringMatching(/^pdf:[0-9a-f]{8}$/)],
       })
     );
   });

--- a/src/infrastracture/adapters/fileConversion/PrepareDeck.ts
+++ b/src/infrastracture/adapters/fileConversion/PrepareDeck.ts
@@ -50,6 +50,10 @@ import type { InducedRescue } from '../../../lib/parser/induction/candidateRules
 import CustomExporter from '../../../lib/parser/exporters/CustomExporter';
 import Workspace from '../../../lib/parser/WorkSpace';
 import path from 'path';
+import {
+  logFileLabel,
+  summarizeFileNames,
+} from '../../../lib/logging/logFileLabel';
 import { writeWorkspaceFile } from './writeWorkspaceFile';
 import { writePdfImageFallbackMarker } from './pdfImageFallbackMarker';
 import { mediaFilesForHtmlFile } from './mediaFilesForHtmlFile';
@@ -175,9 +179,8 @@ async function convertFile(
   if (!file.contents) return null;
 
   console.info('[PrepareDeck] convertFile start', {
-    name: file.name,
+    file: logFileLabel(file.name),
     workspaceLocation: input.workspace.location,
-    mimetype: file.name.split('.').pop() ?? 'unknown',
   });
 
   const t0 = Date.now();
@@ -743,16 +746,12 @@ export async function PrepareDeck(
 
   const files = dedupeFilesByName(input.files);
 
-  console.info('[PrepareDeck] received', {
-    count: files.length,
-    names: files.map((f) => f.name),
-    sources: files.map((f) => f.name.slice(0, 60)),
-  });
+  const fileSummary = summarizeFileNames(files.map((f) => f.name));
+  console.info('[PrepareDeck] received', fileSummary);
 
   console.log('[PrepareDeck] start', {
-    name: input.name,
+    name: logFileLabel(input.name),
     fileCount: files.length,
-    fileNames: files.map((f) => f.name),
     claudeEnabled: input.settings.claudeAIFlashcards,
     noLimits: input.noLimits,
   });

--- a/src/infrastracture/adapters/fileConversion/documentStructureCensus.test.ts
+++ b/src/infrastracture/adapters/fileConversion/documentStructureCensus.test.ts
@@ -137,11 +137,11 @@ describe('censusUploadedFile — zip archives (#4029)', () => {
     expect(entries).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          name: 'Private & Shared/Bony Page abc123.html',
+          name: expect.stringMatching(/^html:[0-9a-f]{8}$/),
           supported: true,
         }),
         expect.objectContaining({
-          name: 'assets/photo.png',
+          name: expect.stringMatching(/^png:[0-9a-f]{8}$/),
           supported: false,
         }),
       ])

--- a/src/infrastracture/adapters/fileConversion/documentStructureCensus.ts
+++ b/src/infrastracture/adapters/fileConversion/documentStructureCensus.ts
@@ -1,4 +1,5 @@
 import * as cheerio from 'cheerio';
+import { logFileLabel } from '../../../lib/logging/logFileLabel';
 import { unzipSync } from 'fflate';
 
 import { convertDocxToHTML } from './convertDocxToHTML';
@@ -35,7 +36,6 @@ export interface ZipStructureCensus {
 }
 
 const ZIP_CENSUS_MAX_ENTRIES = 50;
-const ZIP_CENSUS_MAX_NAME = 120;
 
 // Central-directory walk only — the filter always returns false, so no entry
 // ever inflates and a zip bomb cannot hurt the diagnostics path.
@@ -66,7 +66,7 @@ export function censusZipEntries(buffer: Buffer): ZipStructureCensus {
   const nested = all.filter((e) => /\.zip$/i.test(e.name));
   const flat = all.filter((e) => !/\.zip$/i.test(e.name));
   const entries = all.slice(0, ZIP_CENSUS_MAX_ENTRIES).map((e) => ({
-    name: e.name.slice(0, ZIP_CENSUS_MAX_NAME),
+    name: logFileLabel(e.name),
     size: e.size,
     supported: Boolean(isZipContentFileSupported(e.name)),
   }));

--- a/src/lib/logging/logFileLabel.test.ts
+++ b/src/lib/logging/logFileLabel.test.ts
@@ -1,0 +1,31 @@
+import { logFileLabel, summarizeFileNames } from './logFileLabel';
+
+describe('logFileLabel', () => {
+  it('keeps the extension and a stable hash, never the name', () => {
+    const label = logFileLabel('Immunology Week 3/Screenshot 2026-09-08.PNG');
+    expect(label).toMatch(/^png:[0-9a-f]{8}$/);
+    expect(label).not.toContain('Immunology');
+    expect(logFileLabel('Immunology Week 3/Screenshot 2026-09-08.PNG')).toBe(
+      label
+    );
+  });
+
+  it('labels extensionless and dotted-folder names as none', () => {
+    expect(logFileLabel('media')).toMatch(/^none:/);
+    expect(logFileLabel('v1.2/README')).toMatch(/^none:/);
+  });
+});
+
+describe('summarizeFileNames', () => {
+  it('reports counts per extension and a bounded sample', () => {
+    const names = Array.from({ length: 12 }, (_, i) => `${i}`).concat([
+      'Anatomy.html',
+      'Anatomy/img.png',
+    ]);
+    const summary = summarizeFileNames(names);
+    expect(summary.count).toBe(14);
+    expect(summary.extensions).toEqual({ none: 12, html: 1, png: 1 });
+    expect(summary.sample).toHaveLength(5);
+    expect(JSON.stringify(summary)).not.toContain('Anatomy');
+  });
+});

--- a/src/lib/logging/logFileLabel.ts
+++ b/src/lib/logging/logFileLabel.ts
@@ -1,0 +1,33 @@
+import { createHash } from 'node:crypto';
+
+// Upload file names are deck titles in disguise (Notion exports name the HTML
+// after the page, PDFs after the course). Logs keep a correlation key and the
+// extension, never the name (#4410).
+export function logFileLabel(name: string): string {
+  const dot = name.lastIndexOf('.');
+  const slash = name.lastIndexOf('/');
+  const extension = dot > slash ? name.slice(dot + 1).toLowerCase() : 'none';
+  const digest = createHash('sha1').update(name).digest('hex').slice(0, 8);
+  return `${extension}:${digest}`;
+}
+
+export interface FileListSummary {
+  count: number;
+  extensions: Record<string, number>;
+  sample: string[];
+}
+
+const SAMPLE_SIZE = 5;
+
+export function summarizeFileNames(names: readonly string[]): FileListSummary {
+  const extensions: Record<string, number> = {};
+  for (const name of names) {
+    const extension = logFileLabel(name).split(':')[0];
+    extensions[extension] = (extensions[extension] ?? 0) + 1;
+  }
+  return {
+    count: names.length,
+    extensions,
+    sample: names.slice(0, SAMPLE_SIZE).map(logFileLabel),
+  };
+}

--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -542,7 +542,7 @@ describe('UploadService.handleUpload — error paths', () => {
       expect(capturedStatus()).toBe(400);
       expect(errorSpy).not.toHaveBeenCalled();
       expect(infoSpy).toHaveBeenCalledWith(
-        expect.stringContaining('<details>')
+        expect.stringContaining('<details=true')
       );
     } finally {
       infoSpy.mockRestore();

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -26,6 +26,7 @@ import type {
   UploadIdentityStats,
 } from '../lib/parser/DeckParser';
 import StorageHandler from '../lib/storage/StorageHandler';
+import { logFileLabel } from '../lib/logging/logFileLabel';
 import { UploadedFile } from '../lib/storage/types';
 import GeneratePackagesUseCase from '../usecases/uploads/GeneratePackagesUseCase';
 import { toText } from './NotionService/BlockHandler/helpers/deckNameToText';
@@ -334,7 +335,7 @@ function logNoPackageDiagnostics(uploadedFiles: UploadedFile[]) {
   console.info('[no-package] Zero packages produced. File diagnostics:');
   for (const file of uploadedFiles ?? []) {
     console.info(
-      `  name=${file.originalname} mimetype=${file.mimetype} size=${file.size}`
+      `  file=${logFileLabel(file.originalname)} mimetype=${file.mimetype} size=${file.size}`
     );
     try {
       const contents = file.path ? fs.readFileSync(file.path) : file.buffer;
@@ -351,7 +352,6 @@ function logNoPackageDiagnostics(uploadedFiles: UploadedFile[]) {
         const hasDisplayContents = head.includes('display:contents');
         const hasToggleClass = head.includes('class="toggle"');
         const hasDetails = head.includes('<details');
-        console.info(`  snippet=${JSON.stringify(head.slice(0, 300))}`);
         console.info(
           `  display:contents=${hasDisplayContents} .toggle=${hasToggleClass} <details=${hasDetails}`
         );
@@ -363,7 +363,7 @@ function logNoPackageDiagnostics(uploadedFiles: UploadedFile[]) {
         .then((census) => {
           if (census != null) {
             console.info(
-              `  census=${JSON.stringify(census)} name=${file.originalname}`
+              `  census=${JSON.stringify(census)} file=${logFileLabel(file.originalname)}`
             );
           }
         })


### PR DESCRIPTION
## What

A small `logFileLabel` helper (`src/lib/logging/`) turns an upload file name into `ext:hash8`, and `summarizeFileNames` turns a list into counts per extension plus a five-label sample. The three PrepareDeck lines (`received`, `start`, `convertFile start`) and the zero-package diagnostics in UploadService use them. The diagnostics no longer print a 300-character content snippet; the structural flags it fed (`display:contents`, `.toggle`, `<details`) stay.

## Why

Closes #4410. Prod logs carried page titles, screenshot paths and course names in every conversion, and the `[PrepareDeck] received` line listing all names is also the amplifier behind the 1 GB burst in #4409. Internal only: no user-visible change, no changelog entry.

## Tests

- `logFileLabel.test.ts` (new): label shape, stability, no name leakage, bounded sample.
- `PrepareDeck.test.ts` assertion updated to the summary shape; `UploadService.test.ts` diagnostics test now asserts on the `<details=true` flag line instead of the snippet.
- Full server suite green apart from the documented `getPageCount` pdfinfo environment case; `tsc`, tree-wide `format:check` clean.

Not changed here: the per-format `convertFile <kind>` lines still log `file: file.name` one line each; they are not amplifiers and can follow once this shape settles.

Sonar: not run locally; PR decoration will report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4itmNnsVzTPhUUYevBZUR
