### PR TITLE
feat: return a next step when an MCP deck hits the card cap

### DIFF
--- a/src/services/mcp/McpServerFactory.ts
+++ b/src/services/mcp/McpServerFactory.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 
 import { McpToolsService } from './McpToolsService';
+import type { McpNextStep } from './McpToolsService';
 import {
   McpConvertOptions,
   McpCreateDeckOptions,
@@ -171,10 +172,16 @@ const DECK_RESULT_SHAPE = {
   message: z.string().optional(),
 };
 
-function errorResult(message: string, code = 'error'): ToolResult {
+function errorResult(
+  message: string,
+  code = 'error',
+  nextStep?: McpNextStep
+): ToolResult {
+  const structuredContent: Record<string, unknown> = { code, message };
+  if (nextStep) structuredContent.next_step = { ...nextStep };
   return {
     content: [{ type: 'text', text: message }],
-    structuredContent: { code, message },
+    structuredContent,
     isError: true,
   };
 }
@@ -462,7 +469,11 @@ export function buildMcpServer(context: McpRequestContext): McpServer {
           result.code,
           inputProps
         );
-        return errorResult(result.message, result.code ?? 'convert_failed');
+        return errorResult(
+          result.message,
+          result.code ?? 'convert_failed',
+          result.next_step
+        );
       }
       context.recordToolResult('convert_to_deck', true, undefined, inputProps);
       const raw = result as unknown as Record<string, unknown>;
@@ -556,7 +567,11 @@ export function buildMcpServer(context: McpRequestContext): McpServer {
       );
       if (result.kind === 'error') {
         context.recordToolResult('create_deck', false, result.code);
-        return errorResult(result.message, result.code ?? 'create_failed');
+        return errorResult(
+          result.message,
+          result.code ?? 'create_failed',
+          result.next_step
+        );
       }
       const subdeckCount =
         result.kind === 'deck' && result.applied?.subdecks != null

--- a/src/services/mcp/McpToolsService.test.ts
+++ b/src/services/mcp/McpToolsService.test.ts
@@ -492,12 +492,43 @@ describe('McpToolsService.convertToDeck', () => {
     expect(trackMock).toHaveBeenCalledWith(
       'paywall_shown',
       expect.objectContaining({
-        props: { surface: 'mcp', kind: 'card_count' },
+        props: { source: 'mcp', surface: 'mcp', kind: 'card_count' },
       })
     );
     expect((result as { message: string }).message).toContain(
       'https://2anki.net/pricing?from=mcp'
     );
+    expect(persist).not.toHaveBeenCalled();
+  });
+
+  it('tells create_deck callers how many cards the limit held back', async () => {
+    const uploadEntry: UploadEntrypoint = (_req, res) => {
+      res.redirect('/limit?kind=card_count');
+    };
+    const { service, persist } = makeService({ uploadEntry });
+    trackMock.mockClear();
+    const result = await service.createDeck(
+      [
+        { front: 'What is ATP?', back: 'Energy currency.' },
+        { front: 'What is DNA?', back: 'Heredity molecule.' },
+      ],
+      'Biochemistry',
+      undefined,
+      'owner-9',
+      {}
+    );
+    expect(result).toMatchObject({
+      kind: 'error',
+      code: 'monthly_limit',
+      next_step: {
+        upgrade_url: 'https://2anki.net/pricing?from=mcp',
+        cards_held_back: 2,
+      },
+    });
+    expect((result as { message: string }).message).toMatch(
+      /2 cards were held back — none were created\.$/
+    );
+    expect(trackMock).toHaveBeenCalledTimes(1);
     expect(persist).not.toHaveBeenCalled();
   });
 
@@ -1289,7 +1320,7 @@ describe('McpToolsService.createDeck with subdecks', () => {
       'paywall_shown',
       expect.objectContaining({
         userId: null,
-        props: { surface: 'mcp', kind: 'card_count' },
+        props: { source: 'mcp', surface: 'mcp', kind: 'card_count' },
       })
     );
     expect(persist).not.toHaveBeenCalled();

--- a/src/services/mcp/McpToolsService.test.ts
+++ b/src/services/mcp/McpToolsService.test.ts
@@ -169,6 +169,10 @@ function basicPreview(cards: SampleInput[]): Partial<ApkgPreviewService> {
   return makePreview(basicNoteTypes(), cards);
 }
 
+jest.mock('../events/track', () => ({ track: jest.fn() }));
+import { track } from '../events/track';
+const trackMock = track as jest.Mock;
+
 describe('McpToolsService.listMyDecks', () => {
   it('maps jobs to owner-scoped summaries with download URLs', async () => {
     const { service } = makeService({
@@ -475,13 +479,22 @@ describe('McpToolsService.convertToDeck', () => {
       res.redirect('/limit?kind=card_count');
     };
     const { service, persist } = makeService({ uploadEntry });
+    trackMock.mockClear();
     const result = await service.convertToDeck({ text: 'x' }, 'owner', {});
     expect(result).toEqual({
       kind: 'error',
       code: 'monthly_limit',
       message:
         "You've reached your free limit of 100 cards this month, so this deck wasn't created. Upgrade to Unlimited to keep converting, or wait for your limit to reset next month. Upgrade: https://2anki.net/pricing?from=mcp",
+      next_step: { upgrade_url: 'https://2anki.net/pricing?from=mcp' },
     });
+    expect(trackMock).toHaveBeenCalledTimes(1);
+    expect(trackMock).toHaveBeenCalledWith(
+      'paywall_shown',
+      expect.objectContaining({
+        props: { surface: 'mcp', kind: 'card_count' },
+      })
+    );
     expect((result as { message: string }).message).toContain(
       'https://2anki.net/pricing?from=mcp'
     );
@@ -1261,14 +1274,23 @@ describe('McpToolsService.createDeck with subdecks', () => {
       'owner-9',
       {}
     );
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       kind: 'error',
       code: 'monthly_limit',
-      message:
-        "You've reached your free limit of 100 cards this month, so this deck wasn't created. Upgrade to Unlimited to keep converting, or wait for your limit to reset next month. Upgrade: https://2anki.net/pricing?from=mcp",
+      next_step: {
+        upgrade_url: 'https://2anki.net/pricing?from=mcp',
+        cards_held_back: expect.any(Number),
+      },
     });
-    expect((result as { message: string }).message).toContain(
-      'https://2anki.net/pricing?from=mcp'
+    const message = (result as { message: string }).message;
+    expect(message).toContain('https://2anki.net/pricing?from=mcp');
+    expect(message).toMatch(/\d+ cards were held back — none were created\.$/);
+    expect(trackMock).toHaveBeenCalledWith(
+      'paywall_shown',
+      expect.objectContaining({
+        userId: null,
+        props: { surface: 'mcp', kind: 'card_count' },
+      })
     );
     expect(persist).not.toHaveBeenCalled();
     expect(incrementCardUsage).not.toHaveBeenCalled();

--- a/src/services/mcp/McpToolsService.ts
+++ b/src/services/mcp/McpToolsService.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import { track } from '../events/track';
 import { randomUUID } from 'node:crypto';
 import imageSize from 'image-size';
 
@@ -62,6 +63,35 @@ const MONTHLY_LIMIT_CODE = 'monthly_limit';
 const MONTHLY_LIMIT_MESSAGE =
   "You've reached your free limit of 100 cards this month, so this deck wasn't created. Upgrade to Unlimited to keep converting, or wait for your limit to reset next month. Upgrade: https://2anki.net/pricing?from=mcp";
 const CARD_LIMIT_REDIRECT_PREFIX = '/limit?kind=card_count';
+const UPGRADE_URL = 'https://2anki.net/pricing?from=mcp';
+
+// MCP owners are the OAuth user id as a string; anything else has no user row.
+function ownerToUserId(owner: string): number | null {
+  const id = Number(owner);
+  return Number.isInteger(id) && id > 0 ? id : null;
+}
+
+function heldBackSentence(count: number): string {
+  if (count === 1) return " 1 card was held back — it wasn't created.";
+  return ` ${count} cards were held back — none were created.`;
+}
+
+function monthlyLimitResult(
+  owner: string,
+  cardsHeldBack?: number
+): ConvertResult {
+  track('paywall_shown', {
+    userId: ownerToUserId(owner),
+    props: { surface: 'mcp', kind: 'card_count' },
+  });
+  const next_step: McpNextStep = { upgrade_url: UPGRADE_URL };
+  let message = MONTHLY_LIMIT_MESSAGE;
+  if (cardsHeldBack != null && cardsHeldBack > 0) {
+    next_step.cards_held_back = cardsHeldBack;
+    message += heldBackSentence(cardsHeldBack);
+  }
+  return { kind: 'error', code: MONTHLY_LIMIT_CODE, message, next_step };
+}
 const OVER_SIZE_MESSAGE =
   'These cards are over the 5 MB limit. Split into smaller decks.';
 const NO_CARD_CODES = new Set(['markdown_likely_lossy', 'empty_export']);
@@ -196,7 +226,15 @@ export type ConvertResult =
       ignored?: IgnoredOption[];
       summary: string;
     }
-  | { kind: 'error'; message: string; code?: string };
+  | { kind: 'error'; message: string; code?: string; next_step?: McpNextStep };
+
+// Attached to a monthly-limit error so the assistant can relay the way past
+// the cap in the same turn (#4393). The link is the pricing page already in
+// the message; no checkout deep link, which would need payment code.
+export interface McpNextStep {
+  cards_held_back?: number;
+  upgrade_url: string;
+}
 
 export interface ConvertInput {
   url?: string;
@@ -498,7 +536,7 @@ export class McpToolsService {
       deckName: title,
       ...mcpOptionsToCardSettings(options),
     });
-    const result = await this.mapUploadResult(res, owner, title);
+    const result = await this.mapUploadResult(res, owner, title, cards.length);
     if (result.kind === 'error') {
       return this.everyBackEmpty(cards)
         ? { ...result, message: EMPTY_BACK_MESSAGE }
@@ -553,11 +591,7 @@ export class McpToolsService {
       });
     } catch (error) {
       if (error instanceof MonthlyLimitError) {
-        return {
-          kind: 'error',
-          code: MONTHLY_LIMIT_CODE,
-          message: MONTHLY_LIMIT_MESSAGE,
-        };
+        return monthlyLimitResult(owner, totalCards);
       }
       throw error;
     }
@@ -769,7 +803,8 @@ export class McpToolsService {
   private async mapUploadResult(
     res: CapturingResponse,
     owner: string,
-    fallbackTitle: string
+    fallbackTitle: string,
+    candidateCards?: number
   ): Promise<ConvertResult> {
     if (res.statusCode === 202 && this.isJobBody(res.body)) {
       return {
@@ -794,11 +829,7 @@ export class McpToolsService {
       return this.persistDeckResult(res.bodyBuffer, res, owner, fallbackTitle);
     }
     if (res.redirectedTo?.startsWith(CARD_LIMIT_REDIRECT_PREFIX)) {
-      return {
-        kind: 'error',
-        code: MONTHLY_LIMIT_CODE,
-        message: MONTHLY_LIMIT_MESSAGE,
-      };
+      return monthlyLimitResult(owner, candidateCards);
     }
     const code = this.errorCode(res.body);
     return {

--- a/src/services/mcp/McpToolsService.ts
+++ b/src/services/mcp/McpToolsService.ts
@@ -82,7 +82,7 @@ function monthlyLimitResult(
 ): ConvertResult {
   track('paywall_shown', {
     userId: ownerToUserId(owner),
-    props: { surface: 'mcp', kind: 'card_count' },
+    props: { source: 'mcp', surface: 'mcp', kind: 'card_count' },
   });
   const next_step: McpNextStep = { upgrade_url: UPGRADE_URL };
   let message = MONTHLY_LIMIT_MESSAGE;

--- a/web/src/pages/WhatsNewPage/changelog/2026-09-12-assistant-card-cap-shows-the-way-past-it.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-09-12-assistant-card-cap-shows-the-way-past-it.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-09-12-assistant-card-cap-shows-the-way-past-it",
+  "date": "2026-09-12",
+  "type": "feature",
+  "title": "Decks made from Claude or ChatGPT say how many cards the free limit held back and where to unlock more"
+}


### PR DESCRIPTION
## What

When `create_deck` or `convert_to_deck` is blocked by the monthly card cap, the error result carries `next_step: { upgrade_url, cards_held_back? }` in `structuredContent`, and the message gains one sentence with the held-back count when it is known (the subdeck path and `create_deck` know it; the `convert_to_deck` upload path blocks before counting). The same branch fires `paywall_shown{surface: 'mcp', kind: 'card_count'}` once per blocked call. Caps unchanged.

## Why

Closes #4393. The assistant channel made 184 accounts in 90 days and 9 paid; only 16 ever reached the web app where the cap is explained. Simpler: the way past the cap is in the same turn. Metric: `paywall_shown{surface: mcp}` → `checkout_completed` for `/mcp`-origin accounts, read 30 days after merge against the 9-of-184 baseline in the issue.

## Decisions made overnight (please review)

- The issue assumed MCP truncates a deck; it does not, the tool refuses the whole deck at the cap (pm and engineer both confirmed). So `cards_held_back` is the candidate count that was refused, and the sentence reads "N cards were held back — none were created." Assumption: that phrasing is honest for a refusal. If you would rather MCP deliver a partial deck under the cap, that is a cap-semantics change for its own spec.
- Link: the pricing page with `?from=mcp`, already in the message. No Day Pass checkout deep link: it would need a Stripe session or a new checkout route, which is payment code. Swap once a no-auth pass link exists.
- Event fires from the tools service, not the router, so the subdeck branch (which never reached the upload service's `paywall_shown`) is covered too. User id resolves through the same owner-string rule Photo to Deck uses; a non-numeric owner records null.
- Scope: deliberately did NOT add an anonymous-cap branch (MCP is OAuth-only), partial delivery, or a typed props union.

## Tests

- `McpToolsService.test.ts`: the upload-redirect block returns `next_step` with the link and fires one `paywall_shown{surface: mcp}`; the subdeck block returns the count, the held-back sentence, and the event. Both cases were extended from the existing monthly-limit tests.
- `McpServerFactory.test.ts` unchanged and green; `next_step` passes through `errorResult` into `structuredContent`.
- Full server suite green apart from the documented `getPageCount` pdfinfo environment case; `tsc`, tree-wide `format:check` clean.

Hard rails: none touched. `src/lib/isPaying.ts` is read, not edited; the pricing URL is a string literal.

Sonar: not run locally; PR decoration will report.

Browser check: not applicable — MCP tool result and a changelog JSON, no web code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4itmNnsVzTPhUUYevBZUR
