### PR TITLE
test: import generated decks with real Anki and re-import them

### DIFF
--- a/create_deck/requirements.txt
+++ b/create_deck/requirements.txt
@@ -6,3 +6,7 @@ pylint>=4.0.5
 ftfy~=6.3.1
 pytest
 mock
+# Test-only: Anki's own importer drives tests/test_anki_import.py to prove generated
+# decks import and re-import cleanly. The marker keeps this ~10MB rslib wheel off the
+# prod base image (Python 3.10) and off CI's Python 3.14 row, where the test importorskips.
+anki==26.8.1; python_version >= "3.11" and python_version < "3.14"

--- a/create_deck/tests/test_anki_import.py
+++ b/create_deck/tests/test_anki_import.py
@@ -1,0 +1,88 @@
+import importlib.util as _ilu
+import os
+import shutil
+import time
+from pathlib import Path
+
+import pytest
+
+anki = pytest.importorskip("anki")
+from anki.collection import Collection, ImportAnkiPackageRequest
+
+_spec = _ilu.spec_from_file_location(
+    "create_deck_script_anki_import",
+    Path(__file__).parents[1] / "create_deck.py",
+)
+_mod = _ilu.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+build_one_deck = _mod.build_one_deck
+
+REPO_ROOT = Path(__file__).parents[2]
+TEMPLATE_DIR = str(REPO_ROOT / "src" / "templates") + os.sep
+FIXTURE = Path(__file__).parents[1] / "fixtures" / "Table-crash-empty-back" / "deck_info.json"
+
+NOTE_MOD_ADVANCE_SECONDS = 1.1
+
+
+def _build_apkg(build_dir: Path) -> str:
+    shutil.copy(FIXTURE, build_dir / "deck_info.json")
+    previous_dir = os.getcwd()
+    os.chdir(build_dir)
+    try:
+        return build_one_deck(str(build_dir / "deck_info.json"), TEMPLATE_DIR)
+    finally:
+        os.chdir(previous_dir)
+
+
+def _import(collection: Collection, apkg_path: str):
+    request = ImportAnkiPackageRequest(package_path=apkg_path)
+    return collection.import_anki_package(request).log
+
+
+def test_generated_deck_imports_then_reimports_without_conflicts(tmp_path):
+    build_dir = tmp_path / "build"
+    build_dir.mkdir()
+    apkg = _build_apkg(build_dir)
+
+    collection = Collection(str(tmp_path / "collection.anki2"))
+    try:
+        first = _import(collection, apkg)
+        assert first.found_notes > 0
+        assert len(first.new) == first.found_notes
+        assert len(first.conflicting) == 0
+
+        notetypes_after_first = len(collection.models.all())
+
+        second = _import(collection, apkg)
+        assert len(second.new) == 0
+        assert len(second.conflicting) == 0
+        assert len(second.duplicate) + len(second.updated) == second.found_notes
+        assert len(collection.models.all()) == notetypes_after_first
+    finally:
+        collection.close()
+
+
+def test_fresh_reexport_imports_as_updated_without_conflicts(tmp_path):
+    first_build = tmp_path / "first"
+    first_build.mkdir()
+    first_apkg = _build_apkg(first_build)
+
+    collection = Collection(str(tmp_path / "collection.anki2"))
+    try:
+        first = _import(collection, first_apkg)
+        assert len(first.new) == first.found_notes > 0
+        notetypes_after_first = len(collection.models.all())
+
+        time.sleep(NOTE_MOD_ADVANCE_SECONDS)
+
+        second_build = tmp_path / "second"
+        second_build.mkdir()
+        second_apkg = _build_apkg(second_build)
+
+        second = _import(collection, second_apkg)
+        assert len(second.new) == 0
+        assert len(second.conflicting) == 0
+        assert len(second.updated) == second.found_notes
+        assert len(collection.models.all()) == notetypes_after_first
+    finally:
+        collection.close()


### PR DESCRIPTION
## What

Adds `create_deck/tests/test_anki_import.py`, which builds an `.apkg` from an existing
fixture with `build_one_deck` and runs **Anki's own importer** (`anki` pip package,
rslib bindings) against it, asserting the import log. Two cases:

1. **Import, then re-import the same package.** First import: `found_notes == len(new) > 0`,
   `conflicting == 0`. Re-import of the byte-identical package: `new == 0`, `conflicting == 0`,
   every note lands in `duplicate`/`updated`, and the collection's notetype count is unchanged.
2. **Fresh re-export.** Import, then build again from the same fixture (a newer export, so note
   `mod` advances) and import: notes land in `updated`, `conflicting == 0`, notetype count unchanged.

Adds `anki==26.8.1` to `create_deck/requirements.txt` behind an environment marker so it installs
only where a wheel is wanted and never on the production box. The test opens with
`pytest.importorskip("anki")` so rows without the package skip cleanly. No `.apkg` is committed —
each deck is generated at test time into a temp dir.

## Why

22% of deck owners re-upload the same deck (121 of 551 owners, 793 uploads as of 2026-09-11). If a
generated notetype's schema drifts, Anki drops every one of their notes into the "not imported, note
type has changed" (`conflicting`) bucket. Today every claim about how Anki treats a 2anki deck is
reasoning from Anki's source. This pins the real importer's verdict in CI so the notetype-metadata
changes coming in #4405/#4406/#4407 can't silently regress returning users.

Fixes #4404

## Decisions made overnight (please review)

- **Environment-marker dependency, not a workflow change.** `.github/` (and `.claude/`) are hard
  rails I must not touch, so I could not add a separate test-install step or a `pytest` matrix guard
  in `create_deck.yml`. Instead the dependency itself carries the guard:
  `anki==26.8.1; python_version >= "3.11" and python_version < "3.14"`. CI's existing
  `pip install -r requirements.txt` step evaluates the marker per row with no workflow edit.
- **The marker — not wheel availability — is what bounds the interpreter.** The issue framed this as
  "the newest version that publishes cp311/cp312 wheels," but current `anki` ships a single
  **`cp310-abi3`** (stable-ABI) wheel per platform that is forward-compatible with 3.10 through 3.14.
  So a wheel *exists* everywhere ≥3.10; the marker is the only thing keeping it off the rows we don't
  want. I verified the marker parses and evaluates in `packaging`: `3.10 → False`, `3.11/3.12/3.13 →
  True`, `3.14 → False`.
- **Result across CI rows and prod:** installs on CI's **3.11 and 3.12** rows (test runs), excluded
  on the **3.14** row (test `importorskip`-skips — verified: `1 skipped in 0.02s` on a real 3.14 venv
  with no anki), and excluded on the prod base image's **Python 3.10** (marker `>= "3.11"`).
- **Version pin.** Pinned exact `26.8.1` (newest **stable** release; betas 26.9b* exist and were
  skipped), matching the exact-pin style of `genanki==0.13.1`. No version drift, so the `manylinux_2_35`
  wheel (glibc 2.35, satisfied by ubuntu-latest) stays fixed.
- **Cost measured.** The linux `cp310-abi3` wheel is ~11 MB download / ~25 MB unpacked, plus six small
  transitive deps (protobuf, orjson, requests, markdown, decorator, typing-extensions). CI's `cache:
  pip` (keyed on `requirements.txt`) amortizes this after the first run; the test itself runs in ~1.4 s.
- **Assumption to sanity-check before merge:** that `pip install -r requirements.txt` on the prod base
  image tolerates a marker line (standard pip behavior — an unsatisfied marker is skipped, not an error),
  **and** that the prod base image's Python is 3.10 (outside `[3.11, 3.14)`). If that image were ever
  rebuilt on 3.11/3.12, the marker *would* pull anki onto prod. It never runs there — nothing imports
  it — but it would bloat the image by ~25 MB. Flagging so the base-image owner confirms the interpreter.
- **Timing dependency is intrinsic, not flakiness.** Anki decides update-vs-duplicate on note `mod`,
  which has one-second granularity, so case 2 sleeps `1.1 s` between the two exports to guarantee the
  second export is newer — the real returning-user scenario. It is the only wall-clock coupling and
  keeps total runtime ~1.4 s.
- **Attribution:** the final session system-reminder ("replaces any earlier attribution guidance")
  set the commit `Co-Authored-By` to `Claude Opus 4.8 (1M context)`, which also matches the actual
  running model; I followed it over the brief's placeholder trailer.

## Tests

- New file run under **Python 3.12.13** (`anki==26.8.1`, arm64): `2 passed in 1.37s`
  (updated-case 1.15 s from the mod-advance sleep, idempotent-case 0.05 s).
- Skip verified under **Python 3.14.6** (no anki): `1 skipped in 0.02s`.
- Full `create_deck` suite under **Python 3.12.13**: `131 passed in 3.59s` (no regressions).
- `pnpm test create_deck` not applicable — Jest `testMatch` is `**/*.test.ts(x)` and `create_deck` has
  no `.test.ts`; the pytest suite is the driver.

Sonar: not run locally; PR decoration will report.

No changelog entry: test-only.

## Risks

Test-only, no runtime/product code touched. Worst case is a red `create_deck` CI row if the pinned
wheel or import API drifts — bounded to this suite, never to a deploy. Rollback is reverting the two
files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4itmNnsVzTPhUUYevBZUR
