### PR TITLE
chore: add the MCP Registry server.json for net.2anki/mcp

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "net.2anki/mcp",
+  "title": "2anki",
+  "description": "Turn text, files, URLs, or photos into Anki flashcard decks from your AI assistant.",
+  "version": "1.0.0",
+  "websiteUrl": "https://2anki.net/documentation/reference/mcp",
+  "repository": {
+    "url": "https://github.com/2anki/server",
+    "source": "github",
+    "id": "256559677"
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://2anki.net/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds a `server.json` at the repo root describing the hosted 2anki MCP server for the official MCP Registry: name `net.2anki/mcp`, remote streamable-HTTP endpoint `https://2anki.net/mcp`, website + repository metadata. Conforms to the current registry server schema (`2025-12-11`).

## Why

The official MCP Registry (registry.modelcontextprotocol.io) is auto-ingested by PulseMCP, Glama, and most aggregator directories, so one submission covers the long tail. This is the agent-preparable half of #4391 — the file is authored and validated so the owner only has to run the DNS login and `mcp-publisher publish`, with no schema authoring left at publish time.

## Decisions made overnight (please review)

- **Schema version: `2025-12-11`.** This is the version used in every example in the registry's `docs/reference/server-json` reference; the schema fetched and resolved cleanly. (An older `2025-09-29` schema also exists and is linked in one "browse the schema" paragraph, but the reference examples have moved to `2025-12-11`.)
- **Validation method: official `mcp-publisher` v1.8.1.** Downloaded the pinned `mcp-publisher_darwin_arm64.tar.gz` release binary from `modelcontextprotocol/registry`, verified its SHA-256 against `registry_1.8.1_checksums.txt` (`e45e5208…cb77`, matched), and ran `mcp-publisher validate ./server.json` → `✅ server.json is valid`. No `curl | sh`, no login, no publish.
- **`name` = `net.2anki/mcp`** — DNS-verified namespace per the issue; matches the schema's reverse-DNS pattern.
- **`description` (83 chars, under the 100-char cap)** — "Turn text, files, URLs, or photos into Anki flashcard decks from your AI assistant." VOICE.md register, no exclamation.
- **`version` = `1.0.0`** — matches `MCP_SERVER_VERSION` in `src/services/mcp/McpServerFactory.ts`.
- **`websiteUrl` = the MCP reference doc** (`/documentation/reference/mcp`). The schema has a single `websiteUrl` field; the setup guide (`/documentation/start-here/use-in-claude`) is linked from that reference page, so both are reachable from the one URL.
- **`repository.id` = `256559677`** — the GitHub repo id (`gh api repos/2anki/server --jq .id`), recommended by the schema for resurrection-attack protection.
- **OAuth 2.1 is not expressed as a field.** The `2025-12-11` remote-transport schema has no auth declaration for `streamable-http` beyond `headers`; OAuth is discovered at runtime via the endpoint's well-known metadata, so there is nothing to author here. Nothing else in the target shape could not be verified against the fetched schema.
- **Tools are not listed in `server.json`.** The schema has no per-tool field for remote servers (clients discover tools live at connect time), so the six tools are not enumerated in the file.

## Remaining owner steps (from #4391 — not done here)

- [ ] Install `mcp-publisher` and run `mcp-publisher login dns` for `2anki.net`; it prints a TXT record to add at the DNS provider.
- [ ] Add the TXT record, complete the login, run `mcp-publisher publish`.
- [ ] Confirm the entry appears on registry.modelcontextprotocol.io, then check PulseMCP a day later for the auto-ingested listing.

## Testing

Validated with the official `mcp-publisher validate` (see above). No source code changed, so no unit tests apply.

Sonar: not run locally; PR decoration will report.

No changelog entry: repository metadata only.

Refs #4391

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4itmNnsVzTPhUUYevBZUR
