### PR TITLE
fix: warn when basic-mode cards carry cloze syntax

### DIFF
--- a/src/infrastracture/adapters/fileConversion/PrepareDeck.test.ts
+++ b/src/infrastracture/adapters/fileConversion/PrepareDeck.test.ts
@@ -1,4 +1,4 @@
-import { PrepareDeck, prepareDeckInfoOnly } from './PrepareDeck';
+import { PrepareDeck, parserWarning, prepareDeckInfoOnly } from './PrepareDeck';
 import CardOption from '../../../lib/parser/Settings/CardOption';
 
 jest.mock('../../../lib/claude/ClaudeService', () => {
@@ -998,5 +998,25 @@ describe('assembleParserFiles — both build paths share one file set', () => {
     const all = assembleParserFiles([original], []);
 
     expect(all).toEqual([original]);
+  });
+});
+
+describe('parserWarning', () => {
+  it('reports stray cloze markup as a coded count', () => {
+    expect(parserWarning({ usedHeuristic: false, strayClozeCount: 3 })).toBe(
+      'stray-cloze:3'
+    );
+  });
+
+  it('lets the markdown heuristic outrank stray cloze markup', () => {
+    expect(parserWarning({ usedHeuristic: true, strayClozeCount: 3 })).toBe(
+      'markdown-heuristic'
+    );
+  });
+
+  it('is silent when nothing happened', () => {
+    expect(
+      parserWarning({ usedHeuristic: false, strayClozeCount: 0 })
+    ).toBeUndefined();
   });
 });

--- a/src/infrastracture/adapters/fileConversion/PrepareDeck.ts
+++ b/src/infrastracture/adapters/fileConversion/PrepareDeck.ts
@@ -172,6 +172,19 @@ function shippedInducedRule(
   return induced;
 }
 
+// One coded warning per deck; UploadService turns the code into copy. The
+// markdown heuristic outranks stray cloze markup because it questions the
+// whole deck, not a handful of cards.
+export function parserWarning(parser: {
+  usedHeuristic: boolean;
+  strayClozeCount: number;
+}): string | undefined {
+  if (parser.usedHeuristic) return 'markdown-heuristic';
+  if (parser.strayClozeCount > 0)
+    return `stray-cloze:${parser.strayClozeCount}`;
+  return undefined;
+}
+
 async function convertFile(
   file: DeckParserInput['files'][number],
   input: DeckParserInput
@@ -799,7 +812,7 @@ export async function PrepareDeck(
         cardCount: parser.totalCardCount(),
         mcqCount: 0,
         mcqSkippedCount: 0,
-        warning: parser.usedHeuristic ? 'markdown-heuristic' : undefined,
+        warning: parserWarning(parser),
         droppedImageCount: parser.droppedImageCount,
         expiredNotionImageCount: parser.expiredNotionImageCount,
         emptyBackCount: parser.emptyBackCount,
@@ -838,7 +851,7 @@ export async function PrepareDeck(
     cardCount: parser.totalCardCount(),
     mcqCount,
     mcqSkippedCount,
-    warning: parser.usedHeuristic ? 'markdown-heuristic' : undefined,
+    warning: parserWarning(parser),
     droppedImageCount: parser.droppedImageCount,
     expiredNotionImageCount: parser.expiredNotionImageCount,
     emptyBackCount: parser.emptyBackCount,
@@ -909,7 +922,7 @@ export async function prepareDeckInfoOnly(
         cardCount: 0,
         mcqCount: 0,
         mcqSkippedCount: 0,
-        warning: parser.usedHeuristic ? 'markdown-heuristic' : undefined,
+        warning: parserWarning(parser),
         droppedImageCount: parser.droppedImageCount,
         expiredNotionImageCount: parser.expiredNotionImageCount,
         emptyBackCount: parser.emptyBackCount,
@@ -939,7 +952,7 @@ export async function prepareDeckInfoOnly(
     cardCount: parser.totalCardCount(),
     mcqCount,
     mcqSkippedCount,
-    warning: parser.usedHeuristic ? 'markdown-heuristic' : undefined,
+    warning: parserWarning(parser),
     droppedImageCount: parser.droppedImageCount,
     expiredNotionImageCount: parser.expiredNotionImageCount,
     emptyBackCount: parser.emptyBackCount,

--- a/src/lib/parser/DeckParser.strayCloze.test.ts
+++ b/src/lib/parser/DeckParser.strayCloze.test.ts
@@ -1,0 +1,50 @@
+import { setupTests } from '../../test/configure-jest';
+import CardOption from './Settings/CardOption';
+import { DeckParser } from './DeckParser';
+import Workspace from './WorkSpace';
+
+beforeEach(() => setupTests());
+
+const togglePage = (answer: string): string =>
+  `<html><head><title>Bio</title></head><body><div class="page-body"><ul class="toggle"><li><details open=""><summary>What powers the cell?</summary><p>${answer}</p></details></li></ul></div></body></html>`;
+
+const parse = async (contents: string, cloze: boolean) => {
+  const workspace = new Workspace(true, 'fs');
+  const parser = new DeckParser({
+    name: 'bio.html',
+    settings: new CardOption(cloze ? {} : { cloze: 'false' }),
+    files: [{ name: 'bio.html', contents }],
+    noLimits: true,
+    workspace,
+  });
+  await parser.writeDeckInfo(workspace);
+  return parser;
+};
+
+describe('stray cloze markup on basic-mode cards (#4402)', () => {
+  it('counts a basic card whose answer carries {{c1::…}} and leaves it basic', async () => {
+    const parser = await parse(
+      togglePage('The {{c1::mitochondria}} does.'),
+      false
+    );
+    const cards = parser.payload.flatMap((deck) => deck.cards);
+
+    expect(parser.strayClozeCount).toBe(1);
+    expect(cards).toHaveLength(1);
+    expect(cards[0].cloze).toBe(false);
+    expect(cards[0].name).toContain('What powers the cell?');
+  });
+
+  it('does not count when cloze mode is on', async () => {
+    const parser = await parse(
+      togglePage('The {{c1::mitochondria}} does.'),
+      true
+    );
+    expect(parser.strayClozeCount).toBe(0);
+  });
+
+  it('does not count a basic card without markup', async () => {
+    const parser = await parse(togglePage('The mitochondria does.'), false);
+    expect(parser.strayClozeCount).toBe(0);
+  });
+});

--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -1099,6 +1099,13 @@ export class DeckParser {
     }
   }
 
+  private noteStrayClozeMarkup(card: Note): void {
+    if (card.cloze) return;
+    if (hasClozeMarkup(card.name) || hasClozeMarkup(card.back)) {
+      this.strayClozeCount += 1;
+    }
+  }
+
   private async transformCard(
     card: Note,
     counter: number,
@@ -1116,12 +1123,7 @@ export class DeckParser {
 
     card.enableInput = this.settings.useInput;
     card.cloze = this.settings.isCloze;
-    if (
-      !card.cloze &&
-      (hasClozeMarkup(card.name) || hasClozeMarkup(card.back))
-    ) {
-      this.strayClozeCount += 1;
-    }
+    this.noteStrayClozeMarkup(card);
 
     if (card.cloze) {
       const headerHasCloze = hasInlineClozeCode(card.name);

--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -28,6 +28,7 @@ import Workspace from './WorkSpace';
 import CustomExporter from './exporters/CustomExporter';
 import handleClozeDeletions from './helpers/handleClozeDeletions';
 import hasInlineClozeCode from './helpers/hasInlineClozeCode';
+import hasClozeMarkup from './helpers/hasClozeMarkup';
 import handleOverlappingCloze, {
   OverlappingClozeStyle,
 } from './helpers/handleOverlappingCloze';
@@ -179,6 +180,10 @@ export class DeckParser {
 
   emptyBackCount: number;
 
+  // Basic-mode cards that carry {{cN::…}} markup; Anki renders the braces
+  // literally, so the conversion report warns and offers cloze mode (#4402).
+  strayClozeCount: number;
+
   private readonly knownGuids?: KnownGuids;
 
   private readonly uploadIdentity?: UploadIdentityContext;
@@ -222,6 +227,7 @@ export class DeckParser {
     this.droppedImageCount = 0;
     this.expiredNotionImageCount = 0;
     this.emptyBackCount = 0;
+    this.strayClozeCount = 0;
     this.sawUnclassifiedParse = false;
     this.payload = [];
     this.workspace = input.workspace ?? new Workspace(true, 'fs');
@@ -1110,6 +1116,12 @@ export class DeckParser {
 
     card.enableInput = this.settings.useInput;
     card.cloze = this.settings.isCloze;
+    if (
+      !card.cloze &&
+      (hasClozeMarkup(card.name) || hasClozeMarkup(card.back))
+    ) {
+      this.strayClozeCount += 1;
+    }
 
     if (card.cloze) {
       const headerHasCloze = hasInlineClozeCode(card.name);
@@ -1339,6 +1351,7 @@ export class DeckParser {
     }
 
     this.emptyBackCount = 0;
+    this.strayClozeCount = 0;
     for (const d of this.payload) {
       const deck = d;
       deck.id = get16DigitRandomId();

--- a/src/lib/parser/helpers/hasClozeMarkup.test.ts
+++ b/src/lib/parser/helpers/hasClozeMarkup.test.ts
@@ -1,0 +1,20 @@
+import hasClozeMarkup from './hasClozeMarkup';
+
+describe('hasClozeMarkup', () => {
+  it.each([
+    ['{{c1::mitochondria}}'],
+    ['The <b>{{c2::powerhouse::hint}}</b> of the cell'],
+    ['{{c10::multi\nline}}'],
+  ])('matches Anki cloze syntax in %s', (text) => {
+    expect(hasClozeMarkup(text)).toBe(true);
+  });
+
+  it.each([
+    ['plain text'],
+    ['{{cloze}} template token'],
+    ['{{c1:: }}'.replace(' ', '')],
+    [undefined],
+  ])('ignores %s', (text) => {
+    expect(hasClozeMarkup(text as string | undefined)).toBe(false);
+  });
+});

--- a/src/lib/parser/helpers/hasClozeMarkup.test.ts
+++ b/src/lib/parser/helpers/hasClozeMarkup.test.ts
@@ -12,7 +12,7 @@ describe('hasClozeMarkup', () => {
   it.each([
     ['plain text'],
     ['{{cloze}} template token'],
-    ['{{c1:: }}'.replace(' ', '')],
+    ['{{c1::}}'],
     [undefined],
   ])('ignores %s', (text) => {
     expect(hasClozeMarkup(text as string | undefined)).toBe(false);

--- a/src/lib/parser/helpers/hasClozeMarkup.ts
+++ b/src/lib/parser/helpers/hasClozeMarkup.ts
@@ -1,0 +1,5 @@
+const CLOZE_MARKUP_RE = /{{c\d+::[\s\S]+?}}/;
+
+export default function hasClozeMarkup(text: string | undefined): boolean {
+  return text != null && CLOZE_MARKUP_RE.test(text);
+}

--- a/src/lib/parser/helpers/hasClozeMarkup.ts
+++ b/src/lib/parser/helpers/hasClozeMarkup.ts
@@ -1,4 +1,4 @@
-const CLOZE_MARKUP_RE = /{{c\d+::[\s\S]+?}}/;
+const CLOZE_MARKUP_RE = /{{c\d+::[^}]+}}/;
 
 export default function hasClozeMarkup(text: string | undefined): boolean {
   return text != null && CLOZE_MARKUP_RE.test(text);

--- a/src/lib/parser/helpers/hasClozeMarkup.ts
+++ b/src/lib/parser/helpers/hasClozeMarkup.ts
@@ -1,4 +1,4 @@
-const CLOZE_MARKUP_RE = /{{c\d+::[^}]+}}/;
+const CLOZE_MARKUP_RE = /{{c\d+::[^{}]+}}/;
 
 export default function hasClozeMarkup(text: string | undefined): boolean {
   return text != null && CLOZE_MARKUP_RE.test(text);

--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -4041,6 +4041,9 @@ describe('UploadService.handleUpload — image drops without a vision path (#440
       'image_only_no_text'
     );
     expect(execute).not.toHaveBeenCalled();
+  });
+});
+
 describe('resolveUploadWarning — stray cloze markup', () => {
   it('turns the coded count into user copy, summing across decks', () => {
     expect(resolveUploadWarning(['stray-cloze:2', 'stray-cloze:1'])).toBe(

--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -4044,7 +4044,7 @@ describe('UploadService.handleUpload — image drops without a vision path (#440
 describe('resolveUploadWarning — stray cloze markup', () => {
   it('turns the coded count into user copy, summing across decks', () => {
     expect(resolveUploadWarning(['stray-cloze:2', 'stray-cloze:1'])).toBe(
-      '3 cards contain cloze syntax like {{c1::…}} but cloze mode is off, so the braces show on the card. Turn on cloze mode and convert again.'
+      '3 cards contain cloze syntax like {{c1::text}} but cloze mode is off, so the braces show on the card. Turn on cloze mode and convert again.'
     );
   });
 

--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -76,7 +76,7 @@ import { writePdfImageFallbackMarker } from '../infrastracture/adapters/fileConv
 import type { PhotoToFlashcardsUseCase } from '../usecases/imageOcclusion/PhotoToFlashcardsUseCase';
 import { EmptyDeckError } from '../usecases/jobs/EmptyDeckError';
 import { DeckTooLargeError } from '../lib/parser/exporters/DeckTooLargeError';
-import UploadService from './UploadService';
+import UploadService, { resolveUploadWarning } from './UploadService';
 import { track } from './events/track';
 
 const trackMock = track as jest.Mock;
@@ -4041,5 +4041,22 @@ describe('UploadService.handleUpload — image drops without a vision path (#440
       'image_only_no_text'
     );
     expect(execute).not.toHaveBeenCalled();
+describe('resolveUploadWarning — stray cloze markup', () => {
+  it('turns the coded count into user copy, summing across decks', () => {
+    expect(resolveUploadWarning(['stray-cloze:2', 'stray-cloze:1'])).toBe(
+      '3 cards contain cloze syntax like {{c1::…}} but cloze mode is off, so the braces show on the card. Turn on cloze mode and convert again.'
+    );
+  });
+
+  it('uses the singular for one card', () => {
+    expect(resolveUploadWarning(['stray-cloze:1'])).toMatch(
+      /^1 card contains cloze syntax/
+    );
+  });
+
+  it('keeps the markdown heuristic warning ahead of stray cloze', () => {
+    expect(
+      resolveUploadWarning(['stray-cloze:1', 'markdown-heuristic'])
+    ).toMatch(/heuristic detection/);
   });
 });

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -151,7 +151,16 @@ interface BatchUploadResponse {
 const MARKDOWN_HEURISTIC_WARNING =
   'Your Markdown file was processed using heuristic detection. For reliable results, use the nested bullet format or enable Claude AI in settings.';
 
-function resolveUploadWarning(warnings: string[] | undefined): string | null {
+const STRAY_CLOZE_WARNING_RE = /^stray-cloze:(\d+)$/;
+
+function strayClozeWarning(count: number): string {
+  const subject = count === 1 ? '1 card contains' : `${count} cards contain`;
+  return `${subject} cloze syntax like {{c1::…}} but cloze mode is off, so the braces show on the card. Turn on cloze mode and convert again.`;
+}
+
+export function resolveUploadWarning(
+  warnings: string[] | undefined
+): string | null {
   if (!warnings || warnings.length === 0) return null;
   const passwordWarning = warnings.find((w) =>
     w.includes('password-protected')
@@ -160,6 +169,12 @@ function resolveUploadWarning(warnings: string[] | undefined): string | null {
   if (warnings.includes('markdown-heuristic')) {
     return MARKDOWN_HEURISTIC_WARNING;
   }
+  let strayCloze = 0;
+  for (const warning of warnings) {
+    const match = STRAY_CLOZE_WARNING_RE.exec(warning);
+    if (match) strayCloze += Number(match[1]);
+  }
+  if (strayCloze > 0) return strayClozeWarning(strayCloze);
   return null;
 }
 

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -155,7 +155,7 @@ const STRAY_CLOZE_WARNING_RE = /^stray-cloze:(\d+)$/;
 
 function strayClozeWarning(count: number): string {
   const subject = count === 1 ? '1 card contains' : `${count} cards contain`;
-  return `${subject} cloze syntax like {{c1::…}} but cloze mode is off, so the braces show on the card. Turn on cloze mode and convert again.`;
+  return `${subject} cloze syntax like {{c1::text}} but cloze mode is off, so the braces show on the card. Turn on cloze mode and convert again.`;
 }
 
 export function resolveUploadWarning(

--- a/web/src/pages/WhatsNewPage/changelog/2026-09-12-warn-when-cloze-syntax-found-with-cloze-off.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-09-12-warn-when-cloze-syntax-found-with-cloze-off.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-09-12-warn-when-cloze-syntax-found-with-cloze-off",
+  "date": "2026-09-12",
+  "type": "fix",
+  "title": "Conversion warns when cards contain cloze syntax but cloze mode is off"
+}


### PR DESCRIPTION
## What

When cloze mode is off and a card's front or back contains `{{cN::…}}`, DeckParser counts it. PrepareDeck emits one coded warning per deck (`stray-cloze:<n>`, outranked by the existing markdown-heuristic warning), and UploadService turns the summed count into the `X-Warning` text the upload form already shows. Cards stay basic.

## Why

Closes #4402. Prod sample on 2026-09-11: 14 basic-mode notes across 4 decks carried literal cloze syntax, 13 in the Back field. Simpler: the user learns why the braces show and what to flip, instead of discovering it in Anki. Metric: none instrumented; the report can grow an event once the notice has a click.

## Decisions made overnight (please review)

- Warn, do not auto-convert (pm). 13 of 14 markers sit in the answer; a cloze note's face is the Text field, so auto-converting would promote the answer to the front and demote the question. Assumption: users want their question kept as the front. If wrong, the flip lives at `DeckParser.transformCard` next to the existing back-to-name cloze move.
- Copy (designer): "N cards contain cloze syntax like {{c1::text}} but cloze mode is off, so the braces show on the card. Turn on cloze mode and convert again." Singular form for one card. Swap if you would word it differently.
- Scope: coded warning through the existing single-warning channel; the markdown-heuristic warning keeps priority because it questions the whole deck. Deliberately did NOT build a per-card list, an auto-convert path, or a new header.

## Review round 2

The security fork caught that a Unicode ellipsis in the header value would make Node throw `ERR_INVALID_CHAR` on every upload that tripped the warning. The example is now plain ASCII, verified with `ServerResponse.setHeader`. The marker regex also dropped its lazy any-character body for a no-brace body, so an unterminated marker stays linear.

## Tests

- `hasClozeMarkup.test.ts` (new helper), `DeckParser.strayCloze.test.ts` (basic card with a marker in the answer is counted and stays basic; cloze mode on or no marker counts zero; fails on `main`), `PrepareDeck.test.ts` (`parserWarning` priority), `UploadService.test.ts` (`resolveUploadWarning` copy, summing, singular, priority).
- Full server suite green apart from the documented `getPageCount` pdfinfo environment case; `tsc`, tree-wide `format:check` clean.

Sonar: not run locally; PR decoration will report.

Browser check: not applicable — server-side warning text through the existing `X-Warning` header the form already renders, plus a changelog JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4itmNnsVzTPhUUYevBZUR
