### PR TITLE
feat: warn when cards in a built deck share a question

### DIFF
--- a/src/lib/anki/countDuplicateGuids.test.ts
+++ b/src/lib/anki/countDuplicateGuids.test.ts
@@ -1,0 +1,49 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { countDuplicateGuids } from './countDuplicateGuids';
+
+function workspaceWith(sidecar: string | object | undefined): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dup-guids-'));
+  if (sidecar !== undefined) {
+    const raw = typeof sidecar === 'string' ? sidecar : JSON.stringify(sidecar);
+    fs.writeFileSync(path.join(dir, 'guids.json'), raw);
+  }
+  return dir;
+}
+
+describe('countDuplicateGuids', () => {
+  it('is zero when every note has its own guid', () => {
+    const dir = workspaceWith([
+      { notionId: null, guid: 'a' },
+      { notionId: null, guid: 'b' },
+    ]);
+    expect(countDuplicateGuids(dir)).toBe(0);
+  });
+
+  it('counts the notes Anki drops, one fewer than each group', () => {
+    const dir = workspaceWith([
+      { notionId: null, guid: 'a' },
+      { notionId: null, guid: 'a' },
+      { notionId: null, guid: 'a' },
+      { notionId: 'block', guid: 'b' },
+      { notionId: 'block', guid: 'b' },
+      { notionId: null, guid: 'c' },
+    ]);
+    expect(countDuplicateGuids(dir)).toBe(3);
+  });
+
+  it('ignores entries without a guid', () => {
+    const dir = workspaceWith([{ notionId: null }, { notionId: null }]);
+    expect(countDuplicateGuids(dir)).toBe(0);
+  });
+
+  it.each([
+    ['no sidecar', undefined],
+    ['malformed json', '{not json'],
+    ['a non-array', { guid: 'a' }],
+  ])('is zero with %s', (_label, sidecar) => {
+    expect(countDuplicateGuids(workspaceWith(sidecar))).toBe(0);
+  });
+});

--- a/src/lib/anki/countDuplicateGuids.ts
+++ b/src/lib/anki/countDuplicateGuids.ts
@@ -1,0 +1,28 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Anki treats notes with the same guid as one note: the first imports, the
+// rest are "updated" or "skipped" and the user never sees them. Python owns
+// the guid formula, so the count comes from its guids.json sidecar rather
+// than a TS re-derivation that could drift. Returns how many notes Anki
+// drops: every note past the first in each guid group.
+export function countDuplicateGuids(location: string): number {
+  let entries: unknown;
+  try {
+    entries = JSON.parse(
+      fs.readFileSync(path.join(location, 'guids.json'), 'utf8')
+    );
+  } catch {
+    return 0;
+  }
+  if (!Array.isArray(entries)) return 0;
+  const seen = new Set<string>();
+  let dropped = 0;
+  for (const entry of entries) {
+    const guid = (entry as { guid?: unknown })?.guid;
+    if (typeof guid !== 'string') continue;
+    if (seen.has(guid)) dropped += 1;
+    seen.add(guid);
+  }
+  return dropped;
+}

--- a/src/lib/parser/DeckParser.stableGuids.test.ts
+++ b/src/lib/parser/DeckParser.stableGuids.test.ts
@@ -1,5 +1,6 @@
 import { setupTests } from '../../test/configure-jest';
 import { parseApkgNotes } from '../../services/ApkgPreviewService/parseApkgNotes';
+import { countDuplicateGuids } from '../anki/countDuplicateGuids';
 import CardOption from './Settings/CardOption';
 import { DeckParser } from './DeckParser';
 import Workspace from './WorkSpace';
@@ -168,7 +169,7 @@ describeWithPython('the shipped apkg keeps prod-compatible GUIDs', () => {
     });
     const apkg = await parser.build(workspace);
     const parsed = await parseApkgNotes(apkg);
-    return { guids: parsed.notes.map((n) => n.guid), parser };
+    return { guids: parsed.notes.map((n) => n.guid), parser, workspace };
   }
 
   const withId = detailsToggle(BLOCK_ID, 'Same question', '<p>Same answer</p>');
@@ -191,6 +192,13 @@ describeWithPython('the shipped apkg keeps prod-compatible GUIDs', () => {
     });
     expect(renamed.guids).toEqual([seeded]);
     expect(renamed.parser.issuedGuidEntries).toEqual([]);
+  });
+
+  it('collapses two toggles with the same question onto one guid, and the sidecar counts the loss', async () => {
+    const twice = await buildApkg(withoutId + withoutId, 'Deck One');
+    expect(twice.guids).toHaveLength(2);
+    expect(twice.guids[0]).toBe(twice.guids[1]);
+    expect(countDuplicateGuids(twice.workspace.location)).toBe(1);
   });
 });
 

--- a/src/lib/upload/duplicateGuidWarning.test.ts
+++ b/src/lib/upload/duplicateGuidWarning.test.ts
@@ -1,0 +1,26 @@
+import {
+  duplicateGuidWarning,
+  duplicateGuidWarningText,
+} from './duplicateGuidWarning';
+
+describe('duplicateGuidWarning', () => {
+  it('is silent when no note shares a guid', () => {
+    expect(duplicateGuidWarning(0)).toBeNull();
+  });
+
+  it('codes the number of notes Anki will drop', () => {
+    expect(duplicateGuidWarning(2)).toBe('duplicate-guid:2');
+  });
+
+  it('renders one card in the singular', () => {
+    expect(duplicateGuidWarningText(1)).toBe(
+      '1 card repeats the question of another card in the same deck, so Anki keeps only the first and you import 1 card fewer than you see here. Give it a different question and convert again.'
+    );
+  });
+
+  it('renders several cards in the plural', () => {
+    expect(duplicateGuidWarningText(3)).toBe(
+      '3 cards repeat the question of another card in the same deck, so Anki keeps only the first of each and you import 3 cards fewer than you see here. Make the repeated questions different and convert again.'
+    );
+  });
+});

--- a/src/lib/upload/duplicateGuidWarning.test.ts
+++ b/src/lib/upload/duplicateGuidWarning.test.ts
@@ -14,13 +14,13 @@ describe('duplicateGuidWarning', () => {
 
   it('renders one card in the singular', () => {
     expect(duplicateGuidWarningText(1)).toBe(
-      '1 card repeats the question of another card in the same deck, so Anki keeps only the first and you import 1 card fewer than you see here. Give it a different question and convert again.'
+      '1 card repeats the question of another card in the same deck, so Anki keeps only the first. You import 1 card fewer than you see here. Give it a different question and convert again.'
     );
   });
 
   it('renders several cards in the plural', () => {
     expect(duplicateGuidWarningText(3)).toBe(
-      '3 cards repeat the question of another card in the same deck, so Anki keeps only the first of each and you import 3 cards fewer than you see here. Make the repeated questions different and convert again.'
+      '3 cards repeat the question of another card in the same deck, so Anki keeps only the first of each. You import 3 cards fewer than you see here. Make the repeated questions different and convert again.'
     );
   });
 });

--- a/src/lib/upload/duplicateGuidWarning.ts
+++ b/src/lib/upload/duplicateGuidWarning.ts
@@ -1,0 +1,16 @@
+// Two notes with one guid import as one note, so the deck Anki shows is
+// smaller than the one 2anki previewed. The count is only known once python
+// has issued the guids, so the warning rides the upload warning channel.
+export const DUPLICATE_GUID_WARNING_RE = /^duplicate-guid:(\d+)$/;
+
+export function duplicateGuidWarning(dropped: number): string | null {
+  if (dropped <= 0) return null;
+  return `duplicate-guid:${dropped}`;
+}
+
+export function duplicateGuidWarningText(dropped: number): string {
+  if (dropped === 1) {
+    return '1 card repeats the question of another card in the same deck, so Anki keeps only the first and you import 1 card fewer than you see here. Give it a different question and convert again.';
+  }
+  return `${dropped} cards repeat the question of another card in the same deck, so Anki keeps only the first of each and you import ${dropped} cards fewer than you see here. Make the repeated questions different and convert again.`;
+}

--- a/src/lib/upload/duplicateGuidWarning.ts
+++ b/src/lib/upload/duplicateGuidWarning.ts
@@ -10,7 +10,7 @@ export function duplicateGuidWarning(dropped: number): string | null {
 
 export function duplicateGuidWarningText(dropped: number): string {
   if (dropped === 1) {
-    return '1 card repeats the question of another card in the same deck, so Anki keeps only the first and you import 1 card fewer than you see here. Give it a different question and convert again.';
+    return '1 card repeats the question of another card in the same deck, so Anki keeps only the first. You import 1 card fewer than you see here. Give it a different question and convert again.';
   }
-  return `${dropped} cards repeat the question of another card in the same deck, so Anki keeps only the first of each and you import ${dropped} cards fewer than you see here. Make the repeated questions different and convert again.`;
+  return `${dropped} cards repeat the question of another card in the same deck, so Anki keeps only the first of each. You import ${dropped} cards fewer than you see here. Make the repeated questions different and convert again.`;
 }

--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -1341,6 +1341,40 @@ describe('UploadService.handleSyncUpload — card-limit enforcement', () => {
     expect(res.set).toHaveBeenCalledWith('X-Warning', lockedWarning);
   });
 
+  it('warns on X-Warning when notes in the built package share a guid', async () => {
+    const previousLocation = mockWorkspaceLocation;
+    mockWorkspaceLocation = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'upload-dup-guid-')
+    );
+    fs.writeFileSync(
+      path.join(mockWorkspaceLocation, 'guids.json'),
+      JSON.stringify([
+        { notionId: null, guid: 'same' },
+        { notionId: null, guid: 'same' },
+        { notionId: null, guid: 'other' },
+      ])
+    );
+    mockPackages([{ name: 'notes.html', cardCount: 3 }]);
+
+    const service = new UploadService(
+      buildRepository(),
+      {} as JobRepository,
+      buildUsersRepo(),
+      ...fakeUploadServiceDeps()
+    );
+    const req = buildRequest();
+    const { res, capturedStatus } = buildResponse();
+
+    await service.handleUpload(req, res);
+    mockWorkspaceLocation = previousLocation;
+
+    expect(capturedStatus()).toBe(200);
+    expect(res.set).toHaveBeenCalledWith(
+      'X-Warning',
+      expect.stringMatching(/^1 card repeats the question/)
+    );
+  });
+
   it('sends the deck for an anonymous conversion at or under 21 cards without incrementing usage', async () => {
     mockPackages([{ name: 'deck', cardCount: 21 }]);
     const usersRepo = buildUsersRepo();
@@ -4071,5 +4105,26 @@ describe('resolveUploadWarning — package over the AnkiWeb sync limit', () => {
     ).toBe(
       "This deck is 210.4 MB. AnkiWeb won't sync packages over 100 MB, so split it into smaller decks before syncing."
     );
+  });
+});
+
+describe('resolveUploadWarning — notes sharing a guid', () => {
+  it('turns the coded count into user copy, summing across packages', () => {
+    expect(
+      resolveUploadWarning(['duplicate-guid:2', 'duplicate-guid:1'])
+    ).toMatch(/^3 cards repeat the question/);
+  });
+
+  it('ranks below the sync-size warning and above the markdown heuristic', () => {
+    expect(
+      resolveUploadWarning(['duplicate-guid:1', 'apkg-over-100mb:210.4'])
+    ).toMatch(/^This deck is 210.4 MB/);
+    expect(
+      resolveUploadWarning([
+        'markdown-heuristic',
+        'stray-cloze:2',
+        'duplicate-guid:1',
+      ])
+    ).toMatch(/^1 card repeats the question/);
   });
 });

--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -1365,8 +1365,11 @@ describe('UploadService.handleSyncUpload — card-limit enforcement', () => {
     const req = buildRequest();
     const { res, capturedStatus } = buildResponse();
 
-    await service.handleUpload(req, res);
-    mockWorkspaceLocation = previousLocation;
+    try {
+      await service.handleUpload(req, res);
+    } finally {
+      mockWorkspaceLocation = previousLocation;
+    }
 
     expect(capturedStatus()).toBe(200);
     expect(res.set).toHaveBeenCalledWith(

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -32,6 +32,12 @@ import {
   apkgOversizeWarning,
   apkgOversizeWarningText,
 } from '../lib/upload/apkgOversizeWarning';
+import {
+  DUPLICATE_GUID_WARNING_RE,
+  duplicateGuidWarning,
+  duplicateGuidWarningText,
+} from '../lib/upload/duplicateGuidWarning';
+import { countDuplicateGuids } from '../lib/anki/countDuplicateGuids';
 import { UploadedFile } from '../lib/storage/types';
 import GeneratePackagesUseCase from '../usecases/uploads/GeneratePackagesUseCase';
 import { toText } from './NotionService/BlockHandler/helpers/deckNameToText';
@@ -175,6 +181,12 @@ export function resolveUploadWarning(
     w.includes('password-protected')
   );
   if (passwordWarning) return passwordWarning;
+  let duplicateGuids = 0;
+  for (const warning of warnings) {
+    const match = DUPLICATE_GUID_WARNING_RE.exec(warning);
+    if (match) duplicateGuids += Number(match[1]);
+  }
+  if (duplicateGuids > 0) return duplicateGuidWarningText(duplicateGuids);
   if (warnings.includes('markdown-heuristic')) {
     return MARKDOWN_HEURISTIC_WARNING;
   }
@@ -1441,10 +1453,14 @@ class UploadService {
         throw new Error(`Could not produce APKG for ${name}`);
       }
       const plen = Buffer.byteLength(apkg);
-      const oversizeWarning = apkgOversizeWarning(plen);
-      const syncWarnings = oversizeWarning
-        ? [...(warnings ?? []), oversizeWarning]
-        : warnings;
+      const builtWarnings = [
+        apkgOversizeWarning(plen),
+        duplicateGuidWarning(countDuplicateGuids(ws.location)),
+      ].filter((w): w is string => w != null);
+      const syncWarnings =
+        builtWarnings.length > 0
+          ? [...(warnings ?? []), ...builtWarnings]
+          : warnings;
       const downloadKey =
         owner == null
           ? null

--- a/web/src/pages/WhatsNewPage/changelog/2026-09-13-warn-when-cards-repeat-a-question.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-09-13-warn-when-cards-repeat-a-question.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-09-13-warn-when-cards-repeat-a-question",
+  "date": "2026-09-13",
+  "type": "feature",
+  "title": "A deck where cards repeat a question now warns that Anki keeps only one of each"
+}


### PR DESCRIPTION
## What

After the package is built, count how many notes share a guid (python's `guids.json` sidecar, the real issued guids) and surface it on the upload warning channel as `duplicate-guid:<n>`. `resolveUploadWarning` turns the summed count into one sentence:

> 1 card repeats the question of another card in the same deck, so Anki keeps only the first and you import 1 card fewer than you see here. Give it a different question and convert again.

Priority: sync-size > locked PDF > duplicate guid > markdown heuristic > stray cloze.

## Why

Refs #4408, third of the pre-flight import checks. Anki imports the first note of a guid group and reports the rest as updated/skipped in a log most users dismiss, so a deck that shows N cards in 2anki lands with fewer and nobody is told. 5 of 185 sampled prod decks (2026-09-11) carried a duplicate guid. More beautiful: no silently missing cards. Metric: none instrumented, internal; the warning is visible in the upload response.

## Trio synthesis

- pm: de-dup anonymous guids with an ordinal (like #4388) instead of warning; warn only as a stopgap.
- designer: warn through the existing one-sentence channel, never say "guid", rank just under oversize.
- engineer: count from the sidecar, inject in the single-package branch mirroring the oversize warning, python-gated e2e.
- Conflict resolved: warn now. #4408 scopes this as a warning, de-dup touches the python guid formula fresh from #4388/#4422, and forking identical-back true duplicates turns a silent merge into visible clutter. De-dup gets a follow-up issue with pm's back-diff test on the colliding decks.

## Scope

- Single-package uploads only, the same scope the oversize warning took. Zip batches and Ankify sync builds do not warn.
- Image occlusion decks (`create_io_deck.py`) write no sidecar, so they never warn.
- Server-side English string like the other `X-Warning` sentences; not localized.

## Tests

- `countDuplicateGuids.test.ts`: distinct, grouped, missing guid, no file, malformed, non-array.
- `duplicateGuidWarning.test.ts`: code and singular/plural copy.
- `UploadService.test.ts`: priority, summing, and an end-to-end `X-Warning` on a sidecar with a collision.
- `DeckParser.stableGuids.test.ts`: real python builds two identical toggles onto one guid and the sidecar counts 1 (skips under `SKIP_CREATE_DECK`).
- Full server suite: 7246 passed, 2 failed (`getPageCount`, documented pdfinfo environmental), 25 skipped.
- Browser check: not applicable, server-only change plus a changelog JSON.
- Sonar: not run locally; PR decoration will report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYtX1HSN7jx6gFXBb8bMT1
