### PR TITLE
fix: answer photo drops without a vision path before parsing

### DIFF
--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -3971,3 +3971,75 @@ describe('UploadService.handleSyncUpload — persisted copy for a signed-in owne
     );
   });
 });
+
+describe('UploadService.handleUpload — image drops without a vision path (#4400)', () => {
+  const imageFile = (name: string) =>
+    ({
+      originalname: name,
+      mimetype: 'image/png',
+      size: 2048,
+      path: `/tmp/${name}`,
+    }) as unknown as Express.Multer.File;
+
+  it('answers an anonymous photo drop with the Photo to Deck pointer before any parse', async () => {
+    const execute = jest.fn().mockResolvedValue({ packages: [] });
+    MockGeneratePackagesUseCase.mockImplementation(
+      () =>
+        ({ execute }) as unknown as InstanceType<typeof GeneratePackagesUseCase>
+    );
+    const service = new UploadService(
+      buildRepository(),
+      {} as JobRepository,
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
+    );
+    const req = buildRequest({
+      files: [imageFile('lecture-page.png')],
+      cookies: { anon_id: 'anon-photo' },
+    } as Partial<express.Request>);
+    const { res, capturedStatus, capturedJson } = buildResponse();
+
+    await service.handleUpload(req, res);
+
+    expect(capturedStatus()).toBe(400);
+    expect((capturedJson() as { code: string }).code).toBe(
+      'image_only_no_text'
+    );
+    expect(execute).not.toHaveBeenCalled();
+    expect(trackMock).not.toHaveBeenCalledWith(
+      'conversion_failed',
+      expect.anything()
+    );
+    expect(trackMock).toHaveBeenCalledWith(
+      'image_only_no_text_shown',
+      expect.objectContaining({ anonymousId: 'anon-photo' })
+    );
+  });
+
+  it('answers a signed-in multi-photo drop the same way instead of parsing', async () => {
+    const execute = jest.fn().mockResolvedValue({ packages: [] });
+    MockGeneratePackagesUseCase.mockImplementation(
+      () =>
+        ({ execute }) as unknown as InstanceType<typeof GeneratePackagesUseCase>
+    );
+    const service = new UploadService(
+      buildRepository(),
+      {} as JobRepository,
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
+    );
+    const req = buildRequest({
+      files: [imageFile('one.png'), imageFile('two.png')],
+    } as Partial<express.Request>);
+    const { res, capturedStatus, capturedJson } = buildResponse();
+    res.locals.owner = 42;
+
+    await service.handleUpload(req, res);
+
+    expect(capturedStatus()).toBe(400);
+    expect((capturedJson() as { code: string }).code).toBe(
+      'image_only_no_text'
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -1536,30 +1536,6 @@ class UploadService {
   // uploader succeeds instead of failing with an empty deck. Anonymous and
   // multi-file image uploads never reach here — they keep the image_only_no_text
   // guidance floor.
-  // Photos never parse as text. Anonymous drops and multi-photo drops have
-  // no vision path on this surface, so answer with the Photo to Deck pointer
-  // before any parse runs; the parse used to run first and file the attempt
-  // as an empty deck in the funnel (#4400).
-  private respondImageOnlyNoText(
-    req: express.Request,
-    res: express.Response,
-    files: UploadedFile[] | undefined
-  ) {
-    const owner = getOwner(res);
-    track('image_only_no_text_shown', {
-      userId: owner != null ? Number(owner) : null,
-      anonymousId: this.resolveAnonId(req),
-      props: { source: this.resolveUploadSource(req) },
-    });
-    const body: ImageOnlyResponse = {
-      code: 'image_only_no_text',
-      message: IMAGE_ONLY_NO_TEXT_MESSAGE,
-      filename: files?.[0]?.originalname ?? 'your file',
-      photoToDeckUrl: '/photo-to-deck',
-    };
-    return res.status(400).json(body);
-  }
-
   private async handleImageUpload(
     req: express.Request,
     res: express.Response,
@@ -1631,6 +1607,30 @@ class UploadService {
       },
     });
     return res.status(200).send(apkg);
+  }
+
+  // Photos never parse as text. Anonymous drops and multi-photo drops have
+  // no vision path on this surface, so answer with the Photo to Deck pointer
+  // before any parse runs; the parse used to run first and file the attempt
+  // as an empty deck in the funnel (#4400).
+  private respondImageOnlyNoText(
+    req: express.Request,
+    res: express.Response,
+    files: UploadedFile[] | undefined
+  ) {
+    const owner = getOwner(res);
+    track('image_only_no_text_shown', {
+      userId: owner != null ? Number(owner) : null,
+      anonymousId: this.resolveAnonId(req),
+      props: { source: this.resolveUploadSource(req) },
+    });
+    const body: ImageOnlyResponse = {
+      code: 'image_only_no_text',
+      message: IMAGE_ONLY_NO_TEXT_MESSAGE,
+      filename: files?.[0]?.originalname ?? 'your file',
+      photoToDeckUrl: '/photo-to-deck',
+    };
+    return res.status(400).json(body);
   }
 
   private respondToImageConversionError(

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -913,6 +913,9 @@ class UploadService {
       if (owner != null && files.length === 1 && isImageOnlyUpload(files)) {
         return await this.handleImageUpload(req, res, String(owner), paying);
       }
+      if (isImageOnlyUpload(files)) {
+        return this.respondImageOnlyNoText(req, res, files);
+      }
 
       if (owner != null && paying && settings.claudeAIFlashcards) {
         return await this.handleAsyncUpload(
@@ -979,19 +982,7 @@ class UploadService {
           return res.status(400).json(body);
         }
         if (isImageOnlyUpload(files)) {
-          const owner = getOwner(res);
-          track('image_only_no_text_shown', {
-            userId: owner != null ? Number(owner) : null,
-            anonymousId: this.resolveAnonId(req),
-            props: { source: this.resolveUploadSource(req) },
-          });
-          const body: ImageOnlyResponse = {
-            code: 'image_only_no_text',
-            message: IMAGE_ONLY_NO_TEXT_MESSAGE,
-            filename,
-            photoToDeckUrl: '/photo-to-deck',
-          };
-          return res.status(400).json(body);
+          return this.respondImageOnlyNoText(req, res, files);
         }
         const body: EmptyDeckResponse = {
           code: 'empty_export',
@@ -1545,6 +1536,30 @@ class UploadService {
   // uploader succeeds instead of failing with an empty deck. Anonymous and
   // multi-file image uploads never reach here — they keep the image_only_no_text
   // guidance floor.
+  // Photos never parse as text. Anonymous drops and multi-photo drops have
+  // no vision path on this surface, so answer with the Photo to Deck pointer
+  // before any parse runs; the parse used to run first and file the attempt
+  // as an empty deck in the funnel (#4400).
+  private respondImageOnlyNoText(
+    req: express.Request,
+    res: express.Response,
+    files: UploadedFile[] | undefined
+  ) {
+    const owner = getOwner(res);
+    track('image_only_no_text_shown', {
+      userId: owner != null ? Number(owner) : null,
+      anonymousId: this.resolveAnonId(req),
+      props: { source: this.resolveUploadSource(req) },
+    });
+    const body: ImageOnlyResponse = {
+      code: 'image_only_no_text',
+      message: IMAGE_ONLY_NO_TEXT_MESSAGE,
+      filename: files?.[0]?.originalname ?? 'your file',
+      photoToDeckUrl: '/photo-to-deck',
+    };
+    return res.status(400).json(body);
+  }
+
   private async handleImageUpload(
     req: express.Request,
     res: express.Response,


### PR DESCRIPTION
## What

`handleUpload` answers any image-only drop that the signed-in single-photo vision path does not take (anonymous users, or more than one photo) with the existing `image_only_no_text` response before the parser runs. The empty-deck catch that used to produce that response now calls the same helper.

## Why

Closes #4400. Prod events, 30 days to 2026-09-11: 42 jpg/png drops on the converter recorded `conversion_failed{reason: empty_deck}`. The users did get the Photo to Deck pointer, but only after a full parse, and the funnel counted each as a failed conversion. Faster: the answer arrives without a parse. Metric: `conversion_failed{input_format: jpg|png}` should drop to zero while `image_only_no_text_shown` carries the count, read at the next weekly check.

## Decisions made overnight (please review)

- Reject with the existing pointer, do not run the vision pipeline for anonymous users (pm). Photo to Deck meters cost by owner; an anonymous AI path would need a new spend cap, which is quota code and off limits unattended. Assumption: a free sign-in is acceptable friction for a photo. If wrong, the anonymous vision route is scoped in the engineer's notes on the issue (pass the anonymous id as owner, drop the `owner != null` gate).
- Copy: kept the shipped `IMAGE_ONLY_NO_TEXT_MESSAGE` and the client block it already triggers. Designer offered a sign-in-first variant ("Sign in to turn it into cards with Photo to Deck. It's free."); not adopted because the client renders this response by code with its own copy and a change would need the ten-locale pass. Swap if you want the sign-in nudge.
- Scope: one early return plus a shared helper. Deliberately did NOT add an anonymous vision path, a multi-photo batch, or new copy.

## Tests

- `UploadService.test.ts`: anonymous single photo and signed-in two-photo drops return `image_only_no_text`, never call the package use case, fire `image_only_no_text_shown`, and never fire `conversion_failed`. Both fail on `main`.
- Existing image-only test (0-card parse path) still passes through the shared helper.
- Full server suite green apart from the documented `getPageCount` pdfinfo environment case; `tsc`, format clean; lint warning count in `UploadService.ts` unchanged at the pre-existing 17.

No changelog entry: the response and the client block are unchanged; only the timing and the funnel label move.

Sonar: not run locally; PR decoration will report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4itmNnsVzTPhUUYevBZUR
