### PR TITLE
fix: keep raw <img> tags in markdown as images instead of escaped text

### DIFF
--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -225,4 +225,37 @@ describe('markdownToHTML', () => {
       expect(result).toContain('&lt;blockquote&gt;');
     });
   });
+
+  describe('raw <img> tags in markdown (regression: #4403)', () => {
+    it('restores an inline base64 image instead of escaping it into text', () => {
+      const src = 'data:image/png;base64,iVBORw0KGgo=';
+      const result = markdownToHTML(`Look: <img src="${src}" alt="cell">`);
+      expect(result).toContain(`<img src="${src}" alt="cell">`);
+      expect(result).not.toContain('&lt;img');
+    });
+
+    it('restores a relative image path so the zip embed step can pick it up', () => {
+      const result = markdownToHTML("<img src='images/heart.png'>");
+      expect(result).toContain('<img src="images/heart.png">');
+    });
+
+    it('keeps only src and alt, dropping event handler attributes', () => {
+      const result = markdownToHTML(
+        '<img src="x.png" onerror="alert(1)" alt="a">'
+      );
+      expect(result).toContain('<img src="x.png" alt="a">');
+      expect(result).not.toContain('onerror');
+    });
+
+    it('leaves an image with a script scheme escaped', () => {
+      const result = markdownToHTML('<img src="javascript:alert(1)">');
+      expect(result).not.toContain('<img');
+      expect(result).toContain('&lt;img');
+    });
+
+    it('restores images in the inline (front) render too', () => {
+      const result = markdownToInlineHTML('<img src="a.png">');
+      expect(result).toContain('<img src="a.png">');
+    });
+  });
 });

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -36,10 +36,11 @@ const decodeAttributeEntities = (text: string): string =>
     .replaceAll('&#39;', "'")
     .replaceAll('&amp;', '&');
 
-const attributeValue = (attributes: string, name: string): string | null => {
-  const match = new RegExp(`\\b${name}=(?:"([^"]*)"|'([^']*)')`, 'i').exec(
-    attributes
-  );
+const SRC_ATTRIBUTE_RE = /\bsrc=(?:"([^"]*)"|'([^']*)')/i;
+const ALT_ATTRIBUTE_RE = /\balt=(?:"([^"]*)"|'([^']*)')/i;
+
+const attributeValue = (attributes: string, re: RegExp): string | null => {
+  const match = re.exec(attributes);
   if (!match) return null;
   return match[1] ?? match[2] ?? '';
 };
@@ -47,9 +48,9 @@ const attributeValue = (attributes: string, name: string): string | null => {
 const restoreEscapedImages = (html: string): string =>
   html.replace(ESCAPED_IMG_RE, (whole, rawAttributes: string) => {
     const attributes = decodeAttributeEntities(rawAttributes);
-    const src = attributeValue(attributes, 'src');
+    const src = attributeValue(attributes, SRC_ATTRIBUTE_RE);
     if (!src || !IMAGE_SRC_SCHEME_RE.test(src)) return whole;
-    const alt = attributeValue(attributes, 'alt');
+    const alt = attributeValue(attributes, ALT_ATTRIBUTE_RE);
     const altAttribute =
       alt == null ? '' : ` alt="${alt.replaceAll('"', '&quot;')}"`;
     return `<img src="${src.replaceAll('"', '&quot;')}"${altAttribute}>`;

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -23,14 +23,46 @@ const ESCAPED_CARD_SAFE_TAG_RE = new RegExp(
 const restoreCardSafeTags = (html: string): string =>
   html.replace(ESCAPED_CARD_SAFE_TAG_RE, '<$1>');
 
+// markdown-it runs with html:false, so a raw <img> in a document arrives as
+// escaped text and Anki shows the base64 of an inline image as a wall of
+// characters (#4403). Rebuild the tag from src and alt only; every other
+// attribute (event handlers included) stays dropped.
+const ESCAPED_IMG_RE = /&lt;img\b([^&]*?(?:&(?!gt;)[^&]*?)*)\/?&gt;/gi;
+const IMAGE_SRC_SCHEME_RE = /^(?:data:image\/|https?:\/\/|[^:]*$)/i;
+
+const decodeAttributeEntities = (text: string): string =>
+  text
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, '&');
+
+const attributeValue = (attributes: string, name: string): string | null => {
+  const match = new RegExp(`\\b${name}=(?:"([^"]*)"|'([^']*)')`, 'i').exec(
+    attributes
+  );
+  if (!match) return null;
+  return match[1] ?? match[2] ?? '';
+};
+
+const restoreEscapedImages = (html: string): string =>
+  html.replace(ESCAPED_IMG_RE, (whole, rawAttributes: string) => {
+    const attributes = decodeAttributeEntities(rawAttributes);
+    const src = attributeValue(attributes, 'src');
+    if (!src || !IMAGE_SRC_SCHEME_RE.test(src)) return whole;
+    const alt = attributeValue(attributes, 'alt');
+    const altAttribute =
+      alt == null ? '' : ` alt="${alt.replace(/"/g, '&quot;')}"`;
+    return `<img src="${src.replace(/"/g, '&quot;')}"${altAttribute}>`;
+  });
+
 export const markdownToHTML = (
   html: string,
   trimWhitespace: boolean = false
 ) => {
   const stripped = html.replace(ASIDE_TAG_RE, '');
   const input = trimWhitespace ? stripped.trim() : stripped;
-  return restoreCardSafeTags(md.render(input));
+  return restoreEscapedImages(restoreCardSafeTags(md.render(input)));
 };
 
 export const markdownToInlineHTML = (text: string) =>
-  restoreCardSafeTags(md.renderInline(text));
+  restoreEscapedImages(restoreCardSafeTags(md.renderInline(text)));

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -32,9 +32,9 @@ const IMAGE_SRC_SCHEME_RE = /^(?:data:image\/|https?:\/\/|[^:]*$)/i;
 
 const decodeAttributeEntities = (text: string): string =>
   text
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&amp;/g, '&');
+    .replaceAll('&quot;', '"')
+    .replaceAll('&#39;', "'")
+    .replaceAll('&amp;', '&');
 
 const attributeValue = (attributes: string, name: string): string | null => {
   const match = new RegExp(`\\b${name}=(?:"([^"]*)"|'([^']*)')`, 'i').exec(
@@ -51,8 +51,8 @@ const restoreEscapedImages = (html: string): string =>
     if (!src || !IMAGE_SRC_SCHEME_RE.test(src)) return whole;
     const alt = attributeValue(attributes, 'alt');
     const altAttribute =
-      alt == null ? '' : ` alt="${alt.replace(/"/g, '&quot;')}"`;
-    return `<img src="${src.replace(/"/g, '&quot;')}"${altAttribute}>`;
+      alt == null ? '' : ` alt="${alt.replaceAll('"', '&quot;')}"`;
+    return `<img src="${src.replaceAll('"', '&quot;')}"${altAttribute}>`;
   });
 
 export const markdownToHTML = (

--- a/web/src/pages/WhatsNewPage/changelog/2026-09-12-inline-images-in-markdown-render-as-images.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-09-12-inline-images-in-markdown-render-as-images.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-09-12-inline-images-in-markdown-render-as-images",
+  "date": "2026-09-12",
+  "type": "fix",
+  "title": "Markdown files with HTML image tags keep the picture on the card instead of showing raw code"
+}


### PR DESCRIPTION
## What

`markdownToHTML` and `markdownToInlineHTML` restore an escaped `<img>` after rendering, rebuilt from `src` and `alt` only. Allowed sources: `data:image/…`, `http(s)://`, and scheme-less relative paths. Anything else (a `javascript:` source, an image without `src`) stays escaped exactly as before, and attributes such as `onerror` never come back.

## Why

Closes #4403. A prod sample on 2026-09-11 found recent page decks whose Back field held `&lt;img src=&quot;data:image/png;base64,…` as literal text, so the card showed base64 instead of the picture. Cause: markdown-it runs with `html: false`, and the existing card-safe-tag restore only covers bare formatting tags. More beautiful: the picture the user put in the document is the picture on the card. Metric: none beyond the golden fixtures; the shape is not instrumented.

## Tests

- `markdown.test.ts`: five new cases (base64 image restored, relative path restored, handlers dropped, script scheme stays escaped, inline render). Four fail on `main`, pass here.
- Full server suite green apart from the documented `getPageCount` pdfinfo environment case. `tsc`, format, lint clean.

Sonar: not run locally; PR decoration will report.

Browser check: not applicable — server-side markdown rendering plus a changelog JSON, no web code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4itmNnsVzTPhUUYevBZUR
