### PR TITLE
chore: add a prune-dead-uploads ops command with dry-run

### DIFF
--- a/src/controllers/OpsController.ts
+++ b/src/controllers/OpsController.ts
@@ -32,6 +32,7 @@ import { GrantUnclaimedPassUseCase } from '../usecases/passes/GrantUnclaimedPass
 import { SetBlockIdIdentityUseCase } from '../usecases/ops/SetBlockIdIdentityUseCase';
 import { ChangeUserEmailUseCase } from '../usecases/ops/ChangeUserEmailUseCase';
 import { GetTodaySnapshotUseCase } from '../usecases/ops/GetTodaySnapshotUseCase';
+import { PruneDeadUploadsUseCase } from '../usecases/ops/PruneDeadUploadsUseCase';
 
 class OpsController {
   constructor(
@@ -63,7 +64,8 @@ class OpsController {
     private readonly setBlockIdIdentityUseCase?: SetBlockIdIdentityUseCase,
     private readonly changeUserEmailUseCase?: ChangeUserEmailUseCase,
     private readonly getEmailDeliveryMetricsUseCase?: GetEmailDeliveryMetricsUseCase,
-    private readonly getTodaySnapshotUseCase?: GetTodaySnapshotUseCase
+    private readonly getTodaySnapshotUseCase?: GetTodaySnapshotUseCase,
+    private readonly pruneDeadUploadsUseCase?: PruneDeadUploadsUseCase
   ) {}
 
   async changeUserEmail(req: express.Request, res: express.Response) {
@@ -419,6 +421,22 @@ class OpsController {
     } catch (error) {
       console.error('[ops] deleteInactiveUsers failed', error);
       res.status(500).json({ message: 'Failed to run inactive user deletion' });
+    }
+  }
+
+  async pruneDeadUploads(req: express.Request, res: express.Response) {
+    if (this.pruneDeadUploadsUseCase == null) {
+      res.status(500).json({ message: 'Dead upload prune not configured' });
+      return;
+    }
+    try {
+      const body = req.body as { dryRun?: unknown };
+      const dryRun = body?.dryRun !== false;
+      const result = await this.pruneDeadUploadsUseCase.execute(dryRun);
+      res.status(200).json(result);
+    } catch (error) {
+      console.error('[ops] pruneDeadUploads failed', error);
+      res.status(500).json({ message: 'Failed to prune dead uploads' });
     }
   }
 

--- a/src/controllers/OpsController.ts
+++ b/src/controllers/OpsController.ts
@@ -32,7 +32,10 @@ import { GrantUnclaimedPassUseCase } from '../usecases/passes/GrantUnclaimedPass
 import { SetBlockIdIdentityUseCase } from '../usecases/ops/SetBlockIdIdentityUseCase';
 import { ChangeUserEmailUseCase } from '../usecases/ops/ChangeUserEmailUseCase';
 import { GetTodaySnapshotUseCase } from '../usecases/ops/GetTodaySnapshotUseCase';
-import { PruneDeadUploadsUseCase } from '../usecases/ops/PruneDeadUploadsUseCase';
+import {
+  PruneDeadUploadsUseCase,
+  UnsafeBucketListingError,
+} from '../usecases/ops/PruneDeadUploadsUseCase';
 
 class OpsController {
   constructor(
@@ -435,6 +438,10 @@ class OpsController {
       const result = await this.pruneDeadUploadsUseCase.execute(dryRun);
       res.status(200).json(result);
     } catch (error) {
+      if (error instanceof UnsafeBucketListingError) {
+        res.status(409).json({ message: error.message });
+        return;
+      }
       console.error('[ops] pruneDeadUploads failed', error);
       res.status(500).json({ message: 'Failed to prune dead uploads' });
     }

--- a/src/data_layer/UploadRespository.test.ts
+++ b/src/data_layer/UploadRespository.test.ts
@@ -41,6 +41,30 @@ describe('UploadRepository owner guards', () => {
   });
 });
 
+describe('UploadRepository.getAllUploadReferences', () => {
+  it('returns id, key and owner for rows with a non-empty key', async () => {
+    const dbRows = [
+      { id: 1, key: 'decks/a.apkg', owner: 10 },
+      { id: 2, key: null, owner: 20 },
+      { id: 3, key: '', owner: 30 },
+      { id: 4, key: 'decks/b.apkg', owner: 40 },
+    ];
+    const db = () => ({
+      select: () => ({
+        whereNotNull: () => Promise.resolve(dbRows),
+      }),
+    });
+    const repo = new UploadRepository(db as unknown as never);
+
+    const result = await repo.getAllUploadReferences();
+
+    expect(result).toEqual([
+      { id: 1, key: 'decks/a.apkg', owner: 10 },
+      { id: 4, key: 'decks/b.apkg', owner: 40 },
+    ]);
+  });
+});
+
 describe('UploadRepository.findByObjectId', () => {
   it('returns null and skips the query when the object id is null', async () => {
     let queried = false;

--- a/src/data_layer/UploadRespository.ts
+++ b/src/data_layer/UploadRespository.ts
@@ -70,6 +70,17 @@ class UploadRepository implements IUploadRepository {
     return this.database(this.table).del().where({ owner, key });
   }
 
+  async getAllUploadReferences(): Promise<
+    { id: number; key: string; owner: number }[]
+  > {
+    const rows = await this.database<Uploads>(this.table)
+      .select('id', 'key', 'owner')
+      .whereNotNull('key');
+    return rows
+      .filter((row) => typeof row.key === 'string' && row.key.length > 0)
+      .map((row) => ({ id: row.id, key: row.key, owner: row.owner }));
+  }
+
   getUploadsByOwner(owner: number): Promise<Uploads[]> {
     if (owner == null) {
       console.warn('[UploadRepository] getUploadsByOwner called with no owner');

--- a/src/routes/OpsRouter.ts
+++ b/src/routes/OpsRouter.ts
@@ -90,6 +90,8 @@ import { ReconcileOrphanedSubscriptionsUseCase } from '../usecases/ops/Reconcile
 import { ErrorEventRepository } from '../data_layer/ErrorEventRepository';
 import { TodaySnapshotService } from '../services/ops/TodaySnapshotService';
 import { GetTodaySnapshotUseCase } from '../usecases/ops/GetTodaySnapshotUseCase';
+import { PruneDeadUploadsUseCase } from '../usecases/ops/PruneDeadUploadsUseCase';
+import UploadRepository from '../data_layer/UploadRespository';
 
 const OpsRouter = () => {
   const router = express.Router();
@@ -260,7 +262,8 @@ const OpsRouter = () => {
         repo: new EmailDeliveryMetricsRepository(database),
       })
     ),
-    new GetTodaySnapshotUseCase(todaySnapshotService)
+    new GetTodaySnapshotUseCase(todaySnapshotService),
+    new PruneDeadUploadsUseCase(new UploadRepository(database), storageHandler)
   );
 
   /**
@@ -467,6 +470,38 @@ const OpsRouter = () => {
    */
   router.post('/api/ops/delete-inactive-users', RequireOpsAccess, (req, res) =>
     controller.deleteInactiveUsers(req, res)
+  );
+
+  /**
+   * @swagger
+   * /api/ops/prune-dead-uploads:
+   *   post:
+   *     summary: Delete uploads rows whose bucket object no longer exists
+   *     description: |
+   *       Lists the storage bucket once and removes uploads rows whose key has no
+   *       object and is not a reserved-prefix key (mindmaps/, io-drafts/, assets/) —
+   *       the dead rows the pre-#3881 orphan sweep left behind when it deleted the
+   *       objects but not the rows. Owners of those rows see decks in their list that
+   *       404 on download. Pass dryRun:false in the body to delete; omit it or pass
+   *       dryRun:true to count the missing-key rows and return up to five sample keys.
+   *       Internal endpoint locked to the ops owner — returns 404 for everyone else.
+   *     tags: [Ops]
+   *     requestBody:
+   *       required: false
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             properties:
+   *               dryRun: { type: boolean }
+   *     responses:
+   *       200:
+   *         description: Dry-run count with sample keys, or the deleted-row count
+   *       404:
+   *         description: Not the ops owner
+   */
+  router.post('/api/ops/prune-dead-uploads', RequireOpsAccess, (req, res) =>
+    controller.pruneDeadUploads(req, res)
   );
 
   /**

--- a/src/usecases/ops/PruneDeadUploadsUseCase.test.ts
+++ b/src/usecases/ops/PruneDeadUploadsUseCase.test.ts
@@ -1,0 +1,76 @@
+import {
+  IPruneStorageHandler,
+  IPruneUploadRepository,
+  PruneDeadUploadsUseCase,
+  UploadReference,
+} from './PruneDeadUploadsUseCase';
+
+const rows: UploadReference[] = [
+  { id: 1, key: 'decks/exists-1.apkg', owner: 10 },
+  { id: 2, key: 'decks/missing-1.apkg', owner: 20 },
+  { id: 3, key: 'decks/missing-2.apkg', owner: 30 },
+  { id: 4, key: 'mindmaps/reserved.png', owner: 40 },
+  { id: 5, key: 'decks/exists-2.apkg', owner: 10 },
+];
+
+const bucketKeys = ['decks/exists-1.apkg', 'decks/exists-2.apkg'];
+
+function makeStorage(keys: string[]): IPruneStorageHandler {
+  return {
+    getContents: async () => keys.map((key) => ({ Key: key })),
+  };
+}
+
+function makeRepository(uploadRows: UploadReference[]) {
+  const deleteUpload = jest.fn(async () => 1);
+  const repo: IPruneUploadRepository = {
+    getAllUploadReferences: async () => uploadRows,
+    deleteUpload,
+  };
+  return { repo, deleteUpload };
+}
+
+describe('PruneDeadUploadsUseCase', () => {
+  it('dry-run reports the missing-key rows and deletes nothing', async () => {
+    const { repo, deleteUpload } = makeRepository(rows);
+    const useCase = new PruneDeadUploadsUseCase(repo, makeStorage(bucketKeys));
+
+    const result = await useCase.execute(true);
+
+    expect(result).toEqual({
+      dryRun: true,
+      missingRows: 2,
+      sampleKeys: ['decks/missing-1.apkg', 'decks/missing-2.apkg'],
+    });
+    expect(deleteUpload).not.toHaveBeenCalled();
+  });
+
+  it('caps the dry-run sample at five keys', async () => {
+    const many: UploadReference[] = Array.from({ length: 8 }, (_, index) => ({
+      id: index + 1,
+      key: `decks/gone-${index}.apkg`,
+      owner: 99,
+    }));
+    const { repo } = makeRepository(many);
+    const useCase = new PruneDeadUploadsUseCase(repo, makeStorage([]));
+
+    const result = await useCase.execute(true);
+
+    expect(result).toMatchObject({ dryRun: true, missingRows: 8 });
+    expect((result as { sampleKeys: string[] }).sampleKeys).toHaveLength(5);
+  });
+
+  it('live run deletes exactly the missing-key rows, keeping existing and reserved keys', async () => {
+    const { repo, deleteUpload } = makeRepository(rows);
+    const useCase = new PruneDeadUploadsUseCase(repo, makeStorage(bucketKeys));
+
+    const result = await useCase.execute(false);
+
+    expect(result).toEqual({ dryRun: false, deleted: 2 });
+    expect(deleteUpload).toHaveBeenCalledTimes(2);
+    expect(deleteUpload).toHaveBeenCalledWith(20, 'decks/missing-1.apkg');
+    expect(deleteUpload).toHaveBeenCalledWith(30, 'decks/missing-2.apkg');
+    expect(deleteUpload).not.toHaveBeenCalledWith(10, 'decks/exists-1.apkg');
+    expect(deleteUpload).not.toHaveBeenCalledWith(40, 'mindmaps/reserved.png');
+  });
+});

--- a/src/usecases/ops/PruneDeadUploadsUseCase.test.ts
+++ b/src/usecases/ops/PruneDeadUploadsUseCase.test.ts
@@ -2,6 +2,7 @@ import {
   IPruneStorageHandler,
   IPruneUploadRepository,
   PruneDeadUploadsUseCase,
+  UnsafeBucketListingError,
   UploadReference,
 } from './PruneDeadUploadsUseCase';
 
@@ -52,7 +53,10 @@ describe('PruneDeadUploadsUseCase', () => {
       owner: 99,
     }));
     const { repo } = makeRepository(many);
-    const useCase = new PruneDeadUploadsUseCase(repo, makeStorage([]));
+    const useCase = new PruneDeadUploadsUseCase(
+      repo,
+      makeStorage(['decks/unrelated-live.apkg'])
+    );
 
     const result = await useCase.execute(true);
 
@@ -72,5 +76,29 @@ describe('PruneDeadUploadsUseCase', () => {
     expect(deleteUpload).toHaveBeenCalledWith(30, 'decks/missing-2.apkg');
     expect(deleteUpload).not.toHaveBeenCalledWith(10, 'decks/exists-1.apkg');
     expect(deleteUpload).not.toHaveBeenCalledWith(40, 'mindmaps/reserved.png');
+  });
+
+  it('refuses to judge rows when the bucket listing is empty', async () => {
+    const { repo, deleteUpload } = makeRepository(rows);
+    const useCase = new PruneDeadUploadsUseCase(repo, makeStorage([]));
+
+    await expect(useCase.execute(false)).rejects.toBeInstanceOf(
+      UnsafeBucketListingError
+    );
+    await expect(useCase.execute(true)).rejects.toBeInstanceOf(
+      UnsafeBucketListingError
+    );
+    expect(deleteUpload).not.toHaveBeenCalled();
+  });
+
+  it('refuses to judge rows when the bucket listing hit the paging cap', async () => {
+    const { repo, deleteUpload } = makeRepository(rows);
+    const capped = Array.from({ length: 100_000 }, (_, i) => `decks/${i}.apkg`);
+    const useCase = new PruneDeadUploadsUseCase(repo, makeStorage(capped));
+
+    await expect(useCase.execute(false)).rejects.toBeInstanceOf(
+      UnsafeBucketListingError
+    );
+    expect(deleteUpload).not.toHaveBeenCalled();
   });
 });

--- a/src/usecases/ops/PruneDeadUploadsUseCase.ts
+++ b/src/usecases/ops/PruneDeadUploadsUseCase.ts
@@ -22,6 +22,20 @@ export type PruneDeadUploadsResult =
 const MAX_KEYS = 100_000;
 const SAMPLE_LIMIT = 5;
 
+// A listing that came back empty, or that hit the paging cap, cannot tell a
+// dead row from a live one; every row would look dead and a live run would
+// delete real decks. Refuse rather than guess.
+export class UnsafeBucketListingError extends Error {
+  constructor(reason: 'empty' | 'truncated') {
+    super(
+      reason === 'empty'
+        ? 'The bucket listing came back empty, so no row can be judged dead.'
+        : 'The bucket listing hit the paging cap, so rows past it cannot be judged.'
+    );
+    this.name = 'UnsafeBucketListingError';
+  }
+}
+
 export class PruneDeadUploadsUseCase {
   constructor(
     private readonly uploads: IPruneUploadRepository,
@@ -37,6 +51,13 @@ export class PruneDeadUploadsUseCase {
           (key): key is string => typeof key === 'string' && key.length > 0
         )
     );
+
+    if (existingKeys.size === 0) {
+      throw new UnsafeBucketListingError('empty');
+    }
+    if (storedFiles.length >= MAX_KEYS) {
+      throw new UnsafeBucketListingError('truncated');
+    }
 
     const rows = await this.uploads.getAllUploadReferences();
     const deadRows = rows.filter(

--- a/src/usecases/ops/PruneDeadUploadsUseCase.ts
+++ b/src/usecases/ops/PruneDeadUploadsUseCase.ts
@@ -1,0 +1,60 @@
+import { isReservedKey } from '../../lib/storage/jobs/helpers/isDeletableBucketKey';
+
+export interface UploadReference {
+  id: number;
+  key: string;
+  owner: number;
+}
+
+export interface IPruneUploadRepository {
+  getAllUploadReferences(): Promise<UploadReference[]>;
+  deleteUpload(owner: number, key: string): Promise<number>;
+}
+
+export interface IPruneStorageHandler {
+  getContents(maxKeys?: number): Promise<{ Key?: string }[] | undefined>;
+}
+
+export type PruneDeadUploadsResult =
+  | { dryRun: true; missingRows: number; sampleKeys: string[] }
+  | { dryRun: false; deleted: number };
+
+const MAX_KEYS = 100_000;
+const SAMPLE_LIMIT = 5;
+
+export class PruneDeadUploadsUseCase {
+  constructor(
+    private readonly uploads: IPruneUploadRepository,
+    private readonly storage: IPruneStorageHandler
+  ) {}
+
+  async execute(dryRun: boolean): Promise<PruneDeadUploadsResult> {
+    const storedFiles = (await this.storage.getContents(MAX_KEYS)) ?? [];
+    const existingKeys = new Set<string>(
+      storedFiles
+        .map((file) => file.Key)
+        .filter(
+          (key): key is string => typeof key === 'string' && key.length > 0
+        )
+    );
+
+    const rows = await this.uploads.getAllUploadReferences();
+    const deadRows = rows.filter(
+      (row) => !isReservedKey(row.key) && !existingKeys.has(row.key)
+    );
+
+    if (dryRun) {
+      return {
+        dryRun: true,
+        missingRows: deadRows.length,
+        sampleKeys: deadRows.slice(0, SAMPLE_LIMIT).map((row) => row.key),
+      };
+    }
+
+    let deleted = 0;
+    for (const row of deadRows) {
+      deleted += await this.uploads.deleteUpload(row.owner, row.key);
+    }
+    return { dryRun: false, deleted };
+  }
+}

--- a/web/src/pages/OpsPage/CommandsTab.test.tsx
+++ b/web/src/pages/OpsPage/CommandsTab.test.tsx
@@ -240,3 +240,60 @@ describe('CommandsTab — change account email', () => {
     expect(screen.queryByRole('button', { name: 'Check value' })).toBeNull();
   });
 });
+
+describe('CommandsTab — prune dead upload rows', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  test('keeps the prune button locked until a check finds dead rows, then confirms with the count', async () => {
+    const confirmSpy = vi
+      .spyOn(globalThis, 'confirm')
+      .mockImplementation(() => true);
+    mockFetch((_url, init) => {
+      const body = init?.body ? JSON.parse(init.body as string) : {};
+      return body.dryRun
+        ? { dryRun: true, missingRows: 5, sampleKeys: ['decks/a.apkg'] }
+        : { dryRun: false, deleted: 5 };
+    });
+    renderTab();
+
+    const pruneButton = screen.getByRole('button', { name: 'Prune dead rows' });
+    expect(pruneButton).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Check dead rows' }));
+    expect(
+      await screen.findByText(
+        '5 upload rows point at a deleted file and would be removed.'
+      )
+    ).toBeInTheDocument();
+    expect(pruneButton).toBeEnabled();
+
+    fireEvent.click(pruneButton);
+    expect(confirmSpy).toHaveBeenCalledWith(
+      'Remove 5 dead upload rows? The files are already gone; this only clears the rows that 404 on download.'
+    );
+    expect(
+      await screen.findByText('Removed 5 dead upload rows.')
+    ).toBeInTheDocument();
+    expect(pruneButton).toBeDisabled();
+  });
+
+  test('keeps the prune button locked when the check finds nothing', async () => {
+    mockFetch(() => ({ dryRun: true, missingRows: 0, sampleKeys: [] }));
+    renderTab();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Check dead rows' }));
+    expect(
+      await screen.findByText(
+        '0 upload rows point at a deleted file and would be removed.'
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Prune dead rows' })
+    ).toBeDisabled();
+  });
+});

--- a/web/src/pages/OpsPage/CommandsTab.tsx
+++ b/web/src/pages/OpsPage/CommandsTab.tsx
@@ -8,6 +8,7 @@ import { setBlockIdIdentity } from './setBlockIdIdentity';
 import { changeUserEmail } from './changeUserEmail';
 import { setChatAttachmentsLifecycle } from './setChatAttachmentsLifecycle';
 import { sendPassWinback } from './sendPassWinback';
+import { pruneDeadUploads } from './pruneDeadUploads';
 import {
   deleteInactiveUsers,
   DeleteInactiveUsersResponse,
@@ -79,6 +80,44 @@ export default function CommandsTab() {
   const [emailChangeNew, setEmailChangeNew] = useState('');
   const [emailChangeStatus, setEmailChangeStatus] = useState<Status>('idle');
   const [emailChangeMessage, setEmailChangeMessage] = useState('');
+  const [pruneStatus, setPruneStatus] = useState<Status>('idle');
+  const [pruneMessage, setPruneMessage] = useState('');
+  const [pruneMissing, setPruneMissing] = useState<number | null>(null);
+  const [pruneSampleKeys, setPruneSampleKeys] = useState<string[]>([]);
+
+  const runPrune = async (dryRun: boolean) => {
+    if (
+      !dryRun &&
+      !globalThis.confirm(
+        `Remove ${pruneMissing} dead upload row${pruneMissing === 1 ? '' : 's'}? The files are already gone; this only clears the rows that 404 on download.`
+      )
+    ) {
+      return;
+    }
+    setPruneStatus('loading');
+    setPruneMessage('');
+    try {
+      const result = await pruneDeadUploads(dryRun);
+      setPruneStatus('success');
+      if (result.dryRun) {
+        setPruneMissing(result.missingRows);
+        setPruneSampleKeys(result.sampleKeys);
+        setPruneMessage(
+          `${result.missingRows} upload row${result.missingRows === 1 ? '' : 's'} point at a deleted file and would be removed.`
+        );
+      } else {
+        setPruneMissing(null);
+        setPruneSampleKeys([]);
+        setPruneMessage(
+          `Removed ${result.deleted} dead upload row${result.deleted === 1 ? '' : 's'}.`
+        );
+      }
+    } catch (error) {
+      setPruneMissing(null);
+      setPruneStatus('error');
+      setPruneMessage(error instanceof Error ? error.message : 'Unknown error');
+    }
+  };
 
   const runWinback = async (dryRun: boolean) => {
     const campaign = winbackCampaign.trim();
@@ -651,6 +690,59 @@ export default function CommandsTab() {
       {lifecycleStatus === 'error' && lifecycleMessage && (
         <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>
           {lifecycleMessage}
+        </div>
+      )}
+
+      <section className={`${sharedStyles.surface} ${styles.card}`}>
+        <h3 className={styles.cardTitle}>Prune dead upload rows</h3>
+        <p className={styles.panelSubtitle}>
+          Finds uploads rows whose bucket object the old orphan sweep deleted
+          before it was restricted to unreferenced keys. Those rows still show
+          up in a user&apos;s deck list but 404 on download. Reserved-prefix
+          keys (mindmaps, drafts) are left alone. Check first — the prune button
+          unlocks only after a check in this session finds rows.
+        </p>
+        <div className={styles.controls}>
+          <button
+            type="button"
+            className={sharedStyles.btnSmall}
+            onClick={() => runPrune(true)}
+            disabled={pruneStatus === 'loading'}
+          >
+            {pruneStatus === 'loading' ? 'Working…' : 'Check dead rows'}
+          </button>
+          <button
+            type="button"
+            className={sharedStyles.btnDanger}
+            onClick={() => runPrune(false)}
+            disabled={
+              pruneStatus === 'loading' ||
+              pruneMissing == null ||
+              pruneMissing === 0
+            }
+          >
+            Prune dead rows
+          </button>
+        </div>
+        {pruneSampleKeys.length > 0 && (
+          <ul className={styles.panelSubtitle}>
+            {pruneSampleKeys.map((key) => (
+              <li key={key} data-hj-suppress style={{ fontWeight: 500 }}>
+                {key}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {pruneStatus === 'success' && pruneMessage && (
+        <div className={`${sharedStyles.alertSuccess} ${styles.banner}`}>
+          {pruneMessage}
+        </div>
+      )}
+      {pruneStatus === 'error' && pruneMessage && (
+        <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>
+          {pruneMessage}
         </div>
       )}
 

--- a/web/src/pages/OpsPage/pruneDeadUploads.test.ts
+++ b/web/src/pages/OpsPage/pruneDeadUploads.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { pruneDeadUploads } from './pruneDeadUploads';
+
+describe('pruneDeadUploads', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  test('POSTs dryRun true and returns the missing count with sample keys', async () => {
+    const payload = {
+      dryRun: true,
+      missingRows: 3,
+      sampleKeys: ['decks/a.apkg', 'decks/b.apkg'],
+    };
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: () => Promise.resolve(payload),
+    });
+
+    const result = await pruneDeadUploads(true);
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      '/api/ops/prune-dead-uploads',
+      {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ dryRun: true }),
+      }
+    );
+    expect(result).toEqual(payload);
+  });
+
+  test('POSTs dryRun false for a real prune and returns the deleted count', async () => {
+    const payload = { dryRun: false, deleted: 3 };
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: () => Promise.resolve(payload),
+    });
+
+    const result = await pruneDeadUploads(false);
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      '/api/ops/prune-dead-uploads',
+      {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ dryRun: false }),
+      }
+    );
+    expect(result).toEqual(payload);
+  });
+
+  test('throws the server message on a non-ok response', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      json: () => Promise.resolve({ message: 'Failed to prune dead uploads' }),
+    });
+
+    await expect(pruneDeadUploads(true)).rejects.toThrow(
+      'Failed to prune dead uploads'
+    );
+  });
+
+  test('falls back to status text when the error body has no message', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      json: () => Promise.reject(new Error('no body')),
+    });
+
+    await expect(pruneDeadUploads(false)).rejects.toThrow('404 Not Found');
+  });
+});

--- a/web/src/pages/OpsPage/pruneDeadUploads.ts
+++ b/web/src/pages/OpsPage/pruneDeadUploads.ts
@@ -1,0 +1,21 @@
+export type PruneDeadUploadsResponse =
+  | { dryRun: true; missingRows: number; sampleKeys: string[] }
+  | { dryRun: false; deleted: number };
+
+export async function pruneDeadUploads(
+  dryRun: boolean
+): Promise<PruneDeadUploadsResponse> {
+  const response = await fetch('/api/ops/prune-dead-uploads', {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ dryRun }),
+  });
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(
+      data.message ?? `${response.status} ${response.statusText}`
+    );
+  }
+  return response.json();
+}


### PR DESCRIPTION
## What

Adds an owner-locked ops command `prune-dead-uploads` (route → controller → use case → repository) plus its button in the ops Commands tab. It lists the storage bucket once, loads every `uploads` row, and finds rows whose key has no bucket object and is not a reserved-prefix key (`mindmaps/`, `io-drafts/`, `assets/`). Dry-run by default: returns `{ dryRun: true, missingRows, sampleKeys }` (up to five keys) and deletes nothing. A live run (`dryRun: false` in the POST body) deletes exactly those rows through the upload repository and returns the deleted count. The button mirrors the delete-inactive-accounts check-then-confirm flow — the prune button unlocks only after a check in the same session finds rows.

Scope is item 1 of #4401 (the one-off cleanup). Item 2 (a listing-endpoint guard / nightly check so this cannot silently recur) is intentionally left for a follow-up.

## Why

The orphan sweep deleted objects that `uploads` rows referenced until #3881 (merged 2026-07-27) restricted it to unreferenced keys. The fix stopped the deletions but never cleaned up the rows left behind. Roughly 147 rows across 19 owners — most created in April 2026 — now point at objects that no longer exist, so those owners see decks in their list that 404 on download. This gives us a safe, previewable way to clear them.

## How

`PruneDeadUploadsUseCase` takes narrow interfaces for the bucket listing (`getContents`) and the upload repository (`getAllUploadReferences` + `deleteUpload`), mirroring `deleteDanglingUploadsInBucket` in reverse — one bucket listing, no HeadObject per row. Reserved-prefix filtering reuses `isReservedKey` from the sweep's helper so the two paths agree on what owns its own lifecycle. `getAllUploadReferences` is a new query-builder method on `UploadRepository`; it is not added to the shared `IUploadRepository` interface (the use case consumes a narrow local interface, matching the `IInactiveUserDeleter` pattern) so no existing repository mock breaks.

## Decisions made overnight (please review)

- **Ops command with dry-run, not the alternatives.** Chosen over a HeadObject-per-listing reconciliation (one bucket `ListObjectsV2` pass instead of thousands of HEAD calls) and over auto-deleting the rows inside the daily sweep (a one-off cleanup that quietly deletes rows on every deploy is the wrong shape; a manual, previewable button is safer for a destructive DB operation).
- **Assumption: the missing keys are genuinely absent**, not a transient listing gap or a bucket/env misconfiguration. The dry-run guards this — you see the count and sample keys before anything is deleted, and the live button only unlocks after a dry-run finds rows.
- **No prod data run tonight.** This PR ships the command only. Alexander runs the button (dry-run first, then live) against prod when he chooses. Nothing here touches production data.

## Measuring success

The command returns the deleted-row count in the response and the dry-run count is visible in the ops UI. After a live run, `GET /api/upload/mine` for an affected owner no longer lists the dead decks. A re-run dry-run should report `missingRows: 0` once the backlog is cleared.

## Testing

- Unit test `PruneDeadUploadsUseCase.test.ts`: fake storage handler (known key set) + fake upload repository — dry-run reports the count and deletes nothing; sample cap of five; live run deletes exactly the missing-key rows, keeps existing keys, skips reserved prefixes (asserts on the `deleteUpload` call args).
- `UploadRespository.test.ts`: new `getAllUploadReferences` filters null/empty keys and maps to `{ id, key, owner }`.
- Web: `pruneDeadUploads.test.ts` (fetch wrapper) and a `CommandsTab.test.tsx` case for the check-then-confirm gate. Route↔button parity test stays green.

Full-suite counts:
- Server `pnpm test`: 726 passed / 9 failed / 2 skipped suites; 7130 passed / 81 failed / 25 skipped / 7 todo tests. All 81 failures are the documented environmental suites — `getPageCount` (pdfinfo) and the Python-venv `DeckParser*` / `conversionGolden` / canary suites. Every touched suite passes.
- Web `pnpm --filter 2anki-web test`: 405 files, 3631 tests, all passing.
- `npx tsc -p . --noEmit`, `pnpm format:check`, web typecheck, and web lint: clean (lint shows only pre-existing warnings, none in the new files).

Sonar: not run locally; PR decoration will report.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px

Notes: `pnpm --filter 2anki-web test:golden-path` (Playwright `golden-path.spec.ts`) — 4/4 passed, including "landing renders without console errors at 375px".

## Risks

Deleting the wrong rows if a key's object exists but the listing missed it (e.g. pagination cut-off). Mitigated: `getContents` paginates up to 100k keys and the dry-run count is inspected before any live run. Reserved-prefix keys are never touched. Rollback: the command is manual — simply don't run the live pass; the code path is inert until the button is pressed.

## Goal alignment

Serves **beautiful** indirectly: it stops affected owners seeing broken decks that 404 on download, so their deck list reflects what actually exists. Internal ops surface — no user-facing metric moves; the signal is the dry-run `missingRows` count trending to 0 after the cleanup, read from the ops Commands tab.

## Changelog

No entry — internal-only ops command (owner-locked), no user-visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4itmNnsVzTPhUUYevBZUR

## Review round 2

Both reviewers asked for a fail-safe: an empty or paging-capped bucket listing would have made every row look dead. The use case now refuses (`UnsafeBucketListingError`) before judging any row, on dry-run and live alike, and the route answers 409 with the reason. Two tests cover it.

no changelog entry — owner-only ops command, nothing a user would notice.
